### PR TITLE
Move the engine pin to v26.7.0

### DIFF
--- a/update_libchdb.sh
+++ b/update_libchdb.sh
@@ -5,7 +5,7 @@
 # it too, so both ways of fetching libchdb land on the same build. Keep it on
 # its own line and literal: the release check greps for it when it proposes a
 # bump, and the Makefile cuts the value out of it.
-CHDB_ENGINE_PIN=v26.5.0
+CHDB_ENGINE_PIN=v26.7.0
 
 # CHDB_ENGINE_VERSION overrides the pin, which is how the release check runs the
 # suite against an engine this repository has not adopted yet.


### PR DESCRIPTION
The release check ran the suite against v26.7.0 and found two things this pin was
waiting on. Both are in main now.

- #49 stopped cancelling a stream the engine had already finished, which segfaulted
  deterministically on linux/amd64 under v26.7.0. Verified by dispatching the check
  at the fix branch and watching the architecture that faulted go green.
- #50 stopped the race step failing on the engine's exit-time crash. Unrelated to
  this bump, but it was keeping main red and would have kept this red too.

With those in, the check against v26.7.0 passes. The pin is what the regular jobs
and `make install` build against, so this is the change that actually adopts it.

Full suite passes locally against v26.7.0. CI runs it on both platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update engine pin to v26.7.0 in `update_libchdb.sh`
> Updates `CHDB_ENGINE_PIN` from `v26.5.0` to `v26.7.0` in [update_libchdb.sh](https://github.com/chdb-io/chdb-go/pull/51/files#diff-6f35e23173ec48cae47760551bfa867846783d6a777bcf30354d7dd8e2e11ecb).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa5eb94.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->