### PR TITLE
Judge the race step by what the detector found

### DIFF
--- a/.github/scripts/race-test.sh
+++ b/.github/scripts/race-test.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# The race detector's findings decide this step, not the exit status.
+#
+# libchdb starts process-global ClickHouse thread pools and offers no way to stop
+# them: the v26.7.0 C ABI has 50 functions and none of them shuts the engine down,
+# so ~33 engine threads are still parked on condvars when the test binary exits.
+# Under -race, Go's exit path runs racefini -> __tsan_fini, which tears the
+# sanitizer runtime down while those threads can still wake and run instrumented
+# code. One faults; because it is a C thread, Go's badsignal re-raises and the
+# process dies with a segfault after every test has already reported PASS.
+#
+# Established from a core dump: the crashing thread's stack is
+# runtime.raise <- raisebadsignal <- badsignal <- sigtrampgo, __tsan_fini and
+# __run_exit_handlers are on the stack, and 33 threads sit in
+# __pthread_cond_wait_common inside libchdb. Waiting before exit does not help —
+# measured 5/48, 3/48, 7/48, 3/48 crashes for waits of none, 500ms, 2s and 5s,
+# because BackgroundSchedulePool re-arms its tasks on a timer and never quiesces.
+#
+# So: run the race detector and fail on what it is for — a reported data race, a
+# failing test, a panic — and do not fail on that one segfault. Nothing about the
+# detector's coverage changes; only the way this step reads its own result.
+#
+# Remove this wrapper once the engine can be shut down (chdb-core needs either a
+# chdb_shutdown() for callers or an atexit that stops the pools). Then the plain
+# exit status is trustworthy again.
+set -uo pipefail
+
+LOG=$(mktemp)
+go test -race -timeout=180s ./... 2>&1 | tee "$LOG"
+status=${PIPESTATUS[0]}
+
+if grep -q "DATA RACE" "$LOG"; then
+    echo "::error::the race detector reported a data race"
+    exit 1
+fi
+if grep -qE "^--- FAIL|^\s+--- FAIL" "$LOG"; then
+    echo "::error::a test failed under the race detector"
+    exit 1
+fi
+if grep -qE "^panic:|^fatal error:" "$LOG"; then
+    echo "::error::the test binary panicked under the race detector"
+    exit 1
+fi
+
+if [ "$status" -ne 0 ]; then
+    if grep -q "signal: segmentation fault" "$LOG"; then
+        echo "::warning::tests passed; the binary segfaulted at exit, which is the" \
+             "known libchdb thread-shutdown issue and not a test result"
+        exit 0
+    fi
+    echo "::error::race step failed for a reason this wrapper does not recognise" \
+         "(exit $status, no data race, no failing test, no panic)"
+    exit "$status"
+fi

--- a/.github/scripts/race-test.sh
+++ b/.github/scripts/race-test.sh
@@ -42,13 +42,28 @@ if grep -qE "^panic:|^fatal error:" "$LOG"; then
     exit 1
 fi
 
+# A fault the Go runtime handled itself, i.e. one that hit a thread it owns while
+# a test was running. It prints its own header and a goroutine dump; the exit-time
+# crash never does, because there the signal lands on a libchdb thread and Go's
+# badsignal path re-raises without a dump. The distinction is what keeps the
+# exemption below from covering a crash during a test — a real one landed here
+# once already, chdb-io/chdb-go#46.
+if grep -qE "^(SIGSEGV|SIGBUS|SIGFPE|SIGILL|SIGABRT|SIGTRAP):" "$LOG"; then
+    echo "::error::the runtime reported a fatal signal during a test, not at exit"
+    exit 1
+fi
+
 if [ "$status" -ne 0 ]; then
-    if grep -q "signal: segmentation fault" "$LOG"; then
+    # Positive evidence, not just the presence of the word: the package has to have
+    # reported PASS and then died on the very next line. "Contains a segfault
+    # somewhere" would exempt far more than the one crash this is about.
+    if grep -A1 '^PASS$' "$LOG" | grep -q '^signal: segmentation fault'; then
         echo "::warning::tests passed; the binary segfaulted at exit, which is the" \
              "known libchdb thread-shutdown issue and not a test result"
         exit 0
     fi
     echo "::error::race step failed for a reason this wrapper does not recognise" \
-         "(exit $status, no data race, no failing test, no panic)"
+         "(exit $status; no data race, failing test, panic, or in-test signal, and" \
+         "no PASS immediately followed by a segfault)"
     exit "$status"
 fi

--- a/.github/workflows/chdb.yml
+++ b/.github/workflows/chdb.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Test
       run: make test
     - name: Test with race detector
-      run: go test -race -timeout=180s ./...
+      run: ./.github/scripts/race-test.sh
     - name: Test main
       run: ./chdb-go "SELECT 12345"
 
@@ -51,7 +51,7 @@ jobs:
     - name: Test
       run: make test
     - name: Test with race detector
-      run: go test -race -timeout=180s ./...
+      run: ./.github/scripts/race-test.sh
     - name: Test main
       run: ./chdb-go "SELECT 12345"
 


### PR DESCRIPTION
main has been red since #45 on one step, and not for anything in this repository.
`go test -race` reports every test as PASS and then the process segfaults on the way
out, so the step fails on an exit status that says nothing about the tests.

## What the core dump says

```
#0  runtime.raise
#1  runtime.raisebadsignal (sig=11)
#2  runtime.badsignal (sig=11)
#3  runtime.sigtrampgo
#4  runtime.sigtramp
```

`runtime.badsignal` is Go's path for a signal on a thread it does not own — a C
thread. `__tsan_fini` and `__run_exit_handlers` are on the stack, and **33 threads
are parked in `__pthread_cond_wait_common` inside libchdb**.

So the engine's process-global ClickHouse pools are still alive at exit, because
nothing can stop them: v26.7.0's C ABI has 50 functions and none shuts the engine
down. Under `-race`, Go's exit path runs `racefini` → `__tsan_fini`, tearing the
sanitizer runtime down while those threads can still wake into instrumented code.
One faults, Go re-raises because it is not a Go thread, and the binary dies after
every test has passed.

This is why it only happens under `-race`: without it, the same leaked threads are
killed by `exit_group` and nobody notices.

## Waiting does not fix it

Worth measuring rather than assuming. Crashes over 48 runs, six in parallel:

| wait before exit | crashes |
| --- | --- |
| none | 5 |
| 500ms | 3 |
| 2s | 7 |
| 5s | 3 |

No trend. `BackgroundSchedulePool` re-arms its tasks on a timer, so the threads
never go quiet — a longer wait just picks a different moment to gamble on. (Those
counts are non-zero exits, which at six-way parallelism include some genuine
contention failures, so they overstate the segfault rate. The absence of a trend is
the point.)

## What changes

The step fails on what the race detector is for: a reported data race, a failing
test, a panic. A segfault at exit with nothing else wrong passes, with a warning.

Coverage is unchanged — this is only how the step reads its own result — and it is
not a blanket exemption. A run that segfaults *and* fails a test still fails.

## Verified

In a Linux container and on macOS, against a build that reproduces the crash:

- ordinary pass → 0
- hits the exit segfault → 0, and says so
- hits it *while also failing a test* → 1
- injected data race → 1
- injected failing test → 1
- injected panic → 1

## When to remove this

Once the engine can be shut down. chdb-core has the machinery already —
`GlobalThreadPool::shutdown()` in `src/Common/ThreadPool.h` — and no C entry point
calls or exposes it. Then the plain exit status is trustworthy and this wrapper
should go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Judge the race detector test step by inspecting output rather than exit status
> - Adds [race-test.sh](.github/scripts/race-test.sh), a wrapper around `go test -race` that parses output to determine pass/fail instead of relying on the raw exit code.
> - Fails the step on data races, test failures, panics, or fatal in-test signals; passes (with a warning) on a post-PASS exit-time segfault matching `PASS` immediately followed by `signal: segmentation fault`.
> - Updates [chdb.yml](.github/workflows/chdb.yml) to call the new script in both Linux and macOS race test steps.
> - Behavioral Change: a specific exit-time segfault that previously failed the CI step now exits with status 0 and emits a `::warning::` instead of a `::error::`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 12cb828.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->