### PR TITLE
Resolve libchdb reliably and verify each commit as a published module

### DIFF
--- a/.github/scripts/verify-as-user.sh
+++ b/.github/scripts/verify-as-user.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+#
+# Build this commit into a module archive the way the Go module proxy would,
+# then consume it from a throwaway module outside the repository — the same
+# steps a user runs after `go get`.
+#
+# Testing inside the repository proves less than it looks. It compiles working
+# tree files that may never have been committed, links against artifacts that
+# only exist on the build machine, and can pass while the archive users
+# actually download is missing a file or carries a path that exists nowhere
+# else. This script closes that gap:
+#
+#   * the archive is produced by `git archive`, so only committed content is in
+#     it — an untracked or ignored file that the build needs fails here;
+#   * the consumer module lives outside the repository and resolves everything
+#     through a file-backed module proxy, so nothing is picked up by accident;
+#   * the binary is built with -trimpath and then scanned for build-machine
+#     paths, so a leaked absolute path fails here rather than on a user's
+#     machine;
+#   * the engine is placed beside the built binary and no environment variable
+#     is set, so the default resolution order is what gets exercised.
+#
+# Usage: .github/scripts/verify-as-user.sh
+# Run from the repository root. Needs git, go, curl and tar.
+
+set -euo pipefail
+
+MODULE_PATH="github.com/chdb-io/chdb-go/v2"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# A version that is unique per commit. The module cache is keyed by
+# module@version, so reusing one string across differing archive contents
+# serves stale code and produces failures that look like compiler bugs.
+VERSION="v2.99.99-$(git rev-parse --short HEAD)"
+
+WORK="$(mktemp -d)"
+trap 'chmod -R u+w "$WORK" 2>/dev/null || true; rm -rf "$WORK"' EXIT
+
+PROXY="$WORK/proxy"
+CONSUMER="$WORK/consumer"
+mkdir -p "$PROXY/$MODULE_PATH/@v" "$CONSUMER"
+
+echo "==> Packaging $MODULE_PATH@$VERSION from committed content"
+git archive --format=zip --prefix="$MODULE_PATH@$VERSION/" HEAD \
+	-o "$PROXY/$MODULE_PATH/@v/$VERSION.zip"
+git show HEAD:go.mod >"$PROXY/$MODULE_PATH/@v/$VERSION.mod"
+printf '{"Version":"%s"}\n' "$VERSION" >"$PROXY/$MODULE_PATH/@v/$VERSION.info"
+echo "$VERSION" >"$PROXY/$MODULE_PATH/@v/list"
+
+# The engine is a release artifact, never part of the module. If it ever shows
+# up in the archive, the module has grown a few hundred megabytes by accident.
+if unzip -l "$PROXY/$MODULE_PATH/@v/$VERSION.zip" | grep -qE 'libchdb\.(so|dylib)'; then
+	echo "FAIL: the module archive contains a libchdb binary" >&2
+	exit 1
+fi
+
+echo "==> Writing a consumer module in $CONSUMER"
+cat >"$CONSUMER/go.mod" <<EOF
+module example.com/chdb-consumer
+
+go 1.21
+EOF
+
+cat >"$CONSUMER/main.go" <<'EOF'
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/chdb-io/chdb-go/v2/chdb"
+	chdbpurego "github.com/chdb-io/chdb-go/v2/chdb-purego"
+)
+
+func main() {
+	path, err := chdbpurego.LoadedLibraryPath()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "load failed:", err)
+		os.Exit(1)
+	}
+	fmt.Println("engine:", path)
+
+	res, err := chdb.Query("SELECT 41 + 1", "CSV")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "query failed:", err)
+		os.Exit(1)
+	}
+	fmt.Print("result: ", res.String())
+}
+EOF
+
+# The local proxy only carries this module; third-party dependencies fall
+# through to the next entry in the chain.
+export GOPROXY="file://$PROXY,${GOPROXY:-https://proxy.golang.org},direct"
+export GOSUMDB=off
+export GOFLAGS=-mod=mod
+
+echo "==> go get, as a user would"
+cd "$CONSUMER"
+go get "$MODULE_PATH@$VERSION"
+grep -q "$MODULE_PATH $VERSION" go.mod || {
+	echo "FAIL: go.mod does not reference the packaged version" >&2
+	cat go.mod >&2
+	exit 1
+}
+
+echo "==> go build -trimpath"
+go build -trimpath -o consumer .
+
+echo "==> Checking for build-machine paths in the binary"
+leaked=0
+for pattern in "$REPO_ROOT" "$CONSUMER" "$WORK" "${HOME:-/nonexistent-home}"; do
+	[ -n "$pattern" ] || continue
+	if grep -a -q -F -- "$pattern" consumer; then
+		echo "FAIL: binary embeds the build-machine path $pattern" >&2
+		leaked=1
+	fi
+done
+[ "$leaked" -eq 0 ] || exit 1
+
+echo "==> Placing the engine beside the binary and running with no env set"
+"$REPO_ROOT/update_libchdb.sh" >/dev/null
+ls libchdb.so >/dev/null
+
+output="$(env -u CHDB_LIB_PATH ./consumer)"
+echo "$output"
+
+case "$output" in
+*"engine: $CONSUMER/libchdb.so"* | *"engine: /private$CONSUMER/libchdb.so"*) ;;
+*)
+	echo "FAIL: the engine beside the binary was not the one resolved" >&2
+	exit 1
+	;;
+esac
+
+case "$output" in
+*"result: 42"*) ;;
+*)
+	echo "FAIL: query did not return 42" >&2
+	exit 1
+	;;
+esac
+
+echo "==> Checking the diagnostic when no engine can be found"
+mv libchdb.so engine-moved-away
+if env -u CHDB_LIB_PATH ./consumer >"$WORK/notfound.txt" 2>&1; then
+	echo "FAIL: loading succeeded with no engine present" >&2
+	exit 1
+fi
+cat "$WORK/notfound.txt"
+for want in "libchdb not found" "next to executable" "system path" "CHDB_LIB_PATH"; do
+	grep -q -- "$want" "$WORK/notfound.txt" || {
+		echo "FAIL: diagnostic does not mention $want" >&2
+		exit 1
+	}
+done
+
+echo "==> OK: this commit is usable as a published module"

--- a/.github/workflows/chdb.yml
+++ b/.github/workflows/chdb.yml
@@ -55,3 +55,20 @@ jobs:
     - name: Test main
       run: ./chdb-go "SELECT 12345"
 
+  # Building and testing inside the repository does not prove that what users
+  # download works. This job packages the commit the way the module proxy does
+  # and consumes it from outside the repository, which catches a build that
+  # needs an uncommitted file or that embeds a path from the build machine.
+  consume_as_published_module:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-14]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
+      with:
+        go-version: "1.21"
+    - name: Consume as a published module
+      run: .github/scripts/verify-as-user.sh

--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,6 @@ Temporary Items
 *.icloud
 
 # End of https://www.toptal.com/developers/gitignore/api/go,macos,linux,goland
+
+# Headers extracted by update_libchdb.sh alongside the library
+chdb.hpp

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: update_libchdb all test clean
+.PHONY: update_libchdb all test clean verify-as-user
 
 update_libchdb:
 	./update_libchdb.sh
@@ -6,8 +6,22 @@ update_libchdb:
 install:
 	curl -sL https://lib.chdb.io | bash
 
+# update_libchdb.sh drops the engine in the repository root, but test binaries
+# run from a temporary directory and so never look there. Point the loader at
+# that copy when it exists, so `make update_libchdb && make test` works without
+# a system-wide install.
 test:
-	go test -v -coverprofile=coverage.out ./...
+	@if [ -f "$(CURDIR)/libchdb.so" ] && [ -z "$$CHDB_LIB_PATH" ]; then \
+		echo "using $(CURDIR)/libchdb.so"; \
+		CHDB_LIB_PATH="$(CURDIR)/libchdb.so" go test -v -coverprofile=coverage.out ./...; \
+	else \
+		go test -v -coverprofile=coverage.out ./...; \
+	fi
+
+# Consume this commit the way a user does: package it as the module proxy
+# would, then go get and run it from outside the repository.
+verify-as-user:
+	./.github/scripts/verify-as-user.sh
 
 run:
 	go run main.go

--- a/README.md
+++ b/README.md
@@ -19,6 +19,27 @@
 2. Run `chdb-go` with or without persistent `--path`
   - run `$GOPATH/bin/chdb-go`
 
+### Where the engine is loaded from
+
+`chdb-go` opens `libchdb` at runtime. It is looked up in this order:
+
+1. `CHDB_LIB_PATH`, if set. This points at the library file itself, not a
+   directory. Setting it disables the rest of the search: if the file does not
+   load, that is the error, rather than a different copy of the engine being
+   used instead.
+2. The directory holding the running executable. Shipping your program and
+   `libchdb` side by side in one archive therefore works with nothing
+   installed and no environment variable set.
+3. `PATH`.
+4. `/usr/local/lib`, `/opt/homebrew/lib` and `/usr/lib`.
+
+When none of them yields a usable library, the error lists every location that
+was tried and why each one failed.
+
+`chdbpurego.LoadedLibraryPath()` returns the absolute path of the library the
+process is actually using, which is worth logging at startup if you ship
+`libchdb` yourself.
+
 ### or Build from source
 1. Build `chdb-go`
   - run `make build`

--- a/chdb-purego/binding.go
+++ b/chdb-purego/binding.go
@@ -1,8 +1,7 @@
 package chdbpurego
 
 import (
-	"os"
-	"os/exec"
+	"sync"
 	"syscall"
 	"unsafe"
 
@@ -72,33 +71,6 @@ func restoreSignalHandlers(saved [][sigactionBufSize]byte) {
 	}
 }
 
-func findLibrary() string {
-	// Env var
-	if envPath := os.Getenv("CHDB_LIB_PATH"); envPath != "" {
-		return envPath
-	}
-
-	// ldconfig with Linux
-	if path, err := exec.LookPath("libchdb.so"); err == nil {
-		return path
-	}
-
-	// default path
-	commonPaths := []string{
-		"/usr/local/lib/libchdb.so",
-		"/opt/homebrew/lib/libchdb.dylib",
-	}
-
-	for _, p := range commonPaths {
-		if _, err := os.Stat(p); err == nil {
-			return p
-		}
-	}
-
-	//should be an error ?
-	return "libchdb.so"
-}
-
 var (
 	// old API
 	queryStable            func(argc int, argv []string) *local_result
@@ -139,12 +111,46 @@ var (
 	chdbResetSignalHandlers      func()
 )
 
-func init() {
-	path := findLibrary()
-	libchdb, err := purego.Dlopen(path, purego.RTLD_NOW|purego.RTLD_GLOBAL)
-	if err != nil {
-		panic(err)
+var (
+	loadOnce   sync.Once
+	loadedPath string
+	loadErr    error
+)
+
+// ensureLoaded resolves and loads libchdb, binding its symbols, at most once
+// per process. Every entry point that needs the engine calls this first.
+//
+// Loading deliberately does not happen in init(). A program that imports this
+// package but never opens a connection should not pay for it, and a panic
+// during package initialisation gives the caller nowhere to handle a missing
+// engine — the process is dead before main runs.
+func ensureLoaded() error {
+	loadOnce.Do(func() {
+		handle, path, err := openLibrary()
+		if err != nil {
+			loadErr = err
+			return
+		}
+		loadedPath = path
+		bindSymbols(handle)
+	})
+	return loadErr
+}
+
+// LoadedLibraryPath returns the absolute path of the libchdb this process
+// loaded, loading it if that has not happened yet.
+//
+// It exists so a caller — or a build-verification job checking that a binary
+// resolves the engine it was meant to — can report the file actually in use
+// instead of inferring it from the search order.
+func LoadedLibraryPath() (string, error) {
+	if err := ensureLoaded(); err != nil {
+		return "", err
 	}
+	return loadedPath, nil
+}
+
+func bindSymbols(libchdb uintptr) {
 	purego.RegisterLibFunc(&queryStable, libchdb, "query_stable")
 	purego.RegisterLibFunc(&freeResult, libchdb, "free_result")
 	purego.RegisterLibFunc(&queryStableV2, libchdb, "query_stable_v2")

--- a/chdb-purego/chdb.go
+++ b/chdb-purego/chdb.go
@@ -192,6 +192,10 @@ func (c *connection) Ready() bool {
 //     to a different path while connections are still open returns an error.
 //   - You need to ensure that the path exists before creating a new connection. Or you can use NewConnectionFromConnString.
 func NewConnection(argc int, argv []string) (ChdbConn, error) {
+	if err := ensureLoaded(); err != nil {
+		return nil, err
+	}
+
 	var new_argv []string
 	if (argc > 0 && argv[0] != "clickhouse") || argc == 0 {
 		new_argv = make([]string, argc+1)

--- a/chdb-purego/loader.go
+++ b/chdb-purego/loader.go
@@ -1,0 +1,157 @@
+package chdbpurego
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/ebitengine/purego"
+)
+
+// LibPathEnv names the environment variable that points directly at a libchdb
+// file. When it is set, it is the only location considered.
+const LibPathEnv = "CHDB_LIB_PATH"
+
+// libFileNames lists the file names libchdb is published under, in the order
+// they should be tried.
+//
+// The macOS release archive names the file libchdb.so even though it is a
+// Mach-O dynamic library, so on darwin both spellings have to be tried; a
+// Homebrew install uses libchdb.dylib.
+func libFileNames() []string {
+	if runtime.GOOS == "darwin" {
+		return []string{"libchdb.so", "libchdb.dylib"}
+	}
+	return []string{"libchdb.so"}
+}
+
+// attempt records one location that was considered and what came of it.
+type attempt struct {
+	origin string // where the path came from, for the error message
+	path   string
+	err    error // nil once a candidate loaded successfully
+}
+
+// notFoundError reports every location that was tried, so a failed load can be
+// diagnosed without rebuilding with extra logging.
+type notFoundError struct {
+	attempts []attempt
+}
+
+func (e *notFoundError) Error() string {
+	var b strings.Builder
+	b.WriteString("chdb: libchdb not found\n\ntried:\n")
+	for _, a := range e.attempts {
+		reason := "ok"
+		if a.err != nil {
+			reason = trimDlopenNoise(a.err.Error())
+		}
+		fmt.Fprintf(&b, "  %-22s %-44s %s\n", a.origin, a.path, reason)
+	}
+	b.WriteString("\nfix one of:\n")
+	fmt.Fprintf(&b, "  install the library system-wide:  curl -sL https://lib.chdb.io | bash\n")
+	fmt.Fprintf(&b, "  place libchdb next to the executable\n")
+	fmt.Fprintf(&b, "  point %s at an existing copy\n", LibPathEnv)
+	return b.String()
+}
+
+// trimDlopenNoise shortens dyld's multi-path "tried:" list down to the first
+// concrete reason. Without this the error text repeats every probe path the
+// dynamic loader walked, which buries the useful part.
+func trimDlopenNoise(msg string) string {
+	if i := strings.Index(msg, "): tried: "); i >= 0 {
+		msg = msg[i+len("): tried: "):]
+	}
+	if i := strings.Index(msg, "), "); i >= 0 {
+		msg = msg[:i+1]
+	}
+	msg = strings.TrimSpace(strings.ReplaceAll(msg, "\n", " "))
+	if len(msg) > 120 {
+		msg = msg[:120] + "..."
+	}
+	return msg
+}
+
+// searchPaths returns the candidate locations, in priority order, for the case
+// where CHDB_LIB_PATH is not set.
+//
+// The executable's own directory comes before any system location so that a
+// release archive containing both the program and libchdb works without
+// installing anything, and so that a program shipping a known-good library is
+// never silently overridden by an unrelated copy in /usr/local/lib.
+func searchPaths() []attempt {
+	var out []attempt
+	names := libFileNames()
+
+	if exe, err := os.Executable(); err == nil {
+		if exe, err = filepath.EvalSymlinks(exe); err == nil {
+			dir := filepath.Dir(exe)
+			for _, n := range names {
+				out = append(out, attempt{origin: "next to executable", path: filepath.Join(dir, n)})
+			}
+		}
+	}
+
+	// Kept for compatibility with installs that put libchdb on PATH. Note this
+	// finds the file only if it carries the executable bit, which is why
+	// update_libchdb.sh chmod +x's a shared library.
+	for _, n := range names {
+		if p, err := exec.LookPath(n); err == nil {
+			if abs, err := filepath.Abs(p); err == nil {
+				out = append(out, attempt{origin: "PATH", path: abs})
+			}
+		}
+	}
+
+	for _, dir := range []string{"/usr/local/lib", "/opt/homebrew/lib", "/usr/lib"} {
+		for _, n := range names {
+			out = append(out, attempt{origin: "system path", path: filepath.Join(dir, n)})
+		}
+	}
+	return out
+}
+
+// openLibrary loads libchdb and returns its handle and the absolute path it was
+// loaded from.
+//
+// Two rules shape this function. Every path handed to the dynamic loader is
+// absolute, because a program built with the macOS hardened runtime rejects
+// relative library paths outright and reports it as a path error rather than a
+// permissions one. And a location that was named explicitly is never silently
+// replaced by a different one: if CHDB_LIB_PATH is set and does not load, that
+// is the error, because loading some other build of the engine instead is far
+// harder to diagnose than failing.
+func openLibrary() (uintptr, string, error) {
+	if raw := os.Getenv(LibPathEnv); raw != "" {
+		abs, err := filepath.Abs(raw)
+		if err != nil {
+			return 0, "", fmt.Errorf("chdb: %s=%q cannot be resolved to an absolute path: %w", LibPathEnv, raw, err)
+		}
+		h, err := purego.Dlopen(abs, purego.RTLD_NOW|purego.RTLD_GLOBAL)
+		if err != nil {
+			return 0, "", fmt.Errorf(
+				"chdb: %s=%q could not be loaded: %s\n\n%s is an explicit override, so no other location was tried. Unset it to use the default search",
+				LibPathEnv, abs, trimDlopenNoise(err.Error()), LibPathEnv)
+		}
+		return h, abs, nil
+	}
+
+	candidates := searchPaths()
+	for i := range candidates {
+		c := &candidates[i]
+		if _, err := os.Stat(c.path); err != nil {
+			c.err = fmt.Errorf("no such file")
+			continue
+		}
+		h, err := purego.Dlopen(c.path, purego.RTLD_NOW|purego.RTLD_GLOBAL)
+		if err != nil {
+			c.err = err
+			continue
+		}
+		return h, c.path, nil
+	}
+	return 0, "", &notFoundError{attempts: candidates}
+}

--- a/chdb-purego/loader_test.go
+++ b/chdb-purego/loader_test.go
@@ -1,0 +1,180 @@
+package chdbpurego
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestMain fails the whole package with the loader's diagnostic instead of
+// letting individual tests skip on a confusing precondition. A test run that
+// cannot load the engine is a broken environment, not a skipped feature.
+func TestMain(m *testing.M) {
+	if os.Getenv("CHDB_LOADER_CHILD") == "" {
+		if err := ensureLoaded(); err != nil {
+			os.Stderr.WriteString(err.Error() + "\n")
+			os.Exit(1)
+		}
+	}
+	os.Exit(m.Run())
+}
+
+func TestLibFileNamesCoversPublishedNaming(t *testing.T) {
+	names := libFileNames()
+	if len(names) == 0 {
+		t.Fatal("no candidate file names")
+	}
+	// The macOS release archive ships the Mach-O library named libchdb.so, so
+	// darwin must try that name and not only the .dylib spelling a Homebrew
+	// install uses. Getting this wrong makes a correctly placed library
+	// invisible.
+	if !contains(names, "libchdb.so") {
+		t.Errorf("libchdb.so missing from candidates %v", names)
+	}
+	if runtime.GOOS == "darwin" && !contains(names, "libchdb.dylib") {
+		t.Errorf("libchdb.dylib missing from darwin candidates %v", names)
+	}
+}
+
+func TestSearchPathsPrefersExecutableDirectory(t *testing.T) {
+	paths := searchPaths()
+	if len(paths) == 0 {
+		t.Fatal("no search paths")
+	}
+
+	firstExeDir, firstSystem := -1, -1
+	for i, p := range paths {
+		if p.origin == "next to executable" && firstExeDir < 0 {
+			firstExeDir = i
+		}
+		if p.origin == "system path" && firstSystem < 0 {
+			firstSystem = i
+		}
+	}
+	if firstExeDir < 0 {
+		t.Fatal("executable directory is never searched")
+	}
+	if firstSystem < 0 {
+		t.Fatal("system paths are never searched")
+	}
+	// A program shipping a known-good engine beside itself must not be
+	// silently overridden by an unrelated copy in /usr/local/lib.
+	if firstExeDir > firstSystem {
+		t.Errorf("executable directory (%d) searched after system paths (%d)", firstExeDir, firstSystem)
+	}
+}
+
+func TestSearchPathsAreAbsolute(t *testing.T) {
+	// A binary built with the macOS hardened runtime refuses relative library
+	// paths and reports it as a path error, which sends debugging in the wrong
+	// direction. Every candidate must therefore already be absolute.
+	for _, p := range searchPaths() {
+		if !filepath.IsAbs(p.path) {
+			t.Errorf("%s candidate is not absolute: %q", p.origin, p.path)
+		}
+	}
+}
+
+func TestNotFoundErrorListsEveryAttemptAndAFix(t *testing.T) {
+	err := &notFoundError{attempts: []attempt{
+		{origin: "next to executable", path: "/app/libchdb.so", err: errString("no such file")},
+		{origin: "system path", path: "/usr/local/lib/libchdb.so", err: errString("no such file")},
+	}}
+	msg := err.Error()
+
+	for _, want := range []string{"/app/libchdb.so", "/usr/local/lib/libchdb.so", "no such file", LibPathEnv} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error text is missing %q:\n%s", want, msg)
+		}
+	}
+}
+
+func TestTrimDlopenNoiseKeepsFirstConcreteReason(t *testing.T) {
+	// dyld reports every probe path it walked, which buries the real reason.
+	raw := `dlopen(/c/libchdb.so, 0x0006): tried: '/c/libchdb.so' (no such file), ` +
+		`'/System/Volumes/Preboot/Cryptexes/OS/c/libchdb.so' (no such file)`
+	got := trimDlopenNoise(raw)
+	if !strings.Contains(got, "no such file") {
+		t.Errorf("reason lost: %q", got)
+	}
+	if strings.Contains(got, "Cryptexes") {
+		t.Errorf("probe-path noise kept: %q", got)
+	}
+}
+
+// TestLibPathEnvOverrideIsTerminal checks that an explicit CHDB_LIB_PATH which
+// cannot be loaded produces an error naming that variable, rather than quietly
+// loading some other copy of the engine. Loading happens once per process, so
+// this runs in a child process with the environment set.
+func TestLibPathEnvOverrideIsTerminal(t *testing.T) {
+	if os.Getenv("CHDB_LOADER_CHILD") == "1" {
+		_, err := NewConnectionFromConnString(":memory:")
+		if err == nil {
+			os.Stderr.WriteString("connected despite a bogus " + LibPathEnv + "\n")
+			os.Exit(3)
+		}
+		os.Stderr.WriteString(err.Error())
+		os.Exit(4)
+	}
+
+	bogus := filepath.Join(t.TempDir(), "not-a-library.so")
+	if err := os.WriteFile(bogus, []byte("this is not a shared library"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestLibPathEnvOverrideIsTerminal", "-test.v")
+	cmd.Env = append(os.Environ(), "CHDB_LOADER_CHILD=1", LibPathEnv+"="+bogus)
+	out, err := cmd.CombinedOutput()
+
+	exit := 0
+	if ee, ok := err.(*exec.ExitError); ok {
+		exit = ee.ExitCode()
+	}
+	if exit == 3 {
+		t.Fatalf("a bogus %s did not prevent loading:\n%s", LibPathEnv, out)
+	}
+	if exit != 4 {
+		t.Fatalf("child exited %d, want 4:\n%s", exit, out)
+	}
+
+	msg := string(out)
+	if !strings.Contains(msg, LibPathEnv) {
+		t.Errorf("error does not name %s:\n%s", LibPathEnv, msg)
+	}
+	// The whole point of the override being terminal: no other location may
+	// appear in the diagnostic, because none was tried.
+	if strings.Contains(msg, "/usr/local/lib") {
+		t.Errorf("fell back to the default search despite an explicit override:\n%s", msg)
+	}
+}
+
+// TestLoadedLibraryPathIsReportable is what a build-verification job uses to
+// confirm which engine a binary resolved.
+func TestLoadedLibraryPathIsReportable(t *testing.T) {
+	path, err := LoadedLibraryPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !filepath.IsAbs(path) {
+		t.Errorf("reported path is not absolute: %q", path)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("reported path does not exist: %v", err)
+	}
+}
+
+type errString string
+
+func (e errString) Error() string { return string(e) }
+
+func contains(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
`libchdb` resolution had four ways to fail without saying why. This fixes them
and adds a CI job that consumes each commit the way users do.

## Loader

Returning the bare string `libchdb.so` when nothing was found handed the name
to the dynamic loader instead of reporting an error, so a missing engine looked
like an unrelated `dlopen` failure with no record of where the binding had
looked. It now returns an error listing every location tried and why each one
failed.

The executable's own directory was never considered, so shipping a program
together with `libchdb` — the obvious way to distribute without touching
`/usr/local/lib` — did not work. It is now searched ahead of system paths, so a
program carrying a known-good engine is not silently overridden by an unrelated
copy.

Paths were passed through as given. A binary built with the macOS hardened
runtime rejects relative library paths and reports it as a path error, which
sends debugging in the wrong direction. Every candidate is now absolute.

On darwin only `libchdb.dylib` was looked for in the Homebrew location, while
the published macOS archive names the Mach-O library `libchdb.so`. Both names
are tried.

`CHDB_LIB_PATH` is now terminal: if it is set and does not load, that is the
error. Silently using a different build of the engine instead is much harder to
diagnose than failing.

Loading also moves out of `init()`. Panicking during package initialisation
leaves a caller no way to handle a missing engine, and a program that imports
the package without opening a connection should not pay for the load.
`chdbpurego.LoadedLibraryPath()` reports which file a process resolved.

## CI

Both existing jobs build and test inside the repository against a
system-installed engine. That can pass while what users download is broken: the
working tree may hold files that were never committed, and a binary can embed
paths that exist only on the build machine.

`consume_as_published_module` packages `HEAD` with `git archive`, serves it
through a file-backed module proxy, then `go get`s and builds it from a
throwaway module outside the repository. It scans the `-trimpath` binary for
build-machine paths, places the engine beside the binary and runs with no
environment variable set so the default resolution order is exercised, and
asserts the engine-not-found diagnostic names what it tried. It also fails if
the module archive ever contains a `libchdb` binary.

`make test` now points the loader at the repository-local engine when one is
present, so `make update_libchdb && make test` works without a system-wide
install — test binaries run from a temporary directory and never looked there.

First step toward chdb-io/chdb-go#41. It does not bundle the engine yet.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resolve libchdb reliably with ordered search paths and verify each commit as a published Go module
> - Replaces the ad-hoc `findLibrary` function in [binding.go](https://github.com/chdb-io/chdb-go/pull/42/files#diff-39c1715812186930de4f3267ad8502254a00b69ef0ca0b3524e91c09829665e9) with a new [loader.go](https://github.com/chdb-io/chdb-go/pull/42/files#diff-7b957b5fdf14a72ad21ff030ee9874b2adb4f36c00a0b4cbbe23bf75f21ba513) that searches in order: `CHDB_LIB_PATH` (terminal override), next to the executable, `PATH`, then system library dirs (`/usr/local/lib`, `/opt/homebrew/lib`, `/usr/lib`).
> - Library loading is now lazy (via `sync.Once`) instead of running at `init()` time; `LoadedLibraryPath()` returns the absolute path of the loaded library.
> - On failure, the loader reports every attempted path with a trimmed reason and actionable fix suggestions; `NewConnection` fails early with this diagnostic if the engine cannot be loaded.
> - Adds [verify-as-user.sh](https://github.com/chdb-io/chdb-go/pull/42/files#diff-ae5d40dfb674da3b131677bf67ab2c2dbba4ad9a8eb82867861dcf41f1e03c35) and a CI job in [chdb.yml](https://github.com/chdb-io/chdb-go/pull/42/files#diff-ed59e722ada75c8c12541f659772e0b64658bb1c53f40a10fc8fce78ce6fe41e) that packages the current commit as a Go module proxy archive and verifies it can be consumed externally on `ubuntu-latest` and `macos-14`.
> - Behavioral Change: `make test` now automatically sets `CHDB_LIB_PATH` to `./libchdb.so` when that file exists and the variable is not already set.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 7ef08ef. 8 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->