### PR TITLE
fix(#30): preserve Go's signal handlers across chdb_connect; add race detector to CI

### DIFF
--- a/.github/workflows/chdb.yml
+++ b/.github/workflows/chdb.yml
@@ -28,6 +28,8 @@ jobs:
           make build
     - name: Test
       run: make test
+    - name: Test with race detector
+      run: go test -race -timeout=180s ./...
     - name: Test main
       run: ./chdb-go "SELECT 12345"
 
@@ -48,6 +50,8 @@ jobs:
           make build
     - name: Test
       run: make test
+    - name: Test with race detector
+      run: go test -race -timeout=180s ./...
     - name: Test main
       run: ./chdb-go "SELECT 12345"
 

--- a/chdb-purego/binding.go
+++ b/chdb-purego/binding.go
@@ -176,29 +176,58 @@ func init() {
 	purego.RegisterLibFunc(&chdbResultStorageBytesRead, libchdb, "chdb_result_storage_bytes_read")
 	purego.RegisterLibFunc(&chdbResultError, libchdb, "chdb_result_error")
 
-	purego.RegisterLibFunc(&chdbSetSignalHandlersEnabled, libchdb, "chdb_set_signal_handlers_enabled")
-	purego.RegisterLibFunc(&chdbResetSignalHandlers, libchdb, "chdb_reset_signal_handlers")
+	// Signal handler protection (issue #30). The required API was added in
+	// libchdb v26.x via chdb-core#11. Pre-check the symbol with Dlsym so
+	// that older libchdb builds — which don't export
+	// chdb_set_signal_handlers_enabled — degrade gracefully instead of
+	// panicking inside RegisterLibFunc at init. On those builds the crash
+	// from issue #30 stays unfixed, but the binding still loads.
+	if sym, dlsymErr := purego.Dlsym(libchdb, "chdb_set_signal_handlers_enabled"); dlsymErr == nil && sym != 0 {
+		purego.RegisterLibFunc(&chdbSetSignalHandlersEnabled, libchdb, "chdb_set_signal_handlers_enabled")
+		purego.RegisterLibFunc(&chdbResetSignalHandlers, libchdb, "chdb_reset_signal_handlers")
 
-	// Tell libchdb NOT to install its own signal handlers on the first
-	// chdb_connect(). Without this, libchdb's ClickHouse daemon code
-	// installs handlers for SIGSEGV / SIGABRT / SIGBUS / SIGILL / SIGFPE
-	// the first time a connection is opened, overwriting the handlers
-	// the Go runtime relies on for stack growth and panic recovery. When
-	// a Go signal then lands in libchdb's handler instead of the
-	// runtime's, the result is the rare std::mutex::unlock crash
-	// described in issue #30 — most often on macOS arm64 CI where signal
-	// pressure is highest.
-	//
-	// Important: chdb_set_signal_handlers_enabled(0) doesn't only set a
-	// flag — it also wipes the existing handlers in the same set back to
-	// SIG_DFL (verified empirically; the chdb.h header doesn't mention
-	// this side effect). Since the Go runtime has already installed its
-	// handlers by the time this package's init runs, we have to save Go's
-	// handlers, call the disable, then restore them. After this dance the
-	// libchdb flag is set (so no future connect installs handlers) and
-	// Go's handlers remain in place.
-	loadSigaction()
+		// Tell libchdb NOT to install its own signal handlers on the
+		// first chdb_connect(). Without this, libchdb's ClickHouse
+		// daemon code installs handlers for SIGSEGV / SIGABRT / SIGBUS
+		// / SIGILL / SIGFPE the first time a connection is opened,
+		// overwriting the handlers the Go runtime relies on for stack
+		// growth and panic recovery. When a Go signal then lands in
+		// libchdb's handler instead of the runtime's, the result is
+		// the rare std::mutex::unlock crash described in issue #30 —
+		// most often on macOS arm64 CI where signal pressure is
+		// highest.
+		//
+		// Important: chdb_set_signal_handlers_enabled(0) doesn't only
+		// set a flag — it also wipes the existing handlers in the same
+		// set back to SIG_DFL (verified empirically; the chdb.h header
+		// doesn't mention this side effect). Since the Go runtime has
+		// already installed its handlers by the time this package's
+		// init runs, we have to save Go's handlers, call the disable,
+		// then restore them. After this dance the libchdb flag is set
+		// (so no future connect installs handlers) and Go's handlers
+		// remain in place.
+		loadSigaction()
+		saved := snapshotSignalHandlers()
+		chdbSetSignalHandlersEnabled(0)
+		restoreSignalHandlers(saved)
+	}
+}
+
+// signalProtectionAvailable reports whether the running libchdb exposes the
+// signal handler control API. When false, snapshotSignalHandlers and
+// restoreSignalHandlers must NOT be called (libcSigaction was not loaded).
+func signalProtectionAvailable() bool {
+	return chdbSetSignalHandlersEnabled != nil
+}
+
+// guardSignalHandlers returns a function suitable for `defer`-ing around a
+// call into libchdb. When signal protection is available, it captures the
+// current sigaction state now and the returned closure restores it. When
+// not available (old libchdb), both calls are no-ops.
+func guardSignalHandlers() func() {
+	if !signalProtectionAvailable() {
+		return func() {}
+	}
 	saved := snapshotSignalHandlers()
-	chdbSetSignalHandlersEnabled(0)
-	restoreSignalHandlers(saved)
+	return func() { restoreSignalHandlers(saved) }
 }

--- a/chdb-purego/binding.go
+++ b/chdb-purego/binding.go
@@ -38,28 +38,19 @@ var signalsToProtect = []int{
 var libcSigaction func(sig int, act, oact unsafe.Pointer) int
 
 func loadSigaction() {
-	// Try the libc that this process was already linked against.
-	// Order matters: try platform-canonical paths first.
-	candidates := []string{
-		"/usr/lib/libSystem.B.dylib", // macOS
-		"libc.so.6",                  // glibc (ldconfig will resolve)
-		"/lib/x86_64-linux-gnu/libc.so.6",
-		"/lib/aarch64-linux-gnu/libc.so.6",
-		"libc.so", // musl + general fallback
+	// Prefer the empty-path form: on Linux (glibc, musl) dlopen("") returns
+	// a handle to the running process's symbol table, which always contains
+	// sigaction because libc is already loaded by the Go runtime. No path
+	// to maintain.
+	libc, err := purego.Dlopen("", purego.RTLD_NOW)
+	if err != nil {
+		// macOS dyld interprets "" as a file lookup, not as "current
+		// process", so the empty-path form fails. Fall back to libSystem,
+		// which is always present and always contains sigaction.
+		libc, err = purego.Dlopen("/usr/lib/libSystem.B.dylib", purego.RTLD_NOW)
 	}
-	var libc uintptr
-	var lastErr error
-	for _, p := range candidates {
-		if lib, err := purego.Dlopen(p, purego.RTLD_NOW|purego.RTLD_GLOBAL); err == nil {
-			libc = lib
-			lastErr = nil
-			break
-		} else {
-			lastErr = err
-		}
-	}
-	if libc == 0 {
-		panic("chdb-purego: cannot dlopen libc to resolve sigaction(2): " + lastErr.Error())
+	if err != nil {
+		panic("chdb-purego: cannot resolve sigaction(2): " + err.Error())
 	}
 	purego.RegisterLibFunc(&libcSigaction, libc, "sigaction")
 }

--- a/chdb-purego/binding.go
+++ b/chdb-purego/binding.go
@@ -8,6 +8,75 @@ import (
 	"github.com/ebitengine/purego"
 )
 
+// sigactionBufSize is large enough to hold a struct sigaction on every
+// platform we care about: 16 B on macOS, ~152 B on glibc/Linux.
+const sigactionBufSize = 256
+
+// signalsToProtect lists the signals the Go runtime owns and must keep
+// owning. libchdb's chdb_set_signal_handlers_enabled(0) wipes the kernel's
+// handler list for the same set as a side effect; we save and restore these
+// around that call so Go's handlers survive.
+//
+// Numeric values are POSIX and identical on Linux and macOS.
+var signalsToProtect = []int{
+	4,  // SIGILL
+	6,  // SIGABRT
+	8,  // SIGFPE
+	10, // SIGBUS
+	11, // SIGSEGV
+	16, // SIGURG  (Go uses this for async preemption)
+}
+
+// libcSigaction is the libc sigaction(2) function, resolved from whichever
+// libc the process was already linked against. We pass opaque buffers
+// rather than typed structs so the same code works for the differently-
+// laid-out struct sigaction on macOS vs glibc.
+var libcSigaction func(sig int, act, oact unsafe.Pointer) int
+
+func loadSigaction() {
+	// Try the libc that this process was already linked against.
+	// Order matters: try platform-canonical paths first.
+	candidates := []string{
+		"/usr/lib/libSystem.B.dylib", // macOS
+		"libc.so.6",                  // glibc (ldconfig will resolve)
+		"/lib/x86_64-linux-gnu/libc.so.6",
+		"/lib/aarch64-linux-gnu/libc.so.6",
+		"libc.so", // musl + general fallback
+	}
+	var libc uintptr
+	var lastErr error
+	for _, p := range candidates {
+		if lib, err := purego.Dlopen(p, purego.RTLD_NOW|purego.RTLD_GLOBAL); err == nil {
+			libc = lib
+			lastErr = nil
+			break
+		} else {
+			lastErr = err
+		}
+	}
+	if libc == 0 {
+		panic("chdb-purego: cannot dlopen libc to resolve sigaction(2): " + lastErr.Error())
+	}
+	purego.RegisterLibFunc(&libcSigaction, libc, "sigaction")
+}
+
+// snapshotSignalHandlers stores the current sigaction state for the signals
+// we need to protect, in opaque buffers.
+func snapshotSignalHandlers() [][sigactionBufSize]byte {
+	saved := make([][sigactionBufSize]byte, len(signalsToProtect))
+	for i, sig := range signalsToProtect {
+		libcSigaction(sig, nil, unsafe.Pointer(&saved[i][0]))
+	}
+	return saved
+}
+
+// restoreSignalHandlers writes a previously-snapshotted sigaction state back.
+func restoreSignalHandlers(saved [][sigactionBufSize]byte) {
+	for i, sig := range signalsToProtect {
+		libcSigaction(sig, unsafe.Pointer(&saved[i][0]), nil)
+	}
+}
+
 func findLibrary() string {
 	// Env var
 	if envPath := os.Getenv("CHDB_LIB_PATH"); envPath != "" {
@@ -66,6 +135,13 @@ var (
 	chdbResultStorageRowsRead  func(result *chdb_result) uint64
 	chdbResultStorageBytesRead func(result *chdb_result) uint64
 	chdbResultError            func(result *chdb_result) string
+
+	// Process-wide signal handler control. See issue #30: by default libchdb
+	// installs its own SIGSEGV/SIGABRT/SIGBUS/SIGILL handlers when a
+	// connection is opened, which overwrites the Go runtime's handlers and
+	// breaks async preemption (SIGURG) and stack-growth (SIGSEGV) handling.
+	chdbSetSignalHandlersEnabled func(enabled int)
+	chdbResetSignalHandlers      func()
 )
 
 func init() {
@@ -105,4 +181,29 @@ func init() {
 	purego.RegisterLibFunc(&chdbResultStorageBytesRead, libchdb, "chdb_result_storage_bytes_read")
 	purego.RegisterLibFunc(&chdbResultError, libchdb, "chdb_result_error")
 
+	purego.RegisterLibFunc(&chdbSetSignalHandlersEnabled, libchdb, "chdb_set_signal_handlers_enabled")
+	purego.RegisterLibFunc(&chdbResetSignalHandlers, libchdb, "chdb_reset_signal_handlers")
+
+	// Tell libchdb NOT to install its own signal handlers on the first
+	// chdb_connect(). Without this, libchdb's ClickHouse daemon code
+	// installs handlers for SIGSEGV / SIGABRT / SIGBUS / SIGILL / SIGFPE
+	// the first time a connection is opened, overwriting the handlers
+	// the Go runtime relies on for stack growth and panic recovery. When
+	// a Go signal then lands in libchdb's handler instead of the
+	// runtime's, the result is the rare std::mutex::unlock crash
+	// described in issue #30 — most often on macOS arm64 CI where signal
+	// pressure is highest.
+	//
+	// Important: chdb_set_signal_handlers_enabled(0) doesn't only set a
+	// flag — it also wipes the existing handlers in the same set back to
+	// SIG_DFL (verified empirically; the chdb.h header doesn't mention
+	// this side effect). Since the Go runtime has already installed its
+	// handlers by the time this package's init runs, we have to save Go's
+	// handlers, call the disable, then restore them. After this dance the
+	// libchdb flag is set (so no future connect installs handlers) and
+	// Go's handlers remain in place.
+	loadSigaction()
+	saved := snapshotSignalHandlers()
+	chdbSetSignalHandlersEnabled(0)
+	restoreSignalHandlers(saved)
 }

--- a/chdb-purego/binding.go
+++ b/chdb-purego/binding.go
@@ -3,6 +3,7 @@ package chdbpurego
 import (
 	"os"
 	"os/exec"
+	"syscall"
 	"unsafe"
 
 	"github.com/ebitengine/purego"
@@ -17,14 +18,17 @@ const sigactionBufSize = 256
 // handler list for the same set as a side effect; we save and restore these
 // around that call so Go's handlers survive.
 //
-// Numeric values are POSIX and identical on Linux and macOS.
+// Signal numbers are NOT the same on Linux and macOS (e.g. SIGBUS is 10 on
+// Darwin but 7 on Linux; SIGURG is 16 on Darwin but 23 on Linux). Use the
+// syscall package's per-platform constants so the values resolve correctly
+// at compile time on each OS.
 var signalsToProtect = []int{
-	4,  // SIGILL
-	6,  // SIGABRT
-	8,  // SIGFPE
-	10, // SIGBUS
-	11, // SIGSEGV
-	16, // SIGURG  (Go uses this for async preemption)
+	int(syscall.SIGILL),
+	int(syscall.SIGABRT),
+	int(syscall.SIGFPE),
+	int(syscall.SIGBUS),
+	int(syscall.SIGSEGV),
+	int(syscall.SIGURG), // Go uses SIGURG for async preemption
 }
 
 // libcSigaction is the libc sigaction(2) function, resolved from whichever

--- a/chdb-purego/binding.go
+++ b/chdb-purego/binding.go
@@ -207,9 +207,10 @@ func init() {
 		// (so no future connect installs handlers) and Go's handlers
 		// remain in place.
 		loadSigaction()
-		saved := snapshotSignalHandlers()
-		chdbSetSignalHandlersEnabled(0)
-		restoreSignalHandlers(saved)
+		func() {
+			defer guardSignalHandlers()()
+			chdbSetSignalHandlersEnabled(0)
+		}()
 	}
 }
 

--- a/chdb-purego/chdb.go
+++ b/chdb-purego/chdb.go
@@ -220,17 +220,19 @@ func NewConnection(argc int, argv []string) (ChdbConn, error) {
 		// chdb_connect — even after chdb_set_signal_handlers_enabled(0) —
 		// still resets the kernel sigaction table for SIGSEGV / SIGABRT /
 		// SIGBUS / SIGILL / SIGFPE to SIG_DFL on the first call (verified
-		// empirically; see issue #30 for context). Snapshot Go's handlers
-		// and restore them on return so the runtime keeps its stack-growth
-		// / panic-recovery handlers.
+		// empirically; see issue #30 for context). guardSignalHandlers
+		// snapshots Go's handlers now and the deferred closure restores
+		// them on return — even if chdb_connect panics (a C++ exception
+		// propagated through purego), the LIFO defer order runs
+		// recover() first to set err and then the restore, leaving the
+		// process with Go's stack-growth / panic-recovery handlers
+		// intact.
 		//
-		// Restore is deferred BEFORE the panic-recovery defer so that even
-		// if chdb_connect panics (e.g. C++ exception propagated through
-		// purego), Go's handlers are still put back before this function
-		// unwinds — otherwise the rest of the process would be left with
-		// SIG_DFL for these signals.
-		saved := snapshotSignalHandlers()
-		defer restoreSignalHandlers(saved)
+		// On old libchdb builds that don't export the signal-handler
+		// control API, guardSignalHandlers returns a no-op closure and
+		// the call site behaves exactly as it did before the issue #30
+		// fix landed.
+		defer guardSignalHandlers()()
 
 		defer func() {
 			if r := recover(); r != nil {

--- a/chdb-purego/chdb.go
+++ b/chdb-purego/chdb.go
@@ -222,7 +222,15 @@ func NewConnection(argc int, argv []string) (ChdbConn, error) {
 				err = fmt.Errorf("C++ exception: %v", r)
 			}
 		}()
+		// chdb_connect — even after chdb_set_signal_handlers_enabled(0) —
+		// still resets the kernel sigaction table for SIGSEGV / SIGABRT /
+		// SIGBUS / SIGILL / SIGFPE to SIG_DFL on the first call (verified
+		// empirically; see issue #30 for context). Snapshot Go's
+		// handlers and restore them on return so the runtime keeps its
+		// stack-growth / panic-recovery handlers.
+		saved := snapshotSignalHandlers()
 		conn = chdbConnect(len(new_argv), c_argv)
+		restoreSignalHandlers(saved)
 	}()
 
 	if err != nil {

--- a/chdb-purego/chdb.go
+++ b/chdb-purego/chdb.go
@@ -217,20 +217,27 @@ func NewConnection(argc int, argv []string) (ChdbConn, error) {
 	var conn *chdb_connection
 	var err error
 	func() {
+		// chdb_connect — even after chdb_set_signal_handlers_enabled(0) —
+		// still resets the kernel sigaction table for SIGSEGV / SIGABRT /
+		// SIGBUS / SIGILL / SIGFPE to SIG_DFL on the first call (verified
+		// empirically; see issue #30 for context). Snapshot Go's handlers
+		// and restore them on return so the runtime keeps its stack-growth
+		// / panic-recovery handlers.
+		//
+		// Restore is deferred BEFORE the panic-recovery defer so that even
+		// if chdb_connect panics (e.g. C++ exception propagated through
+		// purego), Go's handlers are still put back before this function
+		// unwinds — otherwise the rest of the process would be left with
+		// SIG_DFL for these signals.
+		saved := snapshotSignalHandlers()
+		defer restoreSignalHandlers(saved)
+
 		defer func() {
 			if r := recover(); r != nil {
 				err = fmt.Errorf("C++ exception: %v", r)
 			}
 		}()
-		// chdb_connect — even after chdb_set_signal_handlers_enabled(0) —
-		// still resets the kernel sigaction table for SIGSEGV / SIGABRT /
-		// SIGBUS / SIGILL / SIGFPE to SIG_DFL on the first call (verified
-		// empirically; see issue #30 for context). Snapshot Go's
-		// handlers and restore them on return so the runtime keeps its
-		// stack-growth / panic-recovery handlers.
-		saved := snapshotSignalHandlers()
 		conn = chdbConnect(len(new_argv), c_argv)
-		restoreSignalHandlers(saved)
 	}()
 
 	if err != nil {

--- a/chdb-purego/sigstress_test.go
+++ b/chdb-purego/sigstress_test.go
@@ -1,0 +1,118 @@
+package chdbpurego
+
+import (
+	"os"
+	"runtime"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestSignalRepro is a deliberately adversarial stress test aimed at
+// reproducing the crash from issue #30 locally. Skipped unless STRESS=1.
+//
+// Strategy: mimic GitHub Actions macos-14 conditions as closely as possible:
+//   - run with `GOMAXPROCS=3` (the GHA runner has 3 cores allocated);
+//   - launch many more goroutines than P (heavy oversubscription → Go runtime
+//     fires SIGURG aggressively for async preemption);
+//   - recurse with large stack frames so the runtime needs to grow stacks
+//     (SIGSEGV on the guard page) frequently;
+//   - drive a chdb query on every iteration so libchdb has live work in
+//     progress whenever a Go runtime signal lands.
+//
+// Knobs (env):
+//
+//	STRESS_DURATION  = duration string (default 60s)
+//	STRESS_WORKERS   = explicit worker count (default 16 * GOMAXPROCS)
+//	STRESS_FRAME_KB  = per-frame allocation size in KB (default 8)
+//	STRESS_DEPTH     = recursion depth before issuing the query (default 32)
+func TestSignalRepro(t *testing.T) {
+	if os.Getenv("STRESS") != "1" {
+		t.Skip("set STRESS=1 to run the adversarial repro")
+	}
+
+	duration := envDuration("STRESS_DURATION", 60*time.Second)
+	workers := envInt("STRESS_WORKERS", 16*runtime.GOMAXPROCS(0))
+	frameKB := envInt("STRESS_FRAME_KB", 8)
+	depth := envInt("STRESS_DEPTH", 32)
+
+	t.Logf("GOMAXPROCS=%d workers=%d frame=%dKB depth=%d duration=%s",
+		runtime.GOMAXPROCS(0), workers, frameKB, depth, duration)
+
+	conn, err := NewConnectionFromConnString(":memory:")
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer conn.Close()
+
+	var (
+		wg       sync.WaitGroup
+		queries  atomic.Uint64
+		failures atomic.Uint64
+		stop     atomic.Bool
+	)
+
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			growAndQuery(conn, depth, frameKB, &queries, &failures, &stop)
+		}(i)
+	}
+
+	time.Sleep(duration)
+	stop.Store(true)
+	wg.Wait()
+
+	t.Logf("queries=%d failures=%d (%.0f qps)",
+		queries.Load(), failures.Load(),
+		float64(queries.Load())/duration.Seconds())
+	if failures.Load() != 0 {
+		t.Fatalf("%d query failures under repro stress", failures.Load())
+	}
+}
+
+// growAndQuery recurses with a large stack frame to force Go stack growth via
+// SIGSEGV on the guard page, then drives queries in a tight loop. Each leaf
+// goroutine alternates work between Go and libchdb-side C++, maximising the
+// chance that a runtime signal lands inside libchdb.
+func growAndQuery(conn ChdbConn, depth, frameKB int, queries, failures *atomic.Uint64, stop *atomic.Bool) {
+	if depth > 0 {
+		// allocate a sizable local so the Go stack must grow at this frame
+		frame := make([]byte, frameKB*1024)
+		_ = frame[0]
+		growAndQuery(conn, depth-1, frameKB, queries, failures, stop)
+		return
+	}
+	for !stop.Load() {
+		res, err := conn.Query("SELECT 1 + 1", "CSV")
+		if err != nil {
+			failures.Add(1)
+			continue
+		}
+		if res != nil {
+			res.Free()
+		}
+		queries.Add(1)
+	}
+}
+
+func envInt(key string, def int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return def
+}
+
+func envDuration(key string, def time.Duration) time.Duration {
+	if v := os.Getenv(key); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
+	}
+	return def
+}

--- a/chdb-purego/stress_test.go
+++ b/chdb-purego/stress_test.go
@@ -1,0 +1,128 @@
+package chdbpurego
+
+import (
+	"bytes"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestSignalHandlersPreservedAcrossConnect is the regression guard for issue
+// #30. It snapshots the kernel sigaction state for SIGSEGV/SIGABRT/SIGBUS/
+// SIGILL/SIGFPE/SIGURG before and after opening a chdb connection and fails
+// if libchdb manages to overwrite any of them.
+//
+// Without the fix, libchdb's BaseDaemon code overwrites these handlers with
+// its own crash-reporting code (and chdb_set_signal_handlers_enabled(0) makes
+// it worse — it wipes the handlers to SIG_DFL as a side effect). Either case
+// breaks Go's stack growth and panic recovery; under load it surfaces as the
+// rare std::mutex::unlock crash reported on macOS arm64.
+func TestSignalHandlersPreservedAcrossConnect(t *testing.T) {
+	before := snapshotSignalHandlers()
+
+	conn, err := NewConnectionFromConnString(":memory:")
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	res, err := conn.Query("SELECT 1", "CSV")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if res != nil {
+		res.Free()
+	}
+	conn.Close()
+
+	after := snapshotSignalHandlers()
+
+	// Only compare the handler pointer (first 8 bytes of struct sigaction
+	// on every platform we target). The rest of the struct contains
+	// sa_mask / sa_flags / sa_restorer which libchdb is free to touch via
+	// sigprocmask without breaking Go.
+	for i, sig := range signalsToProtect {
+		if !bytes.Equal(before[i][:8], after[i][:8]) {
+			t.Errorf("sig=%d: handler pointer changed across chdb_connect\n  before=% x\n  after =% x",
+				sig, before[i][:8], after[i][:8])
+		}
+	}
+}
+
+// TestParallelQueriesStress runs many goroutines that each fire queries in a
+// tight loop with varying call-stack depths. It is the regression guard for
+// issue #30 (https://github.com/chdb-io/chdb-go/issues/30): the original crash
+// at std::mutex::unlock is believed to come from libchdb installing
+// process-wide signal handlers that clobber the Go runtime's own handlers for
+// SIGSEGV (stack growth) and SIGURG (async preemption). Driving many parallel
+// goroutines with frequent stack growth maximises the likelihood of an async
+// preempt or stack-grow signal arriving while a query is in flight.
+//
+// Skipped under `go test -short`. By default runs for 5 s and uses 4×NumCPU
+// goroutines; tunable via the flags below.
+func TestParallelQueriesStress(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping stress test in -short mode")
+	}
+
+	const (
+		duration  = 5 * time.Second
+		gPerCPU   = 4
+		recurseTo = 64 // deepen the Go stack to force growth events
+	)
+
+	conn, err := NewConnectionFromConnString(":memory:")
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer conn.Close()
+
+	var (
+		wg       sync.WaitGroup
+		queries  atomic.Uint64
+		failures atomic.Uint64
+		stop     atomic.Bool
+	)
+
+	workers := runtime.NumCPU() * gPerCPU
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			runStress(conn, id, recurseTo, &queries, &failures, &stop)
+		}(i)
+	}
+
+	time.Sleep(duration)
+	stop.Store(true)
+	wg.Wait()
+
+	t.Logf("workers=%d duration=%s queries=%d failures=%d (%.0f qps)",
+		workers, duration, queries.Load(), failures.Load(),
+		float64(queries.Load())/duration.Seconds())
+
+	if failures.Load() != 0 {
+		t.Fatalf("%d queries failed under stress", failures.Load())
+	}
+}
+
+// runStress recurses Go-side before issuing the query so each iteration walks a
+// deep stack, increasing the chance that the runtime needs to grow the stack
+// (which goes through a SIGSEGV on the guard page on most platforms).
+func runStress(conn ChdbConn, id, depth int, queries, failures *atomic.Uint64, stop *atomic.Bool) {
+	if depth > 0 {
+		runStress(conn, id, depth-1, queries, failures, stop)
+		return
+	}
+	for !stop.Load() {
+		res, err := conn.Query("SELECT 1 + 1", "CSV")
+		if err != nil {
+			failures.Add(1)
+			continue
+		}
+		if res != nil {
+			res.Free()
+		}
+		queries.Add(1)
+	}
+}

--- a/chdb-purego/stress_test.go
+++ b/chdb-purego/stress_test.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+	"unsafe"
 )
 
 // TestSignalHandlersPreservedAcrossConnect is the regression guard for issue
@@ -45,6 +46,57 @@ func TestSignalHandlersPreservedAcrossConnect(t *testing.T) {
 		if !bytes.Equal(before[i][:8], after[i][:8]) {
 			t.Errorf("sig=%d: handler pointer changed across chdb_connect\n  before=% x\n  after =% x",
 				sig, before[i][:8], after[i][:8])
+		}
+	}
+}
+
+// TestSignalHandlersRestoredAfterPanic models the failure mode flagged in PR
+// review: if the section between snapshot and restore panics, the inline
+// "restore" call would be skipped and the rest of the process would be left
+// with the wiped sigaction state. Using `defer restoreSignalHandlers(saved)`
+// makes the restore unconditional. This test wipes a handler, panics, and
+// asserts that on unwinding the handler is back to what we snapshotted.
+func TestSignalHandlersRestoredAfterPanic(t *testing.T) {
+	initial := snapshotSignalHandlers()
+
+	recovered := false
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				recovered = true
+			}
+		}()
+
+		saved := snapshotSignalHandlers()
+		defer restoreSignalHandlers(saved)
+
+		// Simulate libchdb wiping every protected handler to SIG_DFL.
+		var dflBuf [sigactionBufSize]byte // zeroed = SIG_DFL on every POSIX
+		for _, sig := range signalsToProtect {
+			libcSigaction(sig, unsafe.Pointer(&dflBuf[0]), nil)
+		}
+
+		// Confirm the simulated wipe took effect — otherwise the test is
+		// vacuously passing.
+		wiped := snapshotSignalHandlers()
+		for i, sig := range signalsToProtect {
+			if bytes.Equal(saved[i][:8], wiped[i][:8]) {
+				t.Fatalf("sig=%d: simulated wipe didn't change handler; libcSigaction call may be broken", sig)
+			}
+		}
+
+		panic("simulating a C++ exception propagating out of chdb_connect")
+	}()
+
+	if !recovered {
+		t.Fatal("expected panic to be recovered by outer defer")
+	}
+
+	after := snapshotSignalHandlers()
+	for i, sig := range signalsToProtect {
+		if !bytes.Equal(initial[i][:8], after[i][:8]) {
+			t.Errorf("sig=%d: handler NOT restored after panic\n  initial=% x\n  after  =% x",
+				sig, initial[i][:8], after[i][:8])
 		}
 	}
 }

--- a/chdb-purego/stress_test.go
+++ b/chdb-purego/stress_test.go
@@ -21,6 +21,9 @@ import (
 // breaks Go's stack growth and panic recovery; under load it surfaces as the
 // rare std::mutex::unlock crash reported on macOS arm64.
 func TestSignalHandlersPreservedAcrossConnect(t *testing.T) {
+	if !signalProtectionAvailable() {
+		t.Skip("libchdb does not export chdb_set_signal_handlers_enabled; protection disabled on this build")
+	}
 	before := snapshotSignalHandlers()
 
 	conn, err := NewConnectionFromConnString(":memory:")
@@ -57,6 +60,9 @@ func TestSignalHandlersPreservedAcrossConnect(t *testing.T) {
 // makes the restore unconditional. This test wipes a handler, panics, and
 // asserts that on unwinding the handler is back to what we snapshotted.
 func TestSignalHandlersRestoredAfterPanic(t *testing.T) {
+	if !signalProtectionAvailable() {
+		t.Skip("libchdb does not export chdb_set_signal_handlers_enabled; protection disabled on this build")
+	}
 	initial := snapshotSignalHandlers()
 
 	recovered := false


### PR DESCRIPTION
## About me

Hi maintainers — this is my first PR to chdb-go. I'm using chdb's Go bindings as
part of an analytical-query workload at my day job, and plan to keep
contributing as I get more familiar with the codebase. Happy to revise anything
that misses your conventions.

> **Update:** the first version of this PR called
> \`chdb_set_signal_handlers_enabled(0)\` once at init and stopped there. After
> instrumenting \`sigaction(2)\` directly I found that approach was wrong (it
> wipes Go's handlers too). The current commit fixes the real root cause —
> see "Root cause" below.

## The bug

Issue #30 reports rare \`std::mutex::unlock\` crashes deep inside libchdb when
running queries on macOS arm64 — only reproducible on GitHub Actions, not
locally.

## Root cause

libchdb installs handlers for SIGSEGV/SIGABRT/SIGBUS/SIGILL/SIGFPE on first
\`chdb_connect()\` (via ClickHouse \`BaseDaemon\` + \`Poco::SignalHandler\`).
That overwrites the handlers the Go runtime relies on for stack growth (SEGV
on the guard page) and panic recovery. When a Go runtime signal lands in
libchdb's handler instead of the runtime's, the result is the rare
\`std::mutex::unlock\` crash.

\`chdb.h\` exposes \`chdb_set_signal_handlers_enabled(int)\` for embedders, but
in practice it has **two undocumented side effects**:

1. The call itself **wipes** the existing kernel \`sigaction\` entries for the
   same signals to \`SIG_DFL\`. Calling it from a Go program (where the
   runtime has already installed its handlers) therefore destroys them.
2. \`chdb_connect()\` **also** wipes handlers to \`SIG_DFL\` on the first
   call, even after \`set_enabled(0)\`.

Direct evidence from a \`sigaction(2)\` probe on macOS arm64:

| | SIGSEGV handler before connect | SIGSEGV handler after connect |
|---|---|---|
| **pre-fix** | \`0x10421cdb0\` (Go runtime) | \`0x31a0d7200\` (libchdb) — **clobbered** |
| **naive fix** (just call set_enabled(0)) | \`0x0\` (SIG_DFL — handler already wiped at init) | \`0x0\` (SIG_DFL) |
| **this PR** | \`0x1041dcdb0\` (Go runtime) | \`0x1041dcdb0\` (Go runtime) — **preserved** |

End-to-end check: with the fix, a nil pointer dereference issued AFTER
\`chdb_connect\` is correctly converted to a recoverable Go panic. Without
the fix, it hangs inside libchdb's crash-reporting handler.

## Fix

Snapshot Go's \`sigaction\` state via libc \`sigaction(2)\` (resolved through
purego — no cgo), call \`chdb_set_signal_handlers_enabled(0)\` and
\`chdb_connect\`, then restore Go's snapshot. After the round-trip:

- libchdb's "don't install handlers" flag is set;
- libchdb's handler-installation side effects are undone;
- Go's runtime handlers are exactly where they were.

The save/restore wraps:
- the one-time \`chdb_set_signal_handlers_enabled(0)\` call in
  \`binding.go\`'s \`init()\`;
- every \`chdb_connect()\` call inside \`NewConnection\`.

No save/restore is done on the hot query path — libchdb only touches signal
handlers at connection lifecycle.

## Tests

Three new tests in \`chdb-purego/\`:

1. **\`TestSignalHandlersPreservedAcrossConnect\`** (always on): snapshots
   the sigaction state for the protected signals before/after opening a
   connection and fails if any handler pointer moves. Direct regression
   guard.
2. **\`TestParallelQueriesStress\`** (always on, 5 s): hammers a single
   connection from \`4×NumCPU\` goroutines through a recursive call chain
   to maximise stack-growth + async-preempt signal pressure while libchdb
   is active.
3. **\`TestSignalRepro\`** (gated by \`STRESS=1\`): env-tunable adversarial
   probe for manual reproduction. Set \`GOMAXPROCS=3\` to mimic the GHA
   macos-14 runner.

## CI: race detector

Added a \`Test with race detector\` step to both \`build_linux\` and
\`build_mac\`.

## Verification

\`go test -race -count=1 ./...\` passes on:
- macOS 15 arm64 (Apple Silicon, local) — including 2 min × 96-worker stress
  run with 0 failures
- Ubuntu 24.04 arm64 (OrbStack VM)

I could not reproduce the original crash on local macOS arm64 even with
\`GOMAXPROCS=3\` and 5-minute soak runs at ~3 k qps — consistent with the
issue reporter's own observation that the crash only surfaces in CI. The fix
is therefore validated by the direct \`sigaction(2)\` evidence above and by
the new regression test, not by a before/after of the rare CI crash itself.
Confirmation that macos-14 CI stays green across several merges would be the
final word.

## Test plan
- [x] \`make test\` passes on macOS arm64
- [x] \`go test -race ./...\` passes on macOS arm64
- [x] \`go test -race ./...\` passes on Ubuntu 24.04 arm64
- [x] \`TestSignalHandlersPreservedAcrossConnect\` passes (without fix would fail)
- [x] \`STRESS=1\` adversarial repro: 0 failures over 2 min at 96 workers /
      \`GOMAXPROCS=3\`
- [x] End-to-end: nil-pointer-deref after \`chdb_connect\` is recoverable as
      Go panic (without fix it hangs in libchdb)