### PR TITLE
Check the dispatch module's tag against what it dispatches to

### DIFF
--- a/scripts/enginetag/main.go
+++ b/scripts/enginetag/main.go
@@ -78,6 +78,10 @@ func verify(tag string) error {
 		return fmt.Errorf("tag %s: %w", tag, err)
 	}
 
+	if path.Base(moddir) == "embedded" {
+		return verifyDispatch(tag, moddir, version)
+	}
+
 	file := path.Join(moddir, "engine_data.go")
 	data, err := os.ReadFile(file)
 	if err != nil {
@@ -99,5 +103,41 @@ func verify(tag string) error {
 	}
 
 	fmt.Printf("%s: engine %s, packaging %d\n", tag, gotEngine, counter)
+	return nil
+}
+
+var requireRe = regexp.MustCompile(`(?m)^\s*(github\.com/chdb-io/chdb-go/lib/[a-z0-9-]+)\s+(\S+)`)
+
+// verifyDispatch checks lib/embedded, which carries no engine of its own — it only
+// says which version of the platform modules to use. So the thing to check is that
+// its tag and those versions agree: tagging it v0.260700.2 while its go.mod still
+// points at v0.260700.1 would publish a version claiming an engine packaging it
+// does not bring.
+func verifyDispatch(tag, moddir, version string) error {
+	file := path.Join(moddir, "go.mod")
+	data, err := os.ReadFile(file)
+	if err != nil {
+		return err
+	}
+
+	found := 0
+	for _, m := range requireRe.FindAllStringSubmatch(string(data), -1) {
+		mod, got := m[1], m[2]
+		if path.Base(mod) == "embedded" {
+			continue
+		}
+		found++
+		if got != version {
+			return fmt.Errorf("tag %s does not match what %s requires:\n  %s %s\n\n"+
+				"the dispatch module's version says which platform modules it brings, so the "+
+				"two have to be the same", tag, file, mod, got)
+		}
+	}
+	if found != 4 {
+		return fmt.Errorf("%s requires %d platform modules, expected 4 — a platform that is "+
+			"missing here is one this module silently does not cover", file, found)
+	}
+
+	fmt.Printf("%s: dispatches to 4 platform modules, all at %s\n", tag, version)
 	return nil
 }


### PR DESCRIPTION
Tagging `lib/embedded` would have failed its own check. `-verify` reads
`lib/<platform>/engine_data.go`, and the dispatch module has no engine of its own to
declare:

```
$ go run ./scripts/enginetag -verify lib/embedded/v0.260700.1
open lib/embedded/engine_data.go: no such file or directory
```

Found by running the command before pushing the tag rather than after, which is the
whole reason that command exists.

## Skipping it would have been the wrong fix

`lib/embedded` carries no engine, but it does say which version of the platform
modules to bring — so its tag and those versions have to agree. Tagging it
`v0.260700.2` while its `go.mod` still requires `v0.260700.1` would publish a version
claiming a packaging it does not deliver. And it has to name all four: a platform
missing from that list is one the module silently does not cover, which is worse than
not existing.

## Exercised

```
lib/embedded/v0.260700.1   ->  dispatches to 4 platform modules, all at v0.260700.1
lib/embedded/v0.260700.2   ->  tag does not match what lib/embedded/go.mod requires
go.mod naming 3 platforms  ->  requires 3 platform modules, expected 4
lib/darwin-arm64/v0.260700.1 -> unchanged: refuses the placeholder metadata on main
```

`lib/embedded/v0.260700.1` cannot be tagged until this merges, or the tag check goes
red the moment it arrives.

cc @auxten @wudidapaopao


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Validate `lib/embedded` dispatch module tag against its required platform module versions
> - Adds a `verifyDispatch` function in [scripts/enginetag/main.go](https://github.com/chdb-io/chdb-go/pull/58/files#diff-607ac38247bb43363b7239ad94844e8705d37effe047aedebb00690813caec4e) that reads `lib/embedded`'s `go.mod` and checks that all required platform modules match the tag version.
> - The `verify` function now detects when the module directory is `embedded` and delegates to `verifyDispatch` instead of reading `engine_data.go`.
> - `verifyDispatch` enforces that exactly four platform modules are required and that each matches the tag version, printing a summary on success.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 6d929d8. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->