### PR TITLE
Support multiple concurrent connections per process

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,28 @@ func main() {
 }
 ```
 
+#### Concurrency
+
+chDB runs a single embedded engine per process bound to one data path, but that
+engine accepts multiple connections that execute queries concurrently. The
+`database/sql` driver opens an independent native chDB connection per pooled
+connection, so you can scale read/write parallelism with `SetMaxOpenConns`:
+
+```go
+db, err := sql.Open("chdb", "session=/path/to/data")
+if err != nil {
+        log.Fatal(err)
+}
+defer db.Close()
+
+// Each pooled connection is its own native chDB connection to the same data
+// path, so queries run in parallel instead of serializing on one connection.
+db.SetMaxOpenConns(8)
+```
+
+All connections in a process must share the same data path; opening a second,
+different data path while connections are still open returns an error.
+
 ### Golang API docs
 
 - See [lowApi.md](lowApi.md) for the low level APIs.

--- a/chdb-purego/chdb.go
+++ b/chdb-purego/chdb.go
@@ -182,9 +182,10 @@ func (c *connection) Ready() bool {
 //   - argc = 2, argv = []string{"--path=/tmp/chdb", "--readonly=1"}
 //
 // Important:
-//   - There can be only one session at a time. If you want to create a new session, you need to close the existing one.
-//   - Creating a new session will close the existing one.
-//   - You need to ensure that the path exists before creating a new session. Or you can use NewConnectionFromConnString.
+//   - chDB supports only one data path per process. Multiple connections to the
+//     same path can be open at once and execute queries concurrently; connecting
+//     to a different path while connections are still open returns an error.
+//   - You need to ensure that the path exists before creating a new connection. Or you can use NewConnectionFromConnString.
 func NewConnection(argc int, argv []string) (ChdbConn, error) {
 	var new_argv []string
 	if (argc > 0 && argv[0] != "clickhouse") || argc == 0 {
@@ -274,8 +275,9 @@ func NewConnection(argc int, argv []string) (ChdbConn, error) {
 //	- "mode=ro" would be "--readonly=1" for clickhouse (read-only mode)
 //
 // Important:
-//   - There can be only one session at a time. If you want to create a new session, you need to close the existing one.
-//   - Creating a new session will close the existing one.
+//   - chDB supports only one data path per process. Multiple connections to the
+//     same path can be open at once and execute queries concurrently; connecting
+//     to a different path while connections are still open returns an error.
 func NewConnectionFromConnString(conn_string string) (ChdbConn, error) {
 	if conn_string == "" || conn_string == ":memory:" {
 		return NewConnection(0, []string{})

--- a/chdb-purego/chdb.go
+++ b/chdb-purego/chdb.go
@@ -112,9 +112,14 @@ func newChdbConn(conn *chdb_connection) ChdbConn {
 }
 
 // Close implements ChdbConn.
+//
+// Close is idempotent: it nils the underlying handle after freeing it so a
+// second Close (or a Close racing a Query that checks for a nil handle) does
+// not double-free the native connection.
 func (c *connection) Close() {
 	if c.conn != nil {
 		chdbCloseConn(c.conn)
+		c.conn = nil
 	}
 }
 

--- a/chdb-purego/stress_test.go
+++ b/chdb-purego/stress_test.go
@@ -184,3 +184,60 @@ func runStress(conn ChdbConn, id, depth int, queries, failures *atomic.Uint64, s
 		queries.Add(1)
 	}
 }
+
+// TestMultiConnectionStress opens several connections to the same (in-memory)
+// data path and drives queries on all of them concurrently. It guards the
+// multi-connection path (refcounted EmbeddedServer + per-connection clients)
+// against crashes and regressions in the issue-#30 signal handling under
+// concurrent connect/query load. Skipped under `go test -short`.
+func TestMultiConnectionStress(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping stress test in -short mode")
+	}
+
+	const (
+		duration = 5 * time.Second
+		nConns   = 4
+		gPerConn = 4
+		recurse  = 16
+	)
+
+	conns := make([]ChdbConn, 0, nConns)
+	for i := 0; i < nConns; i++ {
+		c, err := NewConnectionFromConnString(":memory:")
+		if err != nil {
+			t.Fatalf("connect %d: %v", i, err)
+		}
+		defer c.Close()
+		conns = append(conns, c)
+	}
+
+	var (
+		wg       sync.WaitGroup
+		queries  atomic.Uint64
+		failures atomic.Uint64
+		stop     atomic.Bool
+	)
+
+	for i := 0; i < nConns; i++ {
+		for g := 0; g < gPerConn; g++ {
+			wg.Add(1)
+			go func(c ChdbConn) {
+				defer wg.Done()
+				runStress(c, 0, recurse, &queries, &failures, &stop)
+			}(conns[i])
+		}
+	}
+
+	time.Sleep(duration)
+	stop.Store(true)
+	wg.Wait()
+
+	t.Logf("conns=%d goroutines=%d queries=%d failures=%d (%.0f qps)",
+		nConns, nConns*gPerConn, queries.Load(), failures.Load(),
+		float64(queries.Load())/duration.Seconds())
+
+	if failures.Load() != 0 {
+		t.Fatalf("%d queries failed under multi-connection stress", failures.Load())
+	}
+}

--- a/chdb.md
+++ b/chdb.md
@@ -28,7 +28,7 @@ import "github.com/chdb-io/chdb-go/chdb"
 func Query(queryStr string, outputFormats ...string) (result chdbpurego.ChdbResult, err error)
 ```
 
-Query calls query\_conn with a default in\-memory session and default output format of "CSV" if not provided.
+Query runs a one\-shot query and returns the materialized result \(default output format "CSV"\). chDB allows only one data path per process, so if a session is already open this helper attaches to that session's data path; otherwise it uses an in\-memory database.
 
 <a name="QueryStream"></a>
 ## func [QueryStream](<https://github.com/s0und0fs1lence/chdb-go/blob/main/chdb/wrapper.go#L23>)
@@ -37,7 +37,7 @@ Query calls query\_conn with a default in\-memory session and default output for
 func QueryStream(queryStr string, outputFormats ...string) (result chdbpurego.ChdbStreamResult, err error)
 ```
 
-Query calls query\_conn with a default in\-memory session and default output format of "CSV" if not provided.
+QueryStream is like Query but returns a streaming result that can be read in chunks, for large datasets that should not be fully materialized in memory. Like Query, it attaches to an already\-open session's data path, or uses an in\-memory database when none is open.
 
 <a name="Session"></a>
 ## type [Session](<https://github.com/s0und0fs1lence/chdb-go/blob/main/chdb/session.go#L14-L19>)

--- a/chdb.md
+++ b/chdb.md
@@ -57,7 +57,7 @@ type Session struct {
 func NewSession(paths ...string) (*Session, error)
 ```
 
-NewSession creates a new session with the given path. If path is empty, a temporary directory is created. Note: The temporary directory is removed when Close is called.
+NewSession creates a new session with the given path. If path is empty, the session reuses an already\-open data path, or creates a temporary directory when none is open. Multiple sessions can be open at once as long as they share the same data path \(each owns an independent native connection, so they can run queries in parallel\); opening a session on a different path while another is still open returns an error. The temporary directory is removed when the last session using it is closed.
 
 <a name="Session.Cleanup"></a>
 ### func \(\*Session\) [Cleanup](<https://github.com/s0und0fs1lence/chdb-go/blob/main/chdb/session.go#L86>)

--- a/chdb/driver/driver.go
+++ b/chdb/driver/driver.go
@@ -293,7 +293,25 @@ func (d Driver) Open(name string) (driver.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	return cc.Connect(context.Background())
+	c, err := cc.Connect(context.Background())
+	if err != nil {
+		// Connect failed; release the keeper session NewConnect just opened so
+		// it does not leak (database/sql would normally own and close cc).
+		if closer, ok := cc.(*connector); ok {
+			_ = closer.Close()
+		}
+		return nil, err
+	}
+	// On the sql.Open path, database/sql keeps the connector and calls
+	// connector.Close() on db.Close(). A direct Driver.Open caller discards the
+	// connector, so tie the keeper session's lifetime to the returned
+	// connection: closing the conn also releases the keeper.
+	if cn, ok := c.(*conn); ok {
+		if cnr, ok := cc.(*connector); ok {
+			cn.connector = cnr
+		}
+	}
+	return c, nil
 }
 
 // OpenConnector expects the same format as driver.Open
@@ -312,6 +330,10 @@ type conn struct {
 	useUnsafe   bool
 	isStreaming bool
 	session     *chdb.Session
+	// connector is set only on the legacy Driver.Open path (not the sql.Open
+	// path, where database/sql owns and closes the connector). When set, Close
+	// also releases the connector's keeper session.
+	connector *connector
 
 	QueryFun  queryHandle
 	streamFun queryStream
@@ -333,6 +355,12 @@ func (c *conn) Close() error {
 	if c.session != nil {
 		c.session.Close()
 		c.session = nil
+	}
+	// Only set on the Driver.Open path; releases the keeper that pins the data
+	// path/temp dir for the connector.
+	if c.connector != nil {
+		_ = c.connector.Close()
+		c.connector = nil
 	}
 	return nil
 }

--- a/chdb/driver/driver.go
+++ b/chdb/driver/driver.go
@@ -182,7 +182,8 @@ type connector struct {
 	bufferSize  int
 	isStreaming bool
 	useUnsafe   bool
-	session     *chdb.Session
+	connStr     string
+	keeper      *chdb.Session
 }
 
 // Connect returns a connection to a database.
@@ -190,13 +191,32 @@ func (c *connector) Connect(ctx context.Context) (driver.Conn, error) {
 	if c.driverType == INVALID {
 		return nil, fmt.Errorf("DriverType not supported")
 	}
+	// Each database/sql connection gets its own native chDB connection to the
+	// shared data path, so a pool of connections (MaxOpenConns > 1) yields real
+	// parallel query execution instead of serializing on a single connection.
+	session, err := chdb.NewSession(c.connStr)
+	if err != nil {
+		return nil, err
+	}
 	cc := &conn{
-		udfPath: c.udfPath, session: c.session,
+		udfPath: c.udfPath, session: session,
 		driverType: c.driverType, bufferSize: c.bufferSize,
 		useUnsafe: c.useUnsafe, isStreaming: c.isStreaming,
 	}
 	cc.SetupQueryFun()
 	return cc, nil
+}
+
+// Close releases the connector's keeper session. database/sql calls this from
+// DB.Close() because the connector implements io.Closer. Dropping the keeper
+// reference lets a registry-owned temp directory be removed once all pooled
+// connections are closed as well.
+func (c *connector) Close() error {
+	if c.keeper != nil {
+		c.keeper.Close()
+		c.keeper = nil
+	}
+	return nil
 }
 
 // Driver returns the underying Driver of the connector,
@@ -221,13 +241,6 @@ func parseConnectStr(str string) (ret map[string]string, err error) {
 }
 func NewConnect(opts map[string]string) (ret *connector, err error) {
 	ret = &connector{}
-	sessionPath, ok := opts[sessionOptionKey]
-	if ok {
-		ret.session, err = chdb.NewSession(sessionPath)
-		if err != nil {
-			return nil, err
-		}
-	}
 	driverType, ok := opts[driverTypeKey]
 	if ok {
 		ret.driverType = parseDriverType(driverType)
@@ -256,13 +269,18 @@ func NewConnect(opts map[string]string) (ret *connector, err error) {
 	if ok {
 		ret.udfPath = udfPath
 	}
-	if ret.session == nil {
 
-		ret.session, err = chdb.NewSession()
-		if err != nil {
-			return nil, err
-		}
+	// Open a "keeper" session that pins the data path (and any temp directory)
+	// for the lifetime of this connector. Each pooled connection then opens its
+	// own session on the same path; the keeper guarantees the engine and temp
+	// dir survive pool churn (when the live connection count briefly hits zero).
+	sessionPath := opts[sessionOptionKey] // "" when not provided
+	ret.keeper, err = chdb.NewSession(sessionPath)
+	if err != nil {
+		return nil, err
 	}
+	ret.connStr = ret.keeper.ConnStr()
+
 	ret.isStreaming = ret.driverType.SupportStreaming()
 	return
 }
@@ -312,6 +330,10 @@ func prepareValues(values []driver.Value) []driver.NamedValue {
 }
 
 func (c *conn) Close() error {
+	if c.session != nil {
+		c.session.Close()
+		c.session = nil
+	}
 	return nil
 }
 

--- a/chdb/driver/driver_open_test.go
+++ b/chdb/driver/driver_open_test.go
@@ -1,0 +1,61 @@
+package chdbdriver
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/chdb-io/chdb-go/chdb"
+)
+
+// TestDriverOpenNoKeeperLeak verifies that the legacy Driver.Open path does not
+// leak the connector's keeper session. database/sql owns the connector on the
+// sql.Open path and calls connector.Close(), but a direct Driver.Open(name)
+// discards the connector, so closing the returned conn must release the keeper
+// too. Pre-fix the keeper session (a native connection + a registry refcount)
+// leaks on every Open call.
+func TestDriverOpenNoKeeperLeak(t *testing.T) {
+	baseline := chdb.ActiveSessionRefs()
+
+	c, err := Driver{}.Open("session=" + session.ConnStr())
+	if err != nil {
+		t.Fatalf("Driver.Open failed: %s", err)
+	}
+	if err := c.Close(); err != nil {
+		t.Fatalf("conn.Close failed: %s", err)
+	}
+
+	if got := chdb.ActiveSessionRefs(); got != baseline {
+		t.Fatalf("Driver.Open leaked sessions: refs=%d, baseline=%d (keeper not released on conn.Close)", got, baseline)
+	}
+}
+
+// TestDbCloseReleasesRefs verifies the database/sql path balances refcounts:
+// opening a *sql.DB, running queries across multiple pooled connections, and
+// closing it returns the registry to its baseline (keeper + per-conn sessions
+// all released).
+func TestDbCloseReleasesRefs(t *testing.T) {
+	baseline := chdb.ActiveSessionRefs()
+
+	db, err := sql.Open("chdb", "session="+session.ConnStr())
+	if err != nil {
+		t.Fatalf("open db failed: %s", err)
+	}
+	db.SetMaxOpenConns(4)
+
+	for i := 0; i < 8; i++ {
+		var n int
+		if err := db.QueryRow("SELECT count() FROM numbers(10)").Scan(&n); err != nil {
+			t.Fatalf("query failed: %s", err)
+		}
+		if n != 10 {
+			t.Fatalf("got %d want 10", n)
+		}
+	}
+
+	if err := db.Close(); err != nil {
+		t.Fatalf("db.Close failed: %s", err)
+	}
+	if got := chdb.ActiveSessionRefs(); got != baseline {
+		t.Fatalf("db.Close left refs leaked: refs=%d, baseline=%d", got, baseline)
+	}
+}

--- a/chdb/driver/driver_test.go
+++ b/chdb/driver/driver_test.go
@@ -50,6 +50,7 @@ func TestDb(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open db fail, err:%s", err)
 	}
+	defer db.Close()
 	if db.Ping() != nil {
 		t.Fatalf("ping db fail")
 	}
@@ -88,6 +89,7 @@ func TestDbWithCompiledArgs(t *testing.T) {
 	if err != nil {
 		t.Errorf("open db fail, err:%s", err)
 	}
+	defer db.Close()
 	if db.Ping() != nil {
 		t.Errorf("ping db fail")
 	}
@@ -170,6 +172,7 @@ func TestDbWithSession(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open db fail, err: %s", err)
 	}
+	defer db.Close()
 	if db.Ping() != nil {
 		t.Fatalf("ping db fail, err: %s", err)
 	}
@@ -217,6 +220,7 @@ func TestDbWithConnection(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open db fail, err: %s", err)
 	}
+	defer db.Close()
 	if db.Ping() != nil {
 		t.Fatalf("ping db fail, err: %s", err)
 	}
@@ -251,6 +255,7 @@ func TestDbWithConnectionSqlDriverOnly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open db fail, err: %s", err)
 	}
+	defer db.Close()
 	if db.Ping() != nil {
 		t.Fatalf("ping db fail, err: %s", err)
 	}
@@ -309,6 +314,7 @@ func TestQueryRow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open db fail, err: %s", err)
 	}
+	defer db.Close()
 	if db.Ping() != nil {
 		t.Fatalf("ping db fail, err: %s", err)
 	}
@@ -339,6 +345,7 @@ func TestExec(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open db fail, err: %s", err)
 	}
+	defer db.Close()
 	if db.Ping() != nil {
 		t.Fatalf("ping db fail, err: %s", err)
 	}

--- a/chdb/driver/driver_test.go
+++ b/chdb/driver/driver_test.go
@@ -4,7 +4,10 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+	"runtime"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/chdb-io/chdb-go/chdb"
 )
@@ -119,16 +122,20 @@ func TestDbWithCompiledArgs(t *testing.T) {
 }
 
 func TestDbWithOpt(t *testing.T) {
+	// chDB allows only one data path per process, so every session option must
+	// point at the same path the global test session already opened. These cases
+	// exercise connection-string parsing, not multiple data paths.
+	sp := session.ConnStr()
 	for _, kv := range []struct {
 		opt       string
 		condition bool
 	}{
 		{"", false},
 		{"udfPath=qq", false},
-		{"udfPath=qq;session=ss", false},
-		{"session=sssss", false},
-		{"session=s2;udfPath=u1", false},
-		{"session=s3;udfPath=u2;fooobar=ssss", false},
+		{fmt.Sprintf("udfPath=qq;session=%s", sp), false},
+		{fmt.Sprintf("session=%s", sp), false},
+		{fmt.Sprintf("session=%s;udfPath=u1", sp), false},
+		{fmt.Sprintf("session=%s;udfPath=u2;fooobar=ssss", sp), false},
 		{"foo;bar", true},
 	} {
 		db, err := sql.Open("chdb", kv.opt)
@@ -141,6 +148,7 @@ func TestDbWithOpt(t *testing.T) {
 		if (db.Ping() != nil) != kv.condition {
 			t.Errorf("ping db fail")
 		}
+		db.Close()
 	}
 }
 
@@ -369,4 +377,113 @@ func TestExec(t *testing.T) {
 		t.Fatalf("QueryRow method should return only one item")
 	}
 
+}
+
+// TestConcurrentQueries verifies that many goroutines can run queries in
+// parallel through a single *sql.DB with MaxOpenConns > 1. Each pooled
+// connection is an independent native chDB connection, so this exercises real
+// concurrent execution rather than serialization on one connection.
+func TestConcurrentQueries(t *testing.T) {
+	db, err := sql.Open("chdb", fmt.Sprintf("session=%s", session.ConnStr()))
+	if err != nil {
+		t.Fatalf("open db fail, err: %s", err)
+	}
+	defer db.Close()
+
+	maxConns := runtime.NumCPU()
+	if maxConns < 2 {
+		maxConns = 2
+	}
+	db.SetMaxOpenConns(maxConns)
+
+	const (
+		workers   = 8
+		perWorker = 25
+	)
+	var wg sync.WaitGroup
+	errCh := make(chan error, workers)
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perWorker; i++ {
+				var n int
+				if err := db.QueryRow("SELECT count() FROM numbers(1000)").Scan(&n); err != nil {
+					errCh <- fmt.Errorf("query failed: %w", err)
+					return
+				}
+				if n != 1000 {
+					errCh <- fmt.Errorf("got count %d, want 1000", n)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for e := range errCh {
+		t.Fatalf("concurrent query error: %v", e)
+	}
+}
+
+// TestConcurrentParallelism proves that queries on separate pooled connections
+// run in parallel rather than serialized. It uses sleep() so wall-clock time
+// reflects scheduling rather than CPU work: N concurrent sleeps should finish in
+// roughly one sleep interval, while running them serially takes ~N intervals.
+func TestConcurrentParallelism(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping timing-based parallelism test in -short mode")
+	}
+	db, err := sql.Open("chdb", fmt.Sprintf("session=%s", session.ConnStr()))
+	if err != nil {
+		t.Fatalf("open db fail, err: %s", err)
+	}
+	defer db.Close()
+
+	const (
+		n        = 4
+		sleepStr = "SELECT sleep(0.5)"
+	)
+
+	// Serial baseline: a single connection runs the queries back-to-back.
+	db.SetMaxOpenConns(1)
+	if _, err := db.Exec(sleepStr); err != nil { // warm up engine/connection
+		t.Fatalf("warmup failed: %s", err)
+	}
+	startSerial := time.Now()
+	for i := 0; i < n; i++ {
+		if _, err := db.Exec(sleepStr); err != nil {
+			t.Fatalf("serial exec failed: %s", err)
+		}
+	}
+	serial := time.Since(startSerial)
+
+	// Parallel: n connections run the queries concurrently.
+	db.SetMaxOpenConns(n)
+	var wg sync.WaitGroup
+	errCh := make(chan error, n)
+	startParallel := time.Now()
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := db.Exec(sleepStr); err != nil {
+				errCh <- err
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for e := range errCh {
+		t.Fatalf("parallel exec failed: %v", e)
+	}
+	parallel := time.Since(startParallel)
+
+	t.Logf("serial=%s parallel=%s speedup=%.2fx (n=%d)", serial, parallel, float64(serial)/float64(parallel), n)
+
+	// True parallelism makes the concurrent run finish far faster than serial.
+	// Require a clear margin to stay robust against scheduling jitter.
+	if float64(parallel) > float64(serial)*0.6 {
+		t.Errorf("queries did not run in parallel: serial=%s parallel=%s", serial, parallel)
+	}
 }

--- a/chdb/session.go
+++ b/chdb/session.go
@@ -28,36 +28,62 @@ import (
 // Connection establishment is serialized by sessMu (it also guards the
 // process-global signal-handler snapshot/restore done during connect); query
 // execution is NOT serialized here and runs concurrently across Sessions.
+//
+// activePath holds the resolved physical identity of the live engine (an
+// absolute directory, or ":memory:") so that two Sessions naming the same data
+// path with different connection-string spellings ("db", "file:db",
+// "file:db?param=v") are correctly recognized as the same path.
 var (
 	sessMu     sync.Mutex
-	activePath string // resolved path of the live engine; "" when none is open
+	activePath string // resolved identity of the live engine; "" when none is open
 	activeRefs int    // number of open Sessions on activePath
 	activeTemp bool   // whether activePath is a temp dir owned by the registry
 )
 
 type Session struct {
+	// mu guards conn and closed so that Query/QueryStream cannot run against a
+	// native connection that Close/Cleanup is freeing. Query takes a read lock
+	// (concurrent queries are allowed); Close/Cleanup take the write lock, which
+	// waits for in-flight queries to finish before the native connection is
+	// destroyed.
+	mu      sync.RWMutex
 	conn    chdbpurego.ChdbConn
-	connStr string
-	path    string
+	connStr string // full connection string handed to the native layer (params preserved)
+	path    string // resolved on-disk data directory ("" for an in-memory session)
 	isTemp  bool
 	closed  bool
 }
 
-// resolvePathKey normalizes a requested path into a stable key used to detect
-// whether two Sessions target the same data path. Plain filesystem paths are
-// made absolute; ":memory:" and connection strings carrying a scheme or query
-// params ("file:...", "...?param=val") are compared verbatim.
-func resolvePathKey(p string) string {
-	if p == "" || p == ":memory:" {
-		return p
+// resolveTarget canonicalizes a requested connection string the same way the
+// native chdb-purego layer (NewConnectionFromConnString) does, so the registry
+// identity key always matches the directory libchdb actually opens. It strips a
+// leading "file:" scheme (and the "file:///" triple slash), drops any "?params"
+// query string, and makes a filesystem path absolute. It returns:
+//
+//   - key: the identity used to decide whether two Sessions share a data path
+//     (an absolute directory, or ":memory:"). Drive-letter and other absolute
+//     paths are normalized by filepath.Abs, which is OS-aware (so Windows
+//     "C:\\data" resolves correctly).
+//   - dir: the on-disk directory to remove on Cleanup ("" for in-memory).
+func resolveTarget(p string) (key, dir string) {
+	s := p
+	if strings.HasPrefix(s, "file:") {
+		s = s[len("file:"):]
+		// "file:///abs/path" -> "/abs/path" (keep a single leading slash).
+		if strings.HasPrefix(s, "///") {
+			s = s[2:]
+		}
 	}
-	if strings.ContainsAny(p, ":?") {
-		return p
+	if i := strings.IndexByte(s, '?'); i != -1 {
+		s = s[:i]
 	}
-	if abs, err := filepath.Abs(p); err == nil {
-		return abs
+	if s == "" || s == ":memory:" {
+		return ":memory:", ""
 	}
-	return p
+	if abs, err := filepath.Abs(s); err == nil {
+		s = abs
+	}
+	return s, s
 }
 
 // NewSession creates a new session with the given path.
@@ -70,7 +96,8 @@ func resolvePathKey(p string) string {
 // data path; each session owns an independent native connection, so they can
 // execute queries in parallel. Opening a session on a different path while
 // another is still open returns an error (chDB allows only one data path per
-// process).
+// process). The same physical path written different ways ("db", "file:db",
+// "file:db?param=v") is recognized as the same path and is allowed.
 func NewSession(paths ...string) (*Session, error) {
 	requested := ""
 	if len(paths) > 0 {
@@ -80,40 +107,50 @@ func NewSession(paths ...string) (*Session, error) {
 	sessMu.Lock()
 	defer sessMu.Unlock()
 
-	var path string
-	var isTemp bool
-	createdTemp := ""
+	var (
+		connStr     string
+		key         string
+		dir         string
+		isTemp      bool
+		createdTemp string
+	)
 
-	if requested == "" {
-		if activeRefs > 0 {
-			// Reuse the already-open data path so the new session attaches to
-			// the same engine instead of trying to open a second path.
-			path = activePath
-			isTemp = activeTemp
-		} else {
-			tempDir, err := os.MkdirTemp("", "chdb_")
-			if err != nil {
-				return nil, err
-			}
-			path = tempDir
-			isTemp = true
-			createdTemp = tempDir
+	switch {
+	case requested == "" && activeRefs > 0:
+		// Reuse the already-open data path so the new session attaches to the
+		// same engine instead of trying to open a second path.
+		connStr = activePath
+		key = activePath
+		if activePath != ":memory:" {
+			dir = activePath
 		}
-	} else {
-		path = resolvePathKey(requested)
-		isTemp = false
+		isTemp = activeTemp
+	case requested == "":
+		// Nothing open and no path requested: create a temp directory.
+		tempDir, err := os.MkdirTemp("", "chdb_")
+		if err != nil {
+			return nil, err
+		}
+		connStr, key, dir = tempDir, tempDir, tempDir
+		isTemp = true
+		createdTemp = tempDir
+	default:
+		// Preserve the original DSN (including any params) for the native
+		// connect, but key/identify the session by its resolved physical path.
+		connStr = requested
+		key, dir = resolveTarget(requested)
 	}
 
-	if activeRefs > 0 && path != activePath {
+	if activeRefs > 0 && key != activePath {
 		if createdTemp != "" {
 			_ = os.RemoveAll(createdTemp)
 		}
 		return nil, fmt.Errorf(
 			"chdb: a session is already open on path %q; chDB allows only one data path per process, cannot also open %q",
-			activePath, path)
+			activePath, key)
 	}
 
-	conn, err := initConnection(path)
+	conn, err := initConnection(connStr)
 	if err != nil {
 		if createdTemp != "" {
 			_ = os.RemoveAll(createdTemp)
@@ -122,12 +159,12 @@ func NewSession(paths ...string) (*Session, error) {
 	}
 
 	if activeRefs == 0 {
-		activePath = path
+		activePath = key
 		activeTemp = isTemp
 	}
 	activeRefs++
 
-	return &Session{connStr: path, path: path, isTemp: isTemp, conn: conn}, nil
+	return &Session{connStr: connStr, path: dir, isTemp: isTemp, conn: conn}, nil
 }
 
 // Query calls `query_conn` function with the current connection and a default output format of "CSV" if not provided.
@@ -135,6 +172,11 @@ func (s *Session) Query(queryStr string, outputFormats ...string) (result chdbpu
 	outputFormat := "CSV" // Default value
 	if len(outputFormats) > 0 {
 		outputFormat = outputFormats[0]
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.closed || s.conn == nil {
+		return nil, fmt.Errorf("chdb: query on a closed session")
 	}
 	return s.conn.Query(queryStr, outputFormat)
 }
@@ -147,55 +189,85 @@ func (s *Session) QueryStream(queryStr string, outputFormats ...string) (result 
 	if len(outputFormats) > 0 {
 		outputFormat = outputFormats[0]
 	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.closed || s.conn == nil {
+		return nil, fmt.Errorf("chdb: query on a closed session")
+	}
 	return s.conn.QueryStreaming(queryStr, outputFormat)
 }
 
 // Close closes this session's native connection. When it is the last open
 // session on a registry-owned temporary directory, that directory is removed.
-// Close is idempotent.
+//
+// Close is idempotent and safe to call concurrently with Query: it waits for
+// any in-flight query on this session to finish before freeing the native
+// connection.
 func (s *Session) Close() {
 	if s == nil {
 		return
 	}
-	sessMu.Lock()
-	defer sessMu.Unlock()
+	s.mu.Lock()
 	if s.closed {
+		s.mu.Unlock()
 		return
 	}
 	s.closed = true
 	if s.conn != nil {
 		s.conn.Close()
+		s.conn = nil
 	}
+	s.mu.Unlock()
+
+	sessMu.Lock()
 	s.release(false)
+	sessMu.Unlock()
 }
 
-// Cleanup closes this session and removes its data directory, regardless of
-// whether it is temporary. It is destructive and intended for teardown; do not
-// call it while other sessions on the same path are still in use. Cleanup is
-// idempotent.
+// Cleanup closes this session and, when it is the last session on the data
+// path, removes the data directory regardless of whether it is temporary. It is
+// destructive and intended for teardown, but it will NOT delete a directory
+// that sibling sessions on the same path are still using. Cleanup is
+// idempotent and, like Close, waits for any in-flight query to finish.
 func (s *Session) Cleanup() {
 	if s == nil {
 		return
 	}
-	sessMu.Lock()
-	defer sessMu.Unlock()
-	pathToRemove := s.path
-	if !s.closed {
+	s.mu.Lock()
+	wasOpen := !s.closed
+	if wasOpen {
 		s.closed = true
 		if s.conn != nil {
 			s.conn.Close()
+			s.conn = nil
 		}
-		s.release(true)
 	}
-	if pathToRemove != "" {
-		_ = os.RemoveAll(pathToRemove)
+	dir := s.path
+	s.mu.Unlock()
+
+	sessMu.Lock()
+	var last bool
+	if wasOpen {
+		// forced: suppress release()'s own temp removal; we remove dir below
+		// (Cleanup removes non-temp directories too).
+		last = s.release(true)
+	} else {
+		// This session was already released by a prior Close; only remove the
+		// directory if the path is now idle (no sibling sessions remain).
+		last = activeRefs == 0
+	}
+	sessMu.Unlock()
+
+	if last && dir != "" {
+		_ = os.RemoveAll(dir)
 	}
 }
 
-// release decrements the active refcount and, when it reaches zero, clears the
-// registry and (unless forced cleanup already handles removal) deletes a
-// registry-owned temp directory. Callers must hold sessMu.
-func (s *Session) release(forced bool) {
+// release decrements the active refcount and reports whether this was the last
+// session on the path. When the count reaches zero the registry is cleared and,
+// unless the caller forces its own cleanup, a registry-owned temp directory is
+// removed. Callers must hold sessMu.
+func (s *Session) release(forced bool) (last bool) {
 	if activeRefs > 0 {
 		activeRefs--
 	}
@@ -205,10 +277,13 @@ func (s *Session) release(forced bool) {
 		}
 		activePath = ""
 		activeTemp = false
+		return true
 	}
+	return false
 }
 
-// Path returns the path of the session.
+// Path returns the resolved on-disk data directory of the session ("" for an
+// in-memory session).
 func (s *Session) Path() string {
 	return s.path
 }
@@ -221,4 +296,14 @@ func (s *Session) ConnStr() string {
 // IsTemp returns whether the session is temporary.
 func (s *Session) IsTemp() bool {
 	return s.isTemp
+}
+
+// ActiveSessionRefs returns the number of currently-open sessions sharing the
+// process-wide data path (0 when no session is open). It is primarily useful
+// for diagnostics and tests that assert sessions and their native connections
+// are released correctly.
+func ActiveSessionRefs() int {
+	sessMu.Lock()
+	defer sessMu.Unlock()
+	return activeRefs
 }

--- a/chdb/session.go
+++ b/chdb/session.go
@@ -1,14 +1,38 @@
 package chdb
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 
 	chdbpurego "github.com/chdb-io/chdb-go/chdb-purego"
 )
 
+// chDB embeds a single ClickHouse engine (EmbeddedServer) per process: the
+// engine is a refcounted singleton bound to one data path, but it accepts
+// multiple independent client connections that can run queries concurrently.
+// The registry below mirrors that contract on the Go side:
+//
+//   - Multiple Sessions may be open at once, each holding its own native
+//     connection (its own ClickHouse client), as long as they all share the
+//     same data path. This is what enables real concurrency (e.g. via
+//     database/sql with MaxOpenConns > 1).
+//   - Opening a Session on a different path while another is still open
+//     returns an error, because the engine allows only one data path per
+//     process.
+//   - A temp directory created for an empty-path Session is owned by the
+//     registry and removed once the last Session on it is closed.
+//
+// Connection establishment is serialized by sessMu (it also guards the
+// process-global signal-handler snapshot/restore done during connect); query
+// execution is NOT serialized here and runs concurrently across Sessions.
 var (
-	globalSession *Session
+	sessMu     sync.Mutex
+	activePath string // resolved path of the live engine; "" when none is open
+	activeRefs int    // number of open Sessions on activePath
+	activeTemp bool   // whether activePath is a temp dir owned by the registry
 )
 
 type Session struct {
@@ -16,38 +40,94 @@ type Session struct {
 	connStr string
 	path    string
 	isTemp  bool
+	closed  bool
+}
+
+// resolvePathKey normalizes a requested path into a stable key used to detect
+// whether two Sessions target the same data path. Plain filesystem paths are
+// made absolute; ":memory:" and connection strings carrying a scheme or query
+// params ("file:...", "...?param=val") are compared verbatim.
+func resolvePathKey(p string) string {
+	if p == "" || p == ":memory:" {
+		return p
+	}
+	if strings.ContainsAny(p, ":?") {
+		return p
+	}
+	if abs, err := filepath.Abs(p); err == nil {
+		return abs
+	}
+	return p
 }
 
 // NewSession creates a new session with the given path.
-// If path is empty, a temporary directory is created.
-// Note: The temporary directory is removed when Close is called.
+//
+// If path is empty, the session reuses the data path of any already-open
+// session, or creates a temporary directory when none is open. The temporary
+// directory is removed when the last session using it is closed.
+//
+// Multiple sessions can be open concurrently as long as they share the same
+// data path; each session owns an independent native connection, so they can
+// execute queries in parallel. Opening a session on a different path while
+// another is still open returns an error (chDB allows only one data path per
+// process).
 func NewSession(paths ...string) (*Session, error) {
-	if globalSession != nil {
-		return globalSession, nil
-	}
-
-	path := ""
+	requested := ""
 	if len(paths) > 0 {
-		path = paths[0]
+		requested = paths[0]
 	}
-	isTemp := false
-	if path == "" {
-		// Create a temporary directory
-		tempDir, err := os.MkdirTemp("", "chdb_")
-		if err != nil {
-			return nil, err
-		}
-		path = tempDir
-		isTemp = true
-	}
-	connStr := path
 
-	conn, err := initConnection(connStr)
+	sessMu.Lock()
+	defer sessMu.Unlock()
+
+	var path string
+	var isTemp bool
+	createdTemp := ""
+
+	if requested == "" {
+		if activeRefs > 0 {
+			// Reuse the already-open data path so the new session attaches to
+			// the same engine instead of trying to open a second path.
+			path = activePath
+			isTemp = activeTemp
+		} else {
+			tempDir, err := os.MkdirTemp("", "chdb_")
+			if err != nil {
+				return nil, err
+			}
+			path = tempDir
+			isTemp = true
+			createdTemp = tempDir
+		}
+	} else {
+		path = resolvePathKey(requested)
+		isTemp = false
+	}
+
+	if activeRefs > 0 && path != activePath {
+		if createdTemp != "" {
+			_ = os.RemoveAll(createdTemp)
+		}
+		return nil, fmt.Errorf(
+			"chdb: a session is already open on path %q; chDB allows only one data path per process, cannot also open %q",
+			activePath, path)
+	}
+
+	conn, err := initConnection(path)
 	if err != nil {
+		if createdTemp != "" {
+			_ = os.RemoveAll(createdTemp)
+		}
 		return nil, err
 	}
-	globalSession = &Session{connStr: connStr, path: path, isTemp: isTemp, conn: conn}
-	return globalSession, nil
+
+	if activeRefs == 0 {
+		activePath = path
+		activeTemp = isTemp
+	}
+	activeRefs++
+
+	return &Session{connStr: path, path: path, isTemp: isTemp, conn: conn}, nil
 }
 
 // Query calls `query_conn` function with the current connection and a default output format of "CSV" if not provided.
@@ -70,24 +150,62 @@ func (s *Session) QueryStream(queryStr string, outputFormats ...string) (result 
 	return s.conn.QueryStreaming(queryStr, outputFormat)
 }
 
-// Close closes the session and removes the temporary directory
-//
-//	temporary directory is created when NewSession was called with an empty path.
+// Close closes this session's native connection. When it is the last open
+// session on a registry-owned temporary directory, that directory is removed.
+// Close is idempotent.
 func (s *Session) Close() {
-	// Remove the temporary directory if it starts with "chdb_"
-	s.conn.Close()
-	if s.isTemp && filepath.Base(s.path)[:5] == "chdb_" {
-		s.Cleanup()
+	if s == nil {
+		return
 	}
-	globalSession = nil
+	sessMu.Lock()
+	defer sessMu.Unlock()
+	if s.closed {
+		return
+	}
+	s.closed = true
+	if s.conn != nil {
+		s.conn.Close()
+	}
+	s.release(false)
 }
 
-// Cleanup closes the session and removes the directory.
+// Cleanup closes this session and removes its data directory, regardless of
+// whether it is temporary. It is destructive and intended for teardown; do not
+// call it while other sessions on the same path are still in use. Cleanup is
+// idempotent.
 func (s *Session) Cleanup() {
-	// Remove the session directory, no matter if it is temporary or not
-	_ = os.RemoveAll(s.path)
-	s.conn.Close()
-	globalSession = nil
+	if s == nil {
+		return
+	}
+	sessMu.Lock()
+	defer sessMu.Unlock()
+	pathToRemove := s.path
+	if !s.closed {
+		s.closed = true
+		if s.conn != nil {
+			s.conn.Close()
+		}
+		s.release(true)
+	}
+	if pathToRemove != "" {
+		_ = os.RemoveAll(pathToRemove)
+	}
+}
+
+// release decrements the active refcount and, when it reaches zero, clears the
+// registry and (unless forced cleanup already handles removal) deletes a
+// registry-owned temp directory. Callers must hold sessMu.
+func (s *Session) release(forced bool) {
+	if activeRefs > 0 {
+		activeRefs--
+	}
+	if activeRefs == 0 {
+		if !forced && activeTemp && activePath != "" {
+			_ = os.RemoveAll(activePath)
+		}
+		activePath = ""
+		activeTemp = false
+	}
 }
 
 // Path returns the path of the session.

--- a/chdb/session_concurrency_test.go
+++ b/chdb/session_concurrency_test.go
@@ -1,0 +1,244 @@
+package chdb
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// requireNoActiveSessions fails the test if the registry did not return to a
+// clean state, catching refcount/temp-dir leaks between tests.
+func requireNoActiveSessions(t *testing.T) {
+	t.Helper()
+	if n := ActiveSessionRefs(); n != 0 {
+		t.Fatalf("expected 0 active session refs at start, got %d (leak from a previous test)", n)
+	}
+}
+
+// TestSessionSamePathDifferentSpelling verifies that two sessions naming the
+// SAME physical directory with different connection-string spellings (plain
+// path vs the documented "file:" prefix) are recognized as the same data path
+// and are allowed to share the engine, instead of being rejected with a
+// spurious "conflicting path" error.
+//
+// Pre-fix this fails: resolvePathKey returned "file:..." verbatim while the
+// native layer resolved both to the same absolute directory, so the keys
+// diverged and the second NewSession was rejected.
+func TestSessionSamePathDifferentSpelling(t *testing.T) {
+	requireNoActiveSessions(t)
+	dir := filepath.Join(t.TempDir(), "db")
+
+	s1, err := NewSession(dir) // absolute path
+	if err != nil {
+		t.Fatalf("NewSession(%q) failed: %s", dir, err)
+	}
+	defer s1.Close()
+
+	s2, err := NewSession("file:" + dir) // same directory, file: prefix
+	if err != nil {
+		t.Fatalf("NewSession(file:%s) on the same physical path was wrongly rejected: %s", dir, err)
+	}
+	defer s2.Close()
+
+	if s1.Path() != s2.Path() {
+		t.Fatalf("sessions should resolve to the same physical path, got %q and %q", s1.Path(), s2.Path())
+	}
+}
+
+// TestSessionMemorySpellings verifies ":memory:" and "file::memory:" map to the
+// same in-memory target and do not spuriously conflict.
+func TestSessionMemorySpellings(t *testing.T) {
+	requireNoActiveSessions(t)
+	s1, err := NewSession(":memory:")
+	if err != nil {
+		t.Fatalf("NewSession(:memory:) failed: %s", err)
+	}
+	defer s1.Close()
+
+	s2, err := NewSession("file::memory:")
+	if err != nil {
+		t.Fatalf("NewSession(file::memory:) on the same in-memory target was wrongly rejected: %s", err)
+	}
+	defer s2.Close()
+}
+
+// TestSessionCleanupRemovesResolvedDir verifies Cleanup() deletes the directory
+// libchdb actually opened, even when the session was created with a "file:"
+// connection string. Pre-fix Cleanup ran os.RemoveAll on the verbatim DSN
+// ("file:<dir>"), leaving the real data directory on disk.
+func TestSessionCleanupRemovesResolvedDir(t *testing.T) {
+	requireNoActiveSessions(t)
+	dir := filepath.Join(t.TempDir(), "data")
+
+	s, err := NewSession("file:" + dir)
+	if err != nil {
+		t.Fatalf("NewSession failed: %s", err)
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("expected data directory %q to exist after open: %s", dir, err)
+	}
+	s.Cleanup()
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("Cleanup should have removed the resolved data directory %q, stat err=%v", dir, err)
+	}
+}
+
+// TestCleanupDoesNotRemoveSharedDir verifies that calling Cleanup() on one
+// session does NOT delete the shared data directory while a sibling session on
+// the same path is still open and usable.
+//
+// Pre-fix this fails: Cleanup ran os.RemoveAll(s.path) unconditionally, wiping
+// the directory out from under the live sibling.
+func TestCleanupDoesNotRemoveSharedDir(t *testing.T) {
+	requireNoActiveSessions(t)
+
+	s1, err := NewSession()
+	if err != nil {
+		t.Fatalf("NewSession failed: %s", err)
+	}
+	defer s1.Close()
+
+	s2, err := NewSession() // reuses s1's (temp) path
+	if err != nil {
+		t.Fatalf("second NewSession failed: %s", err)
+	}
+	defer s2.Close()
+
+	if s1.Path() != s2.Path() {
+		t.Fatalf("expected shared path, got %q and %q", s1.Path(), s2.Path())
+	}
+
+	// Cleanup the first session while the second is still open.
+	s1.Cleanup()
+
+	// The shared directory must still exist and s2 must still be usable.
+	if _, err := os.Stat(s2.Path()); err != nil {
+		t.Fatalf("shared data dir %q was removed while a sibling session was open: %v", s2.Path(), err)
+	}
+	if _, err := s2.Query("SELECT 1"); err != nil {
+		t.Fatalf("sibling session broke after the other session's Cleanup: %s", err)
+	}
+}
+
+// TestRefcountedTempCleanup verifies the temp directory survives until the LAST
+// session on it closes, and is removed afterwards.
+func TestRefcountedTempCleanup(t *testing.T) {
+	requireNoActiveSessions(t)
+
+	s1, err := NewSession()
+	if err != nil {
+		t.Fatalf("NewSession failed: %s", err)
+	}
+	path := s1.Path()
+	s2, err := NewSession()
+	if err != nil {
+		t.Fatalf("second NewSession failed: %s", err)
+	}
+	if ActiveSessionRefs() != 2 {
+		t.Fatalf("expected 2 active refs, got %d", ActiveSessionRefs())
+	}
+
+	s1.Close()
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("temp dir %q removed after first close but a session is still open: %v", path, err)
+	}
+	if ActiveSessionRefs() != 1 {
+		t.Fatalf("expected 1 active ref after first close, got %d", ActiveSessionRefs())
+	}
+
+	s2.Close()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("temp dir %q should be removed after the last close, stat err=%v", path, err)
+	}
+	if ActiveSessionRefs() != 0 {
+		t.Fatalf("expected 0 active refs after last close, got %d", ActiveSessionRefs())
+	}
+}
+
+// TestConflictThenRecover verifies that after a conflicting-path error the
+// registry is left intact: the original session keeps working and a subsequent
+// same-path session still succeeds.
+func TestConflictThenRecover(t *testing.T) {
+	requireNoActiveSessions(t)
+
+	first, err := NewSession()
+	if err != nil {
+		t.Fatalf("NewSession failed: %s", err)
+	}
+	defer first.Close()
+
+	other := filepath.Join(t.TempDir(), "other")
+	if _, err := NewSession(other); err == nil {
+		t.Fatalf("expected conflict error opening a different path")
+	}
+	// Registry must be intact: original still works, refcount unchanged.
+	if ActiveSessionRefs() != 1 {
+		t.Fatalf("conflict error perturbed the refcount, got %d want 1", ActiveSessionRefs())
+	}
+	if _, err := first.Query("SELECT 1"); err != nil {
+		t.Fatalf("original session broke after a conflict error: %s", err)
+	}
+	// A same-path session must still succeed.
+	s2, err := NewSession()
+	if err != nil {
+		t.Fatalf("same-path NewSession after conflict failed: %s", err)
+	}
+	s2.Close()
+}
+
+// TestSessionQueryAfterClose verifies a Query on a closed session returns a
+// clean error instead of dereferencing a freed native connection.
+//
+// Pre-fix this crashes (use-after-free on the freed native connection).
+func TestSessionQueryAfterClose(t *testing.T) {
+	requireNoActiveSessions(t)
+
+	s, err := NewSession()
+	if err != nil {
+		t.Fatalf("NewSession failed: %s", err)
+	}
+	s.Close()
+
+	if _, err := s.Query("SELECT 1"); err == nil {
+		t.Fatalf("expected an error querying a closed session, got nil")
+	}
+}
+
+// TestSessionConcurrentQueryClose hammers a single session with concurrent
+// queries while another goroutine closes it. With the per-session guard in
+// place this must not crash or trip the race detector; queries either succeed
+// or return a clean "closed" error.
+//
+// Pre-fix this is a use-after-free / data race between chdb_query and
+// chdb_close_conn on the same connection.
+func TestSessionConcurrentQueryClose(t *testing.T) {
+	requireNoActiveSessions(t)
+
+	s, err := NewSession()
+	if err != nil {
+		t.Fatalf("NewSession failed: %s", err)
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				// Ignore errors: a "closed" error is an acceptable outcome.
+				if _, err := s.Query("SELECT 1"); err != nil {
+					return
+				}
+			}
+		}()
+	}
+
+	// Close concurrently with the in-flight queries.
+	s.Close()
+	wg.Wait()
+
+	// Idempotent close must be safe too.
+	s.Close()
+	s.Cleanup()
+}

--- a/chdb/session_test.go
+++ b/chdb/session_test.go
@@ -1,47 +1,18 @@
 package chdb
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 )
 
-var (
-	session *Session
-)
-
-func globalSetup() error {
-	sess, err := NewSession()
-	if err != nil {
-		return err
-	}
-	session = sess
-	return nil
-}
-
-func globalTeardown() {
-	session.Cleanup()
-	session.Close()
-}
-
-func TestMain(m *testing.M) {
-	if err := globalSetup(); err != nil {
-		fmt.Println("Global setup failed:", err)
-		os.Exit(1)
-	}
-	// Run all tests.
-	exitCode := m.Run()
-
-	// Global teardown: clean up any resources here.
-	globalTeardown()
-
-	// Exit with the code returned by m.Run().
-	os.Exit(exitCode)
-}
-
 // TestNewSession tests the creation of a new session.
 func TestNewSession(t *testing.T) {
+	session, err := NewSession()
+	if err != nil {
+		t.Fatalf("NewSession failed: %s", err)
+	}
+	defer session.Cleanup()
 
 	// Check if the session directory exists
 	if _, err := os.Stat(session.Path()); os.IsNotExist(err) {
@@ -54,12 +25,14 @@ func TestNewSession(t *testing.T) {
 	}
 }
 
-// This test is currently flaky because of this: https://github.com/chdb-io/chdb/pull/299/commits/91b0aedd8c17e74a4bb213e885d89cc9a77c99ad
 func TestQuery(t *testing.T) {
+	session, err := NewSession()
+	if err != nil {
+		t.Fatalf("NewSession failed: %s", err)
+	}
+	defer session.Cleanup()
 
-	// time.Sleep(time.Second * 5)
-
-	_, err := session.Query("CREATE TABLE IF NOT EXISTS TestQuery (id UInt32) ENGINE = MergeTree() ORDER BY id;")
+	_, err = session.Query("CREATE TABLE IF NOT EXISTS TestQuery (id UInt32) ENGINE = MergeTree() ORDER BY id;")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,6 +76,59 @@ func TestSessionPathAndIsTemp(t *testing.T) {
 
 	if session.IsTemp() {
 		t.Errorf("Session should not be temporary")
+	}
+}
+
+// TestSessionConflictingPath verifies that opening a second session on a
+// different path while one is already open is rejected (chDB allows only one
+// data path per process).
+func TestSessionConflictingPath(t *testing.T) {
+	first, err := NewSession()
+	if err != nil {
+		t.Fatalf("NewSession failed: %s", err)
+	}
+	defer first.Cleanup()
+
+	other := filepath.Join(os.TempDir(), "chdb_conflict_test")
+	defer os.RemoveAll(other)
+	if _, err := NewSession(other); err == nil {
+		t.Errorf("expected an error opening a second session on a different path, got nil")
+	}
+}
+
+// TestConcurrentSessionsSamePath verifies that multiple sessions can be open
+// on the same data path at once and share state.
+func TestConcurrentSessionsSamePath(t *testing.T) {
+	s1, err := NewSession()
+	if err != nil {
+		t.Fatalf("NewSession failed: %s", err)
+	}
+	defer s1.Cleanup()
+
+	// A second session on the same (empty -> reused) path must succeed.
+	s2, err := NewSession()
+	if err != nil {
+		t.Fatalf("second NewSession on same path failed: %s", err)
+	}
+	defer s2.Close()
+
+	if s1.Path() != s2.Path() {
+		t.Fatalf("expected both sessions to share the path, got %q and %q", s1.Path(), s2.Path())
+	}
+
+	if _, err := s1.Query("CREATE TABLE IF NOT EXISTS shared (id UInt32) ENGINE = MergeTree() ORDER BY id;"); err != nil {
+		t.Fatalf("create via s1 failed: %s", err)
+	}
+	if _, err := s1.Query("INSERT INTO shared VALUES (7);"); err != nil {
+		t.Fatalf("insert via s1 failed: %s", err)
+	}
+	// s2 must see data written through s1 (shared engine instance).
+	ret, err := s2.Query("SELECT * FROM shared;")
+	if err != nil {
+		t.Fatalf("select via s2 failed: %s", err)
+	}
+	if string(ret.Buf()) != "7\n" {
+		t.Fatalf("s2 should see s1's data (7), got %q", string(ret.Buf()))
 	}
 }
 

--- a/chdb/wrapper.go
+++ b/chdb/wrapper.go
@@ -4,34 +4,58 @@ import (
 	chdbpurego "github.com/chdb-io/chdb-go/chdb-purego"
 )
 
-// Query calls query_conn with a default in-memory session and default output format of "CSV" if not provided.
+// Query runs a one-shot query and returns the materialized result. Output
+// format defaults to "CSV" when not provided.
+//
+// chDB allows only one data path per process, so if a session is already open
+// this helper attaches to that session's data path; otherwise it uses an
+// in-memory database.
 func Query(queryStr string, outputFormats ...string) (result chdbpurego.ChdbResult, err error) {
 	outputFormat := "CSV" // Default value
 	if len(outputFormats) > 0 {
 		outputFormat = outputFormats[0]
 	}
-	// tempSession, err := initConnection(":memory:?verbose&log-level=test")
-	tempSession, err := initConnection(":memory:")
+	sess, err := ephemeralSession()
 	if err != nil {
 		return nil, err
 	}
-	defer tempSession.Close()
-	return tempSession.Query(queryStr, outputFormat)
+	defer sess.Close()
+	return sess.Query(queryStr, outputFormat)
 }
 
-// Query calls query_conn with a default in-memory session and default output format of "CSV" if not provided.
+// QueryStream is like Query but returns a streaming result that can be read in
+// chunks, for large datasets that should not be fully materialized in memory.
 func QueryStream(queryStr string, outputFormats ...string) (result chdbpurego.ChdbStreamResult, err error) {
 	outputFormat := "CSV" // Default value
 	if len(outputFormats) > 0 {
 		outputFormat = outputFormats[0]
 	}
-	// tempSession, err := initConnection(":memory:?verbose&log-level=test")
-	tempSession, err := initConnection(":memory:")
+	sess, err := ephemeralSession()
 	if err != nil {
 		return nil, err
 	}
-	defer tempSession.Close()
-	return tempSession.QueryStreaming(queryStr, outputFormat)
+	defer sess.Close()
+	return sess.QueryStream(queryStr, outputFormat)
+}
+
+// ephemeralSession returns a short-lived session for the package-level one-shot
+// helpers. It reuses the already-open data path when a session exists (chDB
+// permits only one data path per process), and otherwise falls back to an
+// in-memory database.
+func ephemeralSession() (*Session, error) {
+	sessMu.Lock()
+	reuse := activeRefs > 0
+	sessMu.Unlock()
+	if reuse {
+		return NewSession()
+	}
+	sess, err := NewSession(":memory:")
+	if err != nil {
+		// A path-based session may have opened concurrently between the check
+		// and the connect; attach to whatever is now active.
+		return NewSession()
+	}
+	return sess, nil
 }
 
 func initConnection(connStr string) (result chdbpurego.ChdbConn, err error) {

--- a/chdb/wrapper.go
+++ b/chdb/wrapper.go
@@ -51,8 +51,18 @@ func ephemeralSession() (*Session, error) {
 	}
 	sess, err := NewSession(":memory:")
 	if err != nil {
-		// A path-based session may have opened concurrently between the check
-		// and the connect; attach to whatever is now active.
+		// The in-memory open may have lost a race with a path-based session
+		// opened concurrently between the check above and this connect (chDB
+		// allows only one data path per process). Only in that case retry by
+		// attaching to whatever path is now active; otherwise the failure is
+		// unrelated (e.g. a native connection error) and must be surfaced
+		// rather than masked by the retry.
+		sessMu.Lock()
+		conflict := activeRefs > 0
+		sessMu.Unlock()
+		if !conflict {
+			return nil, err
+		}
 		return NewSession()
 	}
 	return sess, nil

--- a/lowApi.md
+++ b/lowApi.md
@@ -53,9 +53,8 @@ Session will keep the state of query. If path is None, it will create a temporar
 
 Important:
 
-- There can be only one session at a time. If you want to create a new session, you need to close the existing one.
-- Creating a new session will close the existing one.
-- You need to ensure that the path exists before creating a new session. Or you can use NewConnectionFromConnString.
+- chDB supports only one data path per process. Multiple connections to the same path can be open at once and execute queries concurrently; connecting to a different path while connections are still open returns an error.
+- You need to ensure that the path exists before creating a new connection. Or you can use NewConnectionFromConnString.
 
 <a name="NewConnectionFromConnString"></a>
 ### func [NewConnectionFromConnString](<https://github.com/s0und0fs1lence/chdb-go/blob/main/chdb-purego/chdb.go#L269>)
@@ -88,8 +87,7 @@ Some special args handling:
 
 Important:
 
-- There can be only one session at a time. If you want to create a new session, you need to close the existing one.
-- Creating a new session will close the existing one.
+- chDB supports only one data path per process. Multiple connections to the same path can be open at once and execute queries concurrently; connecting to a different path while connections are still open returns an error.
 
 <a name="ChdbResult"></a>
 ## type [ChdbResult](<https://github.com/s0und0fs1lence/chdb-go/blob/main/chdb-purego/types.go#L39-L55>)


### PR DESCRIPTION
## Summary

chDB's engine (`EmbeddedServer`) already accepts multiple independent client connections that share one data path and run queries concurrently (the query path has no global lock). The only blocker was the Go layer, which forced a single connection. This PR removes that restriction.

- **`chdb/session.go`**: replace the `globalSession` singleton with a mutex-protected, path-keyed, refcounted registry. Each `Session` opens its own native connection, multiple sessions can be open at once on the same path, and a registry-owned temp dir is removed when the last session on it closes. Connect is serialized (it also guards the issue-#30 signal-handler dance); queries are not.
- **`chdb/driver/driver.go`**: the connector pins the data path via a "keeper" session and opens an independent native connection per pooled `database/sql` connection; `conn.Close()` closes it and `connector.Close()` (io.Closer) releases the keeper. `db.SetMaxOpenConns(N)` now yields N real parallel lanes.
- **`chdb/wrapper.go`**: package-level `Query`/`QueryStream` reuse the active data path, or use `:memory:` when none is open, so they no longer collide with an open file-path engine.
- Opening a **different** data path while one is open returns a clear error (chDB allows only one data path per process).
- Docs updated: README concurrency section + `SetMaxOpenConns` example, godoc, `lowApi.md`/`chdb.md`.

## Breaking / behavior changes

No source-level or signature breaks — all exported signatures are unchanged, so existing code compiles without modification, and the common single-session / single-`sql.DB` / explicit-path usage behaves the same. The following behavior changes are worth noting (roughly in order of impact):

1. **`NewSession()` is no longer a process-wide singleton.** Each call returns a distinct `*Session` with its own native connection (sessions on the same path share the underlying engine, so data is still shared), and every session must be closed. If you previously called `NewSession()` repeatedly relying on it returning the same singleton, cache the `*Session` yourself — otherwise you open (and leak) extra native connections.
2. **Opening a different data path concurrently now returns an error** instead of silently returning the first session and ignoring the requested path. Sequential use (close A, then open B) still works; for two different databases at once, use separate processes.
3. **Temp-dir cleanup is now refcounted, and the driver's `conn.Close()` actually closes its connection (previously a no-op).** A temp (empty-path) directory is removed when the last session on it closes, so a `sql.DB` opened with an empty/temp DSN now has its temp data removed on `db.Close()` (previously it leaked for the process lifetime). Use an explicit path for persistence.
4. **`chdb.Query` / `chdb.QueryStream` reuse an open session's data path** instead of always using `:memory:`. With no session open they still use `:memory:`.
5. **The default `database/sql` pool now opens multiple native connections under concurrency** (this is the point — real parallelism). Tune with `SetMaxOpenConns(N)`; existing `SetMaxOpenConns(1)` code keeps working.

`chdb-purego` has no behavior change (docs only).

## Test plan

- [x] `go test ./...` passes
- [x] `go test ./... -race` passes with no data races (already runs in CI)
- [x] `TestConcurrentParallelism` (driver): ~4x speedup (serial 2.0s -> parallel 0.5s)
- [x] `TestMultiConnectionStress` (purego): 4 conns / 16 goroutines, ~14k qps, 0 failures
- [x] `TestConcurrentQueries`, `TestConcurrentSessionsSamePath`, `TestSessionConflictingPath`

## Notes

- Single data path per process remains an engine constraint; for fully independent databases in one process you still need separate processes.
- No CI change needed: `-race` was already added to both jobs.