### PR TITLE
Put CHDB_LIB_PATH above the carried engine, where the code has it

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,38 @@
 
 ## Install
 
-### Install libchdb.so
-1. Install [`libchdb`](https://github.com/chdb-io/chdb/releases)
-  - curl -sL https://lib.chdb.io | bash
+The engine can either come from the machine or from the build. Both are supported;
+which one you want depends on whether you would rather install something or carry
+it.
 
-### Install chdb-go
-1. Install `chdb-go`
-  - `go install github.com/chdb-io/chdb-go/v2@latest`
-2. Run `chdb-go` with or without persistent `--path`
-  - run `$GOPATH/bin/chdb-go`
+### From the machine
+
+Install `libchdb` once, then use `chdb-go` against it:
+
+```
+curl -sL https://lib.chdb.io | bash
+go get github.com/chdb-io/chdb-go/v2
+```
+
+The engine is looked up at runtime — see [where the engine is loaded
+from](#where-the-engine-is-loaded-from). Upgrading `chdb-go` does not upgrade the
+engine, so re-run the installer, or `update_libchdb.sh`, to move both together.
+
+### From the build
+
+Import an [engine module](#engine-modules) and nothing needs installing: the engine
+travels inside the binary and is extracted to a cache directory on first run. This
+is what you want for a self-contained binary, a `FROM scratch` image, or anywhere
+you cannot ask for an install step.
+
+### The CLI
+
+```
+go install github.com/chdb-io/chdb-go/v2@latest
+$GOPATH/bin/chdb-go            # with or without a persistent --path
+```
+
+The CLI resolves the engine the same way, so it needs one installed on the machine.
 
 ### Where the engine is loaded from
 
@@ -77,29 +100,31 @@ func init() {
 directory and then the temporary directory. It must be a directory no other user
 can write to or substitute, or extraction refuses it.
 
-### Versioning
+### Reading the version
 
-A module version names the chdb-core release its engine came from, then counts
-packagings of that same engine:
+The middle field is the chdb-core release, six digits, two per field. The last is
+which packaging of that same engine this is, counting from 1.
 
-| chdb-core release | packaging | module version |
+```
+v0.260700.1
+   ▲▲▲▲▲▲ ▲
+   26 07 00 — chdb-core v26.7.0, on the ClickHouse 26.7 line
+            1 — first packaging of it
+```
+
+| module version | chdb-core release | ClickHouse line |
 | --- | --- | --- |
-| `v26.7.0` | first | `v0.260700.1` |
-| `v26.7.0` | second | `v0.260700.2` |
-| `v26.7.2-rc.1` | first | `v0.260702.0-rc.1.1` |
+| `v0.260700.1` | `v26.7.0` | 26.7 |
+| `v0.260700.2` | `v26.7.0`, repackaged | 26.7 |
+| `v0.260702.0-rc.1.1` | `v26.7.2-rc.1` | 26.7 |
 
-The engine goes in the minor field with a major of zero because Go requires a
-`/vN` path suffix from major 2 up, and the engine's major is 26. The counter
-starts at 1 and rises when the module's own code changes but the engine has not.
-This is the same scheme chdb-node publishes `@chdb/lib-<platform>` under
-(`26.7.0-stable.1`, `26.7.2-rc.1.1`).
+The first two fields of a chdb-core release are the ClickHouse line it carries; its
+third is chdb-core's own counter, so `v26.7.0` is some ClickHouse 26.7 and not a
+ClickHouse 26.7.0. `chdbpurego.EmbeddedEngineVersion()` returns the chdb-core
+release at runtime, and `SELECT version()` returns the exact ClickHouse build.
 
 Candidates sort below every release of the same engine, so
-`go get lib/<platform>@latest` never picks one:
-
-```
-v0.260700.1  <  v0.260702.0-rc.1.1  <  v0.260702.0-rc.2.1  <  v0.260702.1
-```
+`go get lib/<platform>@latest` never picks one.
 
 ### Publishing
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,12 @@
 
 `chdb-go` opens `libchdb` at runtime. It is looked up in this order:
 
-1. An engine compiled into the binary, if the build imports one of the
-   [engine modules](#engine-modules). Nothing below is tried.
-2. `CHDB_LIB_PATH`, if set — the library file, not a directory. Setting it
+1. `CHDB_LIB_PATH`, if set — the library file, not a directory. Setting it
    disables the rest of the search, so a copy that does not load is an error
-   rather than a reason to use a different one.
+   rather than a reason to use a different one. It outranks a carried engine,
+   which is how a build that has one can still be pointed at another.
+2. An engine compiled into the binary, if the build imports one of the
+   [engine modules](#engine-modules). Nothing below is tried.
 3. The directory holding the running executable.
 4. `PATH`.
 5. `/usr/local/lib`, `/opt/homebrew/lib` and `/usr/lib`.

--- a/chdb-purego/loader.go
+++ b/chdb-purego/loader.go
@@ -187,11 +187,11 @@ func openLibrary() (uintptr, string, error) {
 		return h, abs, nil
 	}
 
-	// A build carrying its own engine does not consult the machine at all. That
-	// is the point of embedding it: the version is decided when the binary is
-	// built, and quietly preferring some other copy found on the host would
-	// undo that guarantee in a way nobody would notice until the behaviour
-	// differed.
+	// Past the explicit override above, a build carrying its own engine does not
+	// consult the machine at all. That is the point of embedding it: the version
+	// is decided when the binary is built, and quietly preferring some other copy
+	// found on the host would undo that guarantee in a way nobody would notice
+	// until the behaviour differed.
 	if e := registeredEngine(); e != nil {
 		return openEmbedded(e, dlopenLibrary)
 	}


### PR DESCRIPTION
The README had the first two entries of the load order the wrong way round: it
listed a carried engine first and `CHDB_LIB_PATH` second. The code checks
`CHDB_LIB_PATH` before it looks for a registered engine.

Following the README, a reader would conclude that a build carrying its own engine
cannot be pointed at another one — when that is exactly what the override is for,
and what someone with a specific engine build needs.

## Verified by running it, not by reading it again

Reading it is how the order got written down backwards, so this time a probe binary
registered an embedded engine and reported which library it actually loaded:

```
nothing set        →  <cache>/701623a8546c053cac74fa4e363c6df6/libchdb.so   (the carried engine)
CHDB_LIB_PATH set  →  /tmp/chdblib/libchdb.so                              (the override wins)
```

The remaining five entries were checked the same way, by printing the origins
`searchPaths()` produces in order:

```
1. next to executable
2. PATH
3. system path
4. LD_LIBRARY_PATH
5. dynamic loader
```

which matches entries 3–7 as documented. `PATH` only contributes a candidate when a
`libchdb` carrying the executable bit is actually on it — it takes a populated
`PATH` to see it at all, which is worth knowing before concluding the entry is
missing.

The comment above the embedded-engine branch in `loader.go` gains a clause for the
same reason: "a build carrying its own engine does not consult the machine at all"
reads as though it outranks the override too, and that is what misled me into
writing the README backwards.

cc @auxten @wudidapaopao


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Correct comment order in `openLibrary` to match `CHDB_LIB_PATH` precedence over embedded engine
> Fixes a misleading comment in [loader.go](https://github.com/chdb-io/chdb-go/pull/56/files#diff-7b957b5fdf14a72ad21ff030ee9874b2adb4f36c00a0b4cbbe23bf75f21ba513) that implied the embedded engine was checked before `CHDB_LIB_PATH`. No code logic changed — only the comment is moved to accurately reflect that `CHDB_LIB_PATH` is honored first. The [README.md](https://github.com/chdb-io/chdb-go/pull/56/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) is also updated to document engine resolution order, CLI usage, and version semantics.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 513b4a5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->