### PR TITLE
Check an engine module tag when it is pushed, and document how modules are published

### DIFF
--- a/.github/workflows/engine-module-tag.yml
+++ b/.github/workflows/engine-module-tag.yml
@@ -19,12 +19,22 @@ name: Engine module tag
 on:
   push:
     tags: ['lib/**']
+  # A push carrying more than three tags creates no event at all — not a partial
+  # one — and a release is four platform tags. package-engine.sh prints one push
+  # per tag for that reason, but an instruction is not a guarantee, and this check
+  # is worthless if the one release that skips it is the one that was wrong. So
+  # every published tag is re-checked on a schedule regardless of how it arrived,
+  # including tags that predate this workflow.
+  schedule:
+    - cron: '17 * * * *'
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
   tag_names_its_engine:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -33,3 +43,42 @@ jobs:
           go-version: "1.21"
       - name: The tag has to name the engine the module was built from
         run: go run ./scripts/enginetag -verify "${{ github.ref_name }}"
+
+  every_published_tag:
+    if: github.event_name != 'push'
+    runs-on: ubuntu-latest
+    steps:
+      # blob:none because the tags carry the engine payloads: a full clone would
+      # pull every version ever published to read one small generated file from
+      # each. The blobs actually needed are fetched on demand below.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          filter: blob:none
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.21"
+      - name: Every lib/* tag has to name the engine its module was built from
+        run: |
+          set -uo pipefail
+
+          tags=$(git tag --list 'lib/*')
+          if [ -z "$tags" ]; then
+            echo "no engine module tags published yet"
+            exit 0
+          fi
+
+          failed=0
+          for tag in $tags; do
+            moddir=${tag%/*}
+            # The metadata as it is at that tag, not as it is on the default
+            # branch, which carries placeholders.
+            if ! git checkout -q "$tag" -- "$moddir/engine_data.go" 2>/dev/null; then
+              echo "::error::$tag has no $moddir/engine_data.go"
+              failed=1
+              continue
+            fi
+            go run ./scripts/enginetag -verify "$tag" || failed=1
+            git checkout -q HEAD -- "$moddir/engine_data.go"
+          done
+          exit "$failed"

--- a/.github/workflows/engine-module-tag.yml
+++ b/.github/workflows/engine-module-tag.yml
@@ -1,0 +1,35 @@
+name: Engine module tag
+
+# Publishing a platform engine module is one command: push a lib/<platform>/vX tag.
+# There is no build to fail and no registry to reject it — the module proxy simply
+# serves whatever that tag points at, forever, and will not serve different bytes
+# for it afterwards. A tag that names the wrong engine cannot be corrected, only
+# superseded by a version that no longer means what it says.
+#
+# verify-embedded-engine.sh already checks any lib/* tag sitting on the commit, but
+# a CI checkout carries no tags, so in practice that check only ever runs on the
+# machine doing the publishing — which is the machine that just typed the tag. This
+# runs on the push itself, so the tag is checked whether or not whoever pushed it
+# ran anything locally.
+#
+# It cannot refuse the push. What it can do is fail loudly within a minute, while
+# deleting and re-pushing the tag is still cheap: the proxy caches on first fetch,
+# so a wrong tag nobody has fetched yet can still be taken back.
+
+on:
+  push:
+    tags: ['lib/**']
+
+permissions:
+  contents: read
+
+jobs:
+  tag_names_its_engine:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.21"
+      - name: The tag has to name the engine the module was built from
+        run: go run ./scripts/enginetag -verify "${{ github.ref_name }}"

--- a/README.md
+++ b/README.md
@@ -23,15 +23,18 @@
 
 `chdb-go` opens `libchdb` at runtime. It is looked up in this order:
 
-1. `CHDB_LIB_PATH`, if set. This points at the library file itself, not a
-   directory. Setting it disables the rest of the search: if the file does not
-   load, that is the error, rather than a different copy of the engine being
-   used instead.
-2. The directory holding the running executable. Shipping your program and
-   `libchdb` side by side in one archive therefore works with nothing
-   installed and no environment variable set.
-3. `PATH`.
-4. `/usr/local/lib`, `/opt/homebrew/lib` and `/usr/lib`.
+1. An engine compiled into the binary, if the build imports one of the
+   [engine modules](#engine-modules). Nothing below is tried.
+2. `CHDB_LIB_PATH`, if set — the library file, not a directory. Setting it
+   disables the rest of the search, so a copy that does not load is an error
+   rather than a reason to use a different one.
+3. The directory holding the running executable.
+4. `PATH`.
+5. `/usr/local/lib`, `/opt/homebrew/lib` and `/usr/lib`.
+6. The directories in `LD_LIBRARY_PATH`, `DYLD_LIBRARY_PATH` and
+   `DYLD_FALLBACK_LIBRARY_PATH`.
+7. The dynamic loader, by name — this is what reaches an `ldconfig`-registered
+   install, `/usr/lib/<triple>` on a multiarch distribution, or a `RUNPATH`.
 
 When none of them yields a usable library, the error lists every location that
 was tried and why each one failed.
@@ -45,6 +48,73 @@ process is actually using, which is worth logging at startup if you ship
   - run `make build`
 2. Run `chdb-go` with or without persistent `--path`
   - run `./chdb-go`
+
+## Engine modules
+
+`lib/<platform>` are four Go modules, one per platform, each carrying a compressed
+`libchdb`. Importing one makes the engine part of the build: on first run it is
+extracted to a cache directory named after its digest, and reused after that.
+
+```go
+import (
+    chdbpurego "github.com/chdb-io/chdb-go/v2/chdb-purego"
+    engine "github.com/chdb-io/chdb-go/lib/linux-amd64"
+)
+
+func init() {
+    chdbpurego.RegisterEmbeddedEngine(chdbpurego.EmbeddedEngine{
+        Version:  engine.Version,
+        FileName: engine.FileName,
+        Digest:   engine.Digest,
+        Size:     engine.Size,
+        Open:     engine.Open,
+    })
+}
+```
+
+`CHDB_CACHE_DIR` chooses where it is extracted, defaulting to the user cache
+directory and then the temporary directory. It must be a directory no other user
+can write to or substitute, or extraction refuses it.
+
+### Versioning
+
+A module version names the chdb-core release its engine came from, then counts
+packagings of that same engine:
+
+| chdb-core release | packaging | module version |
+| --- | --- | --- |
+| `v26.7.0` | first | `v0.260700.1` |
+| `v26.7.0` | second | `v0.260700.2` |
+| `v26.7.2-rc.1` | first | `v0.260702.0-rc.1.1` |
+
+The engine goes in the minor field with a major of zero because Go requires a
+`/vN` path suffix from major 2 up, and the engine's major is 26. The counter
+starts at 1 and rises when the module's own code changes but the engine has not.
+This is the same scheme chdb-node publishes `@chdb/lib-<platform>` under
+(`26.7.0-stable.1`, `26.7.2-rc.1.1`).
+
+Candidates sort below every release of the same engine, so
+`go get lib/<platform>@latest` never picks one:
+
+```
+v0.260700.1  <  v0.260702.0-rc.1.1  <  v0.260702.0-rc.2.1  <  v0.260702.1
+```
+
+### Publishing
+
+```
+scripts/package-engine.sh v26.7.0                    # every platform
+CHDB_PACKAGING=2 scripts/package-engine.sh v26.7.0   # repackage the same engine
+```
+
+The script prints the exact `git tag` commands. Use those — the module proxy
+serves a tag's bytes permanently, so a wrong tag can only be superseded, never
+fixed. `internal/enginetag` defines the rule, `go run ./scripts/enginetag -verify
+lib/<platform>/<version>` checks a tag against the module it names, and CI runs
+that check on every `lib/**` tag pushed.
+
+Payloads are added with `git add -f` at publish time and are not on the default
+branch, so a clone does not carry every engine version ever shipped.
 
 ## chdb-go CLI
 

--- a/scripts/package-engine.sh
+++ b/scripts/package-engine.sh
@@ -190,6 +190,13 @@ cat <<EOF
       git add -f${platform_paths}
       git commit -m "Package chdb-core $TAG"
 $(for platform in "${PLATFORMS[@]}"; do echo "      git tag lib/$platform/$MODULE_VERSION"; done)
+$(for platform in "${PLATFORMS[@]}"; do echo "      git push origin lib/$platform/$MODULE_VERSION"; done)
+
+    One push per tag, and not 'git push --tags'. GitHub creates no event at all
+    when more than three tags arrive in a single push, and there are four here —
+    so a single push would publish all four without .github/workflows/
+    engine-module-tag.yml ever running on any of them. Pushed one at a time, each
+    is checked. A scheduled sweep re-checks every published tag in any case.
 
     $MODULE_VERSION says which engine is inside and which packaging of it this
     is, the way chdb-node's @chdb/lib-<platform> subpackages do. It cannot be the


### PR DESCRIPTION
Follow-up to #52. Two things it left: the tag check only ever ran on the
publisher's own machine, and the README said nothing about any of this.

## The check now runs on the push

Publishing a platform engine module is one command — push a `lib/<platform>/vX`
tag. There is no build to fail and no registry to reject it: the proxy serves
whatever that tag points at, forever, and will not serve different bytes for it
later. A tag naming the wrong engine cannot be corrected, only superseded by a
version that no longer means what it says.

`verify-embedded-engine.sh` already checks any `lib/*` tag sitting on the commit,
and in practice never gets the chance: a CI checkout carries no tags, so that
check only runs on the machine that just typed the tag. A workflow on
`push: tags: ['lib/**']` now runs `enginetag -verify` on the tag itself.

It cannot refuse the push. It fails within a minute, while taking the tag back is
still cheap — the proxy caches on first fetch, so a tag nobody has fetched yet can
still be deleted.

Exercised locally against real generated metadata:

| tag | verdict |
| --- | --- |
| `lib/darwin-arm64/v0.260700.1` | passes — engine v26.7.0, packaging 1 |
| `lib/darwin-arm64/v0.260701.0-rc.1.1` | fails — names v26.7.1-rc.1, module was built from v26.7.0 |
| `lib/linux-amd64/v0.260700.1` | fails — that module still carries placeholder metadata |

## README

The engine modules landed with no user-facing explanation. Added: what importing
`lib/<platform>` does, `CHDB_CACHE_DIR` and why the cache directory has to be
private, the mapping from a chdb-core release to a module version, why the engine
is encoded into the minor field rather than used as the version, why a candidate
sorts below every release of the same engine, and how to publish one.

| chdb-core release | packaging | module version |
| --- | --- | --- |
| `v26.7.0` | first | `v0.260700.1` |
| `v26.7.0` | second | `v0.260700.2` |
| `v26.7.2-rc.1` | first | `v0.260702.0-rc.1.1` |

Every claim in that section was checked against the real tools rather than
written from memory — the table against `scripts/enginetag`, and the ordering
chain `v0.260700.1 < v0.260702.0-rc.1.1 < v0.260702.0-rc.2.1 < v0.260702.1`
against `golang.org/x/mod/semver`.

The load order was also stale: it predated the embedded engine, and predated the
loader-path environment variables and the by-name fallback being restored in #52,
so it listed four locations where there are now seven and did not mention that a
carried engine skips the search entirely.

cc @auxten @wudidapaopao


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add CI workflow to verify engine module tags when pushed and document module publishing
> - Adds [engine-module-tag.yml](.github/workflows/engine-module-tag.yml), a GitHub Actions workflow that runs `go run ./scripts/enginetag -verify` on any tag pushed matching `lib/**`, and a scheduled hourly sweep that re-verifies all existing `lib/*` tags.
> - Updates [scripts/package-engine.sh](scripts/package-engine.sh) to print per-platform `git push origin lib/<platform>/$MODULE_VERSION` commands and explains why tags must be pushed individually (GitHub ignores bulk pushes of more than three tags).
> - Expands [README.md](README.md) with a new "Engine modules" section covering usage, caching via `CHDB_CACHE_DIR`, versioning scheme, and publishing instructions including the CI verification requirement.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b31579b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->