### PR TITLE
Let one blank import carry the engine

### DIFF
--- a/.github/scripts/verify-embedded-engine.sh
+++ b/.github/scripts/verify-embedded-engine.sh
@@ -59,10 +59,27 @@ echo "==> Cross-compiling every platform module"
 # are pure Go, so building them for another platform costs seconds. GOWORK=off
 # because each module must build on its own, from its own go.mod.
 for dir in lib/*/; do
-	platform="$(basename "$dir")"
-	echo "    $platform"
-	(cd "$dir" && GOWORK=off GOOS="${platform%%-*}" GOARCH="${platform##*-}" go build ./...)
+	name="$(basename "$dir")"
+	case "$name" in
+	*-*) ;;
+	# lib/embedded is not a platform: its name carries no GOOS-GOARCH to build
+	# for, and it covers all four through build tags. Built separately below.
+	*)
+		continue
+		;;
+	esac
+	echo "    $name"
+	(cd "$dir" && GOWORK=off GOOS="${name%%-*}" GOARCH="${name##*-}" go build ./...)
 done
+
+# The dispatch module, once per platform it dispatches to, plus one it does not:
+# on an uncovered platform it must still build and simply register nothing.
+if [ -d lib/embedded ]; then
+	echo "    embedded"
+	for pair in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64; do
+		(cd lib/embedded && GOWORK=off GOOS="${pair%/*}" GOARCH="${pair#*/}" go build ./...)
+	done
+fi
 
 # Compression ratio is a property of a release, not of the machinery this script
 # checks: the level changes neither the extracted library nor its digest, and the

--- a/README.md
+++ b/README.md
@@ -76,8 +76,24 @@ process is actually using, which is worth logging at startup if you ship
 ## Engine modules
 
 `lib/<platform>` are four Go modules, one per platform, each carrying a compressed
-`libchdb`. Importing one makes the engine part of the build: on first run it is
-extracted to a cache directory named after its digest, and reused after that.
+`libchdb`. Bringing one into the build makes the engine part of it: on first run
+the engine is extracted to a cache directory named after its digest, and reused
+after that.
+
+One blank import does it, with no platform in the path and no engine version in
+your `go.mod`:
+
+```go
+import _ "github.com/chdb-io/chdb-go/lib/embedded"
+```
+
+`lib/embedded` is a dispatch module: its `go.mod` names the four platform modules
+and which version of each, and the build takes the one that matches. On a platform
+none of them covers it registers nothing and the build still succeeds, leaving the
+engine to be looked up on the machine as usual.
+
+Import a platform module directly instead when you want to choose the engine
+version yourself:
 
 ```go
 import (

--- a/README.md
+++ b/README.md
@@ -28,10 +28,16 @@ engine, so re-run the installer, or `update_libchdb.sh`, to move both together.
 
 ### From the build
 
-Import an [engine module](#engine-modules) and nothing needs installing: the engine
-travels inside the binary and is extracted to a cache directory on first run. This
-is what you want for a self-contained binary, a `FROM scratch` image, or anywhere
-you cannot ask for an install step.
+One blank import and nothing needs installing — the engine travels inside the binary
+and is extracted to a cache directory on first run:
+
+```go
+import _ "github.com/chdb-io/chdb-go/lib/embedded"
+```
+
+This is what you want for a self-contained binary, a `FROM scratch` image, or
+anywhere you cannot ask for an install step. See [engine
+modules](#engine-modules).
 
 ### The CLI
 

--- a/lib/embedded/darwin-amd64.go
+++ b/lib/embedded/darwin-amd64.go
@@ -1,0 +1,18 @@
+//go:build darwin && amd64
+
+package embedded
+
+import (
+	chdbpurego "github.com/chdb-io/chdb-go/v2/chdb-purego"
+	engine "github.com/chdb-io/chdb-go/lib/darwin-amd64"
+)
+
+func init() {
+	chdbpurego.RegisterEmbeddedEngine(chdbpurego.EmbeddedEngine{
+		Version:  engine.Version,
+		FileName: engine.FileName,
+		Digest:   engine.Digest,
+		Size:     engine.Size,
+		Open:     engine.Open,
+	})
+}

--- a/lib/embedded/darwin-arm64.go
+++ b/lib/embedded/darwin-arm64.go
@@ -1,0 +1,18 @@
+//go:build darwin && arm64
+
+package embedded
+
+import (
+	chdbpurego "github.com/chdb-io/chdb-go/v2/chdb-purego"
+	engine "github.com/chdb-io/chdb-go/lib/darwin-arm64"
+)
+
+func init() {
+	chdbpurego.RegisterEmbeddedEngine(chdbpurego.EmbeddedEngine{
+		Version:  engine.Version,
+		FileName: engine.FileName,
+		Digest:   engine.Digest,
+		Size:     engine.Size,
+		Open:     engine.Open,
+	})
+}

--- a/lib/embedded/doc.go
+++ b/lib/embedded/doc.go
@@ -1,0 +1,18 @@
+// Package embedded registers the libchdb build for the platform being compiled,
+// so a program needs nothing installed on the machine it runs on:
+//
+//	import _ "github.com/chdb-io/chdb-go/lib/embedded"
+//
+// That is the whole API. One blank import, with no platform in the path and no
+// engine version in your go.mod — this module's go.mod names the four
+// lib/<platform> modules and which version of each, and the build takes the one
+// that matches. Import a lib/<platform> module directly instead if you want to
+// pick the engine version yourself.
+//
+// CHDB_LIB_PATH still wins when it is set, so a build carrying an engine can be
+// pointed at a different one without rebuilding. Otherwise the engine is extracted
+// to a cache directory on first run and reused after that.
+//
+// On a platform none of the four modules covers, nothing is registered and the
+// build still succeeds; the engine is then looked up on the machine as usual.
+package embedded

--- a/lib/embedded/go.mod
+++ b/lib/embedded/go.mod
@@ -1,0 +1,17 @@
+module github.com/chdb-io/chdb-go/lib/embedded
+
+go 1.21
+
+require (
+	github.com/chdb-io/chdb-go/lib/darwin-amd64 v0.260700.1
+	github.com/chdb-io/chdb-go/lib/darwin-arm64 v0.260700.1
+	github.com/chdb-io/chdb-go/lib/linux-amd64 v0.260700.1
+	github.com/chdb-io/chdb-go/lib/linux-arm64 v0.260700.1
+	github.com/chdb-io/chdb-go/v2 v2.1.0
+)
+
+require (
+	github.com/ebitengine/purego v0.8.2 // indirect
+	github.com/klauspost/compress v1.17.9 // indirect
+	golang.org/x/sys v0.22.0 // indirect
+)

--- a/lib/embedded/go.sum
+++ b/lib/embedded/go.sum
@@ -1,0 +1,16 @@
+github.com/chdb-io/chdb-go/lib/darwin-amd64 v0.260700.1 h1:QiXQ1vZWcQCbRpciirWG/+F3KRXYnDLiFOVYkAJxCls=
+github.com/chdb-io/chdb-go/lib/darwin-amd64 v0.260700.1/go.mod h1:jB7U0oct7fDV+SbrDzh3oorQFAQ8YOM5QFXf273ZEEs=
+github.com/chdb-io/chdb-go/lib/darwin-arm64 v0.260700.1 h1:qvkIS/fozvgJfd30MEPM1nVDSM1JMXQgqZfqp1Oh7aQ=
+github.com/chdb-io/chdb-go/lib/darwin-arm64 v0.260700.1/go.mod h1:tebe6DiYx113PoHD0WjWCWVY74QDmaPcCdWA+aNpWPM=
+github.com/chdb-io/chdb-go/lib/linux-amd64 v0.260700.1 h1:w1q1whc7LlBpJtzoMkokgnSsdRrFLAG2kgRkb1tQ7jM=
+github.com/chdb-io/chdb-go/lib/linux-amd64 v0.260700.1/go.mod h1:LK3ORN5rYtQDUYKswMZKf09RT1qIdwlCGk/3/vB7aHE=
+github.com/chdb-io/chdb-go/lib/linux-arm64 v0.260700.1 h1:GoviqHKnVOJIfnfgiSYWiEqxciThy2XGmSHUdq1qvmI=
+github.com/chdb-io/chdb-go/lib/linux-arm64 v0.260700.1/go.mod h1:vkAVOjzg+j6TwFWobfxvmU+pV8fD7dS9ibBdZc3Wf8Y=
+github.com/chdb-io/chdb-go/v2 v2.1.0 h1:Nf/StmYfE90mePp0EzdWqCbqUv/TJUbVOrnea/x3PN0=
+github.com/chdb-io/chdb-go/v2 v2.1.0/go.mod h1:tyiHoF8pWUfrD7ylseofFEnELnA+jocf/yElE3AHBaQ=
+github.com/ebitengine/purego v0.8.2 h1:jPPGWs2sZ1UgOSgD2bClL0MJIqu58nOmIcBuXr62z1I=
+github.com/ebitengine/purego v0.8.2/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
+github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
+golang.org/x/sys v0.22.0 h1:RI27ohtqKCnwULzJLqkv897zojh5/DwS/ENaMzUOaWI=
+golang.org/x/sys v0.22.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/lib/embedded/linux-amd64.go
+++ b/lib/embedded/linux-amd64.go
@@ -1,0 +1,18 @@
+//go:build linux && amd64
+
+package embedded
+
+import (
+	chdbpurego "github.com/chdb-io/chdb-go/v2/chdb-purego"
+	engine "github.com/chdb-io/chdb-go/lib/linux-amd64"
+)
+
+func init() {
+	chdbpurego.RegisterEmbeddedEngine(chdbpurego.EmbeddedEngine{
+		Version:  engine.Version,
+		FileName: engine.FileName,
+		Digest:   engine.Digest,
+		Size:     engine.Size,
+		Open:     engine.Open,
+	})
+}

--- a/lib/embedded/linux-arm64.go
+++ b/lib/embedded/linux-arm64.go
@@ -1,0 +1,18 @@
+//go:build linux && arm64
+
+package embedded
+
+import (
+	chdbpurego "github.com/chdb-io/chdb-go/v2/chdb-purego"
+	engine "github.com/chdb-io/chdb-go/lib/linux-arm64"
+)
+
+func init() {
+	chdbpurego.RegisterEmbeddedEngine(chdbpurego.EmbeddedEngine{
+		Version:  engine.Version,
+		FileName: engine.FileName,
+		Digest:   engine.Digest,
+		Size:     engine.Size,
+		Open:     engine.Open,
+	})
+}


### PR DESCRIPTION
Using a carried engine meant three things a caller should not have to know to say
"bring the engine along": naming a platform module in your own imports, writing an
`init()` to register it, and holding the engine version in your own `go.mod`.

```go
import _ "github.com/chdb-io/chdb-go/lib/embedded"
```

`lib/embedded` is a dispatch module — four files behind build tags, each pulling in
the matching platform module and registering it. Its `go.mod` holds the four
versions, so a consumer's `go.mod` names no platform and pins no engine:

```
require (
	github.com/chdb-io/chdb-go/lib/embedded v0.260700.1
	github.com/chdb-io/chdb-go/v2 v2.1.0
)
require (
	github.com/chdb-io/chdb-go/lib/darwin-amd64 v0.260700.1 // indirect
	github.com/chdb-io/chdb-go/lib/darwin-arm64 v0.260700.1 // indirect
	github.com/chdb-io/chdb-go/lib/linux-amd64 v0.260700.1  // indirect
	github.com/chdb-io/chdb-go/lib/linux-arm64 v0.260700.1  // indirect
)
```

Importing a platform module directly still works, and is still how to choose an
engine version yourself. The README shows both.

## Why its own module

A package inside `chdb-go/v2` would put the four platform requirements in the main
module's `go.mod`, where every consumer would carry them whether or not they want an
engine. As a separate module, a build that does not import it has no trace of one.

## One fix it forced

`verify-embedded-engine.sh` iterates `lib/*/` and derives `GOOS`/`GOARCH` from the
directory name — and `embedded` yields neither, so it would have tried
`GOOS=embedded`. Names without a dash are now skipped there, and the dispatch module
is built separately for each platform it covers plus one it does not: on an
uncovered platform it has to compile and simply register nothing.

## Verified against the published modules

Not a `replace` directive — `lib/embedded` was served through a proxy exactly as it
would be after tagging, resolving `chdb-go/v2@v2.1.0` and the four
`lib/<platform>@v0.260700.1` from the real one:

```
cold start                 engine: v26.7.0
                           loaded: <cache>/701623a8546c053cac74fa4e363c6df6/libchdb.so
                           result: "26.7.2.1",42
with CHDB_LIB_PATH set     loaded: /tmp/chdblib/libchdb.so        ← override still wins
```

Cross-compiles for `linux/{amd64,arm64}`, `darwin/{amd64,arm64}`, and — registering
nothing — `windows/amd64` and `linux/386`.

## After this merges

`lib/embedded` needs its own tag to be usable. `v0.260700.1` matches the engine it
wires up, so it reads the same way as the platform modules.

cc @auxten @wudidapaopao


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `lib/embedded` dispatch module to register the chdb engine via a single blank import
> - Adds a new `lib/embedded` Go module with per-platform files ([linux-amd64.go](https://github.com/chdb-io/chdb-go/pull/57/files#diff-bf29d7c5143617da0ca9994270263ee77213f346eb8e5a1f38f74da5d7cb8fdb), [linux-arm64.go](https://github.com/chdb-io/chdb-go/pull/57/files#diff-08e4e047d98734b7741aa06b1b959cd4bc5189b617eea76bb5849ac2c6913f73), [darwin-amd64.go](https://github.com/chdb-io/chdb-go/pull/57/files#diff-56a89ce55ae14a29301ff953203da44bab43e7ac0efa45c4d7308d89fc9667a6), [darwin-arm64.go](https://github.com/chdb-io/chdb-go/pull/57/files#diff-ceadb3c10ae1a92023f2a818da14f6f1eb62a20dcc53c559b4eeb30344aa2ecf)) that each call `chdbpurego.RegisterEmbeddedEngine` in `init()`.
> - A single blank import (`import _ "github.com/chdb-io/chdb-go/lib/embedded"`) is now sufficient to embed the engine; no install step or platform-specific path is required.
> - On unsupported platforms the build succeeds but no engine is registered.
> - Updates [verify-embedded-engine.sh](https://github.com/chdb-io/chdb-go/pull/57/files#diff-01bf996e51fd40d68423b8151852e563a77cf018a35b27c4f44df52d9ca54dbb) to skip non-`GOOS-GOARCH` directories and separately build the `lib/embedded` module for all supported platforms.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 359dc12.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->