### PR TITLE
fix: use /v2 module path so v2 is consumable as a Go module (#39)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ### Install chdb-go
 1. Install `chdb-go`
-  - `go install github.com/chdb-io/chdb-go@latest`
+  - `go install github.com/chdb-io/chdb-go/v2@latest`
 2. Run `chdb-go` with or without persistent `--path`
   - run `$GOPATH/bin/chdb-go`
 
@@ -55,7 +55,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/chdb-io/chdb-go/chdb"
+	"github.com/chdb-io/chdb-go/v2/chdb"
 )
 
 func main() {
@@ -102,7 +102,7 @@ import (
         "database/sql"
         "log"
 
-        _ "github.com/chdb-io/chdb-go/chdb/driver"
+        _ "github.com/chdb-io/chdb-go/v2/chdb/driver"
 )
 
 func main() {

--- a/chdb.md
+++ b/chdb.md
@@ -3,7 +3,7 @@
 # chdb
 
 ```go
-import "github.com/chdb-io/chdb-go/chdb"
+import "github.com/chdb-io/chdb-go/v2/chdb"
 ```
 
 ## Index

--- a/chdb/doc.md
+++ b/chdb/doc.md
@@ -3,7 +3,7 @@
 # chdb
 
 ```go
-import "github.com/chdb-io/chdb-go/chdb"
+import "github.com/chdb-io/chdb-go/v2/chdb"
 ```
 
 ## Index

--- a/chdb/driver/driver.go
+++ b/chdb/driver/driver.go
@@ -10,8 +10,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/chdb-io/chdb-go/chdb"
-	chdbpurego "github.com/chdb-io/chdb-go/chdb-purego"
+	"github.com/chdb-io/chdb-go/v2/chdb"
+	chdbpurego "github.com/chdb-io/chdb-go/v2/chdb-purego"
 	"github.com/huandu/go-sqlbuilder"
 	"github.com/parquet-go/parquet-go"
 )

--- a/chdb/driver/driver_open_test.go
+++ b/chdb/driver/driver_open_test.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"testing"
 
-	"github.com/chdb-io/chdb-go/chdb"
+	"github.com/chdb-io/chdb-go/v2/chdb"
 )
 
 // TestDriverOpenNoKeeperLeak verifies that the legacy Driver.Open path does not

--- a/chdb/driver/driver_test.go
+++ b/chdb/driver/driver_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/chdb-io/chdb-go/chdb"
+	"github.com/chdb-io/chdb-go/v2/chdb"
 )
 
 var (

--- a/chdb/driver/parquet.go
+++ b/chdb/driver/parquet.go
@@ -9,7 +9,7 @@ import (
 
 	"reflect"
 
-	chdbpurego "github.com/chdb-io/chdb-go/chdb-purego"
+	chdbpurego "github.com/chdb-io/chdb-go/v2/chdb-purego"
 	"github.com/parquet-go/parquet-go"
 )
 

--- a/chdb/driver/parquet_rows_internal_test.go
+++ b/chdb/driver/parquet_rows_internal_test.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"testing"
 
-	chdbpurego "github.com/chdb-io/chdb-go/chdb-purego"
+	chdbpurego "github.com/chdb-io/chdb-go/v2/chdb-purego"
 	"github.com/parquet-go/parquet-go"
 )
 

--- a/chdb/driver/parquet_streaming.go
+++ b/chdb/driver/parquet_streaming.go
@@ -9,7 +9,7 @@ import (
 
 	"reflect"
 
-	chdbpurego "github.com/chdb-io/chdb-go/chdb-purego"
+	chdbpurego "github.com/chdb-io/chdb-go/v2/chdb-purego"
 	"github.com/parquet-go/parquet-go"
 )
 

--- a/chdb/session.go
+++ b/chdb/session.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"sync"
 
-	chdbpurego "github.com/chdb-io/chdb-go/chdb-purego"
+	chdbpurego "github.com/chdb-io/chdb-go/v2/chdb-purego"
 )
 
 // chDB embeds a single ClickHouse engine (EmbeddedServer) per process: the

--- a/chdb/wrapper.go
+++ b/chdb/wrapper.go
@@ -1,7 +1,7 @@
 package chdb
 
 import (
-	chdbpurego "github.com/chdb-io/chdb-go/chdb-purego"
+	chdbpurego "github.com/chdb-io/chdb-go/v2/chdb-purego"
 )
 
 // Query runs a one-shot query and returns the materialized result. Output

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/chdb-io/chdb-go
+module github.com/chdb-io/chdb-go/v2
 
 go 1.21
 

--- a/lowApi.md
+++ b/lowApi.md
@@ -3,7 +3,7 @@
 # chdbpurego
 
 ```go
-import "github.com/chdb-io/chdb-go/chdb-purego"
+import "github.com/chdb-io/chdb-go/v2/chdb-purego"
 ```
 
 ## Index

--- a/main.go
+++ b/main.go
@@ -7,11 +7,11 @@ import (
 
 	"github.com/c-bata/go-prompt"
 
-	// "github.com/chdb-io/chdb-go/cli"
-	// "github.com/chdb-io/chdb-go/cli/completer"
-	// "github.com/chdb-io/chdb-go/cli/history"
+	// "github.com/chdb-io/chdb-go/v2/cli"
+	// "github.com/chdb-io/chdb-go/v2/cli/completer"
+	// "github.com/chdb-io/chdb-go/v2/cli/history"
 
-	"github.com/chdb-io/chdb-go/chdb"
+	"github.com/chdb-io/chdb-go/v2/chdb"
 )
 
 func main() {


### PR DESCRIPTION
## Problem

Fixes #39.

The `v2.0.0` tag can't be consumed by the Go toolchain because its `go.mod` module path lacks the required major-version suffix:

```
$ go get github.com/chdb-io/chdb-go/v2@v2.0.0
go: ...: invalid version: go.mod has non-.../v2 module path "github.com/chdb-io/chdb-go" ...
```

Go's [semantic import versioning](https://go.dev/ref/mod#major-version-suffixes) requires that modules tagged `v2.0.0+` declare the major version in the module path (`github.com/chdb-io/chdb-go/v2`). Since `v0`/`v1` share the unsuffixed path, this never came up before the v2 bump.

## Changes

- `go.mod`: `module github.com/chdb-io/chdb-go` → `module github.com/chdb-io/chdb-go/v2`
- Rewrote all internal imports of `.../chdb` and `.../chdb-purego` to the `/v2` path
- Updated import examples in `README.md`, `chdb.md`, `chdb/doc.md`, `lowApi.md`
- Updated the `go install github.com/chdb-io/chdb-go/v2@latest` instruction
- Left genuine GitHub URLs (`/issues/`, `/blob/`, `/actions/`) untouched

## Verification

```
go build ./...   # OK
go vet ./...      # OK
go build -o chdb-go .   # CLI OK
```

## Follow-up (maintainer action)

This corrects the source, but the broken `v2.0.0` tag remains. After merging, please cut a new patch tag so consumers can depend on it:

```
git tag v2.0.1 && git push origin v2.0.1
```

Then `go get github.com/chdb-io/chdb-go/v2@v2.0.1` will work.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update module path to `github.com/chdb-io/chdb-go/v2` for Go semantic import versioning
> Updates [go.mod](https://github.com/chdb-io/chdb-go/pull/40/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6) module declaration and all internal import paths across the repository to use the `/v2` suffix, making the v2 release consumable as a proper Go module. Documentation and example snippets in README and API docs are also updated to reflect the new import paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7ad721c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->