### PR TITLE
Do not cancel a stream the engine has already finished

### DIFF
--- a/chdb-purego/streaming.go
+++ b/chdb-purego/streaming.go
@@ -6,6 +6,9 @@ type streamingResult struct {
 	curConn  *chdb_connection
 	stream   *chdb_result
 	curChunk ChdbResult
+	// Set once the engine has signalled end of data, so Free() knows there is
+	// nothing left to cancel. See the comment there.
+	finished bool
 }
 
 func newStreamingResult(conn *chdb_connection, cRes *chdb_result) ChdbStreamResult {
@@ -37,7 +40,20 @@ func (c *streamingResult) Error() error {
 // Free implements ChdbStreamResult.
 func (c *streamingResult) Free() {
 	if c.curConn != nil && c.stream != nil {
-		chdbStreamCancelQuery(c.curConn, c.stream)
+		// Cancel only while the engine still has a stream to stop. Once it has
+		// signalled end of data it has retired the query's state, and cancelling a
+		// retired stream walks into it: chdb_stream_cancel_query takes the handle as
+		// an opaque pointer and casts it without checking, so there is nothing on
+		// the engine side to turn that into an error instead of a fault. Against
+		// chdb-core v26.7.0 it segfaults on linux/amd64, and survives on arm64 only
+		// because the freed memory happens to still read back the way it did.
+		//
+		// Destroying is still correct and still required — the engine's own note on
+		// cancel says the handle is released by chdb_destroy_query_result, not by
+		// cancel — so only the cancel is conditional.
+		if !c.finished {
+			chdbStreamCancelQuery(c.curConn, c.stream)
+		}
 		chdbDestroyQueryResult(c.stream)
 	}
 
@@ -55,21 +71,21 @@ func (c *streamingResult) Cancel() {
 
 // GetNext implements ChdbStreamResult.
 func (c *streamingResult) GetNext() ChdbResult {
-	if c.curChunk == nil {
-		nextChunk := chdbStreamFetchResult(c.curConn.internal_data, c.stream)
-		if nextChunk == nil {
-			return nil
-		}
-		c.curChunk = newChdbResult(nextChunk)
-		return c.curChunk
+	if c.curChunk != nil {
+		// free the current chunk before getting the next one
+		c.curChunk.Free()
+		c.curChunk = nil
 	}
-	// free the current chunk before getting the next one
-	c.curChunk.Free()
-	c.curChunk = nil
 	nextChunk := chdbStreamFetchResult(c.curConn.internal_data, c.stream)
 	if nextChunk == nil {
+		c.finished = true
 		return nil
 	}
 	c.curChunk = newChdbResult(nextChunk)
+	// A chunk with no rows is how the engine says the stream is done; callers
+	// treat it as EOF and stop reading, so this is the last chunk there will be.
+	if c.curChunk.RowsRead() == 0 {
+		c.finished = true
+	}
 	return c.curChunk
 }


### PR DESCRIPTION
Closes #46.

The engine release check found this on its first run: the driver's parquet
streaming tests segfault against chdb-core v26.7.0. Deterministic on
linux/amd64 — two runs, same frame — while linux/arm64 and darwin/arm64 pass with
the same engine and the same Go version.

```
parquetStreamingRows.Close
  → streamingResult.Free
  → chdb_stream_cancel_query     SIGSEGV
```

`Free()` cancelled unconditionally, because this type never recorded whether the
stream had ended. Cancelling is meaningful only while the engine still has work to
stop; once it has signalled end of data it has retired the query's state, and the
cancel walks into it. `chdb_stream_cancel_query` takes the handle as an opaque
pointer and `reinterpret_cast`s it with no validity check, so nothing on the engine
side can turn that into an error rather than a fault.

The C entry point is byte-identical between v26.5.0 and v26.7.0. What changed is
underneath: `ChdbClient.cpp` went from 482 to 1029 lines and reworked streaming
teardown, with its own new comments about avoiding use-after-free and about marking
a stream finalized "so a handle that outlives this connection becomes inert". That
guard was added for insert streams; query streams still take a raw pointer. **The
call was always wrong — it only stopped being survivable.** Which is also why arm64
passes: freed memory that still reads back the way it did is not a correctness
result.

End of data has two spellings — a nil fetch, and a chunk with no rows, which is
what callers already treat as EOF — and `GetNext` records both. Destroying is
untouched and still unconditional: the engine's own note on cancel says the handle
is released by `chdb_destroy_query_result`, not by cancel.

The duplicated fetch in `GetNext` is folded into one path while here; the two
branches differed only in freeing the previous chunk first.

## Verified where it actually failed

Neither local platform reproduces the crash — arm64 never faulted, including under
Go 1.21 in a Linux container. So the fix was dispatched to CI against the
architecture that did:

```
gh workflow run engine-release-check.yml --ref fix/no-cancel-on-finished-stream \
  -f engine_version=v26.7.0
```

`test (ubuntu-latest)` passes. Suites also pass locally against v26.7.0 and against
the pinned v26.5.0.

chdb-io/chdb-core#180 is the other half: the C ABI honours the `stream_exhausted`
flag it already checks on the fetch path, so cancel-after-EOF stops being a fault
for every binding rather than just this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `streamingResult.Free` to skip canceling an already-finished stream
> - Adds a `finished` boolean to `streamingResult` in [streaming.go](https://github.com/chdb-io/chdb-go/pull/49/files#diff-a6fa5083f9593ed80aa04576b6c8b2f8b24eac42e0dc5ee565f950f560c819ee) that is set when the engine signals end-of-data.
> - `Free()` now skips `chdbStreamCancelQuery` when `finished` is true, but still calls `chdbDestroyQueryResult`.
> - `GetNext()` sets `finished` when the engine returns no chunk or a zero-row chunk; zero-row chunks are still returned to the caller.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2192fdb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->