### PR TITLE
Fix chdb.QueryStream reading through a closed connection

### DIFF
--- a/chdb-purego/chdb.go
+++ b/chdb-purego/chdb.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
@@ -100,6 +101,11 @@ func (c *result) String() string {
 }
 
 type connection struct {
+	// mu guards conn so that Close cannot free the native connection while a
+	// query or a streaming fetch is still running against it. Queries take the
+	// read lock and keep running concurrently; Close takes the write lock and
+	// therefore waits for the in-flight ones to finish.
+	mu   sync.RWMutex
 	conn *chdb_connection
 }
 
@@ -117,6 +123,8 @@ func newChdbConn(conn *chdb_connection) ChdbConn {
 // second Close (or a Close racing a Query that checks for a nil handle) does
 // not double-free the native connection.
 func (c *connection) Close() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	if c.conn != nil {
 		chdbCloseConn(c.conn)
 		c.conn = nil
@@ -125,6 +133,8 @@ func (c *connection) Close() {
 
 // Query implements ChdbConn.
 func (c *connection) Query(queryStr string, formatStr string) (result ChdbResult, err error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	if c.conn == nil {
 		return nil, fmt.Errorf("invalid connection")
 	}
@@ -146,7 +156,8 @@ func (c *connection) Query(queryStr string, formatStr string) (result ChdbResult
 
 // QueryStreaming implements ChdbConn.
 func (c *connection) QueryStreaming(queryStr string, formatStr string) (result ChdbStreamResult, err error) {
-
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	if c.conn == nil {
 		return nil, fmt.Errorf("invalid connection")
 	}
@@ -156,20 +167,65 @@ func (c *connection) QueryStreaming(queryStr string, formatStr string) (result C
 		// According to the C ABI of chDB v1.2.0, the C function query_stable_v2
 		// returns nil if the query returns no data. This is not an error. We
 		// will change this behavior in the future.
-		return newStreamingResult(c.conn, res), nil
+		return newStreamingResult(c, res), nil
 	}
 	if s := chdbResultError(res); s != "" {
 		return nil, errors.New(s)
 	}
 
-	return newStreamingResult(c.conn, res), nil
+	return newStreamingResult(c, res), nil
 }
 
 func (c *connection) Ready() bool {
-	if c.conn != nil {
-		return true
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.conn != nil
+}
+
+// A streaming result is not a materialized buffer: libchdb computes it lazily
+// and every call below takes the connection that started the query, because the
+// stream handle is only a cursor into state that connection owns. The three
+// helpers therefore hold the read lock for the whole native call, so a Close
+// racing them waits instead of pulling the connection out from under the engine,
+// and they turn "the connection is already gone" into an end-of-data/no-op
+// answer instead of a read of freed memory.
+
+// fetchStream pulls the next chunk of a streaming query, reporting end of data
+// when the connection has been closed.
+func (c *connection) fetchStream(stream *chdb_result) *chdb_result {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.conn == nil || stream == nil {
+		return nil
 	}
-	return false
+	return chdbStreamFetchResult(c.conn.internal_data, stream)
+}
+
+// streamError reads the error a streaming query recorded on its handle.
+func (c *connection) streamError(stream *chdb_result) string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.conn == nil || stream == nil {
+		return ""
+	}
+	return chdbResultError(stream)
+}
+
+// releaseStream cancels (when the stream is still running) and destroys a
+// streaming query handle. Once the connection is closed the engine has already
+// retired the query along with it, so there is nothing safe left to call on the
+// handle and it is dropped instead — that only happens when a caller closes a
+// connection while still holding one of its streams.
+func (c *connection) releaseStream(stream *chdb_result, cancel bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.conn == nil || stream == nil {
+		return
+	}
+	if cancel {
+		chdbStreamCancelQuery(c.conn, stream)
+	}
+	chdbDestroyQueryResult(stream)
 }
 
 // NewConnection is the low level function to create a new connection to the chdb server.

--- a/chdb-purego/streaming.go
+++ b/chdb-purego/streaming.go
@@ -3,7 +3,10 @@ package chdbpurego
 import "errors"
 
 type streamingResult struct {
-	curConn  *chdb_connection
+	// conn is the connection the query was started on, not just its handle:
+	// every chunk is fetched through it, so the stream goes through the
+	// connection's own guards instead of dereferencing a handle it does not own.
+	conn     *connection
 	stream   *chdb_result
 	curChunk ChdbResult
 	// Set once the engine has signalled end of data, so Free() knows there is
@@ -11,7 +14,7 @@ type streamingResult struct {
 	finished bool
 }
 
-func newStreamingResult(conn *chdb_connection, cRes *chdb_result) ChdbStreamResult {
+func newStreamingResult(conn *connection, cRes *chdb_result) ChdbStreamResult {
 
 	// nextChunk := streamingResultNext(conn, cRes)
 	// if nextChunk == nil {
@@ -19,8 +22,8 @@ func newStreamingResult(conn *chdb_connection, cRes *chdb_result) ChdbStreamResu
 	// }
 
 	res := &streamingResult{
-		curConn: conn,
-		stream:  cRes,
+		conn:   conn,
+		stream: cRes,
 		// curChunk: newChdbResult(nextChunk),
 	}
 
@@ -31,7 +34,7 @@ func newStreamingResult(conn *chdb_connection, cRes *chdb_result) ChdbStreamResu
 
 // Error implements ChdbStreamResult.
 func (c *streamingResult) Error() error {
-	if s := chdbResultError(c.stream); s != "" {
+	if s := c.conn.streamError(c.stream); s != "" {
 		return errors.New(s)
 	}
 	return nil
@@ -39,7 +42,7 @@ func (c *streamingResult) Error() error {
 
 // Free implements ChdbStreamResult.
 func (c *streamingResult) Free() {
-	if c.curConn != nil && c.stream != nil {
+	if c.stream != nil {
 		// Cancel only while the engine still has a stream to stop. Once it has
 		// signalled end of data it has retired the query's state, and cancelling a
 		// retired stream walks into it: chdb_stream_cancel_query takes the handle as
@@ -50,11 +53,9 @@ func (c *streamingResult) Free() {
 		//
 		// Destroying is still correct and still required — the engine's own note on
 		// cancel says the handle is released by chdb_destroy_query_result, not by
-		// cancel — so only the cancel is conditional.
-		if !c.finished {
-			chdbStreamCancelQuery(c.curConn, c.stream)
-		}
-		chdbDestroyQueryResult(c.stream)
+		// cancel — so only the cancel is conditional. releaseStream skips both when
+		// the connection is already closed, which retires the query anyway.
+		c.conn.releaseStream(c.stream, !c.finished)
 	}
 
 	c.stream = nil
@@ -76,7 +77,13 @@ func (c *streamingResult) GetNext() ChdbResult {
 		c.curChunk.Free()
 		c.curChunk = nil
 	}
-	nextChunk := chdbStreamFetchResult(c.curConn.internal_data, c.stream)
+	if c.finished {
+		// The engine does not stop at end of data: asked again it keeps handing
+		// out empty chunks, so a caller reading until GetNext returns nil would
+		// never leave the loop. Report the end once and stay there.
+		return nil
+	}
+	nextChunk := c.conn.fetchStream(c.stream)
 	if nextChunk == nil {
 		c.finished = true
 		return nil

--- a/chdb-purego/streaming_test.go
+++ b/chdb-purego/streaming_test.go
@@ -1,0 +1,76 @@
+package chdbpurego
+
+import "testing"
+
+// A stream is a cursor into state its connection owns, so closing the connection
+// while a stream is still held has to end the stream rather than let it fetch
+// through the freed connection (a segfault against chdb-core v26.7).
+func TestStreamingResultAfterConnectionClose(t *testing.T) {
+	conn, err := NewConnectionFromConnString(":memory:")
+	if err != nil {
+		t.Fatalf("NewConnectionFromConnString() error: %v", err)
+	}
+	defer conn.Close()
+
+	stream, err := conn.QueryStreaming("SELECT number FROM system.numbers LIMIT 200000", "CSV")
+	if err != nil {
+		t.Fatalf("QueryStreaming() error: %v", err)
+	}
+	if chunk := stream.GetNext(); chunk == nil {
+		t.Fatal("GetNext() returned no chunk")
+	}
+
+	conn.Close()
+
+	if chunk := stream.GetNext(); chunk != nil {
+		t.Error("GetNext() on a closed connection returned a chunk, want nil")
+	}
+	if err := stream.Error(); err != nil {
+		t.Errorf("Error() on a closed connection = %v, want nil", err)
+	}
+	// Neither of these may reach the engine: the connection took the query's
+	// state with it, so there is nothing left to cancel or destroy.
+	stream.Free()
+	stream.Cancel()
+}
+
+// The engine answers a fetch past end of data with an empty chunk, and keeps
+// doing so; the stream reports the end once so that reading until nil ends.
+func TestStreamingResultReportsEndOfData(t *testing.T) {
+	conn, err := NewConnectionFromConnString(":memory:")
+	if err != nil {
+		t.Fatalf("NewConnectionFromConnString() error: %v", err)
+	}
+	defer conn.Close()
+
+	stream, err := conn.QueryStreaming("SELECT number FROM system.numbers LIMIT 10", "CSV")
+	if err != nil {
+		t.Fatalf("QueryStreaming() error: %v", err)
+	}
+	defer stream.Free()
+
+	var (
+		rows   uint64
+		chunks int
+	)
+	for {
+		chunk := stream.GetNext()
+		if chunk == nil {
+			break
+		}
+		if err := chunk.Error(); err != nil {
+			t.Fatalf("chunk %d: %v", chunks, err)
+		}
+		rows += chunk.RowsRead()
+		chunks++
+		if chunks > 100 {
+			t.Fatal("stream never reported end of data")
+		}
+	}
+	if rows != 10 {
+		t.Errorf("streamed %d rows, want 10", rows)
+	}
+	if chunk := stream.GetNext(); chunk != nil {
+		t.Error("GetNext() past end of data returned a chunk, want nil")
+	}
+}

--- a/chdb/driver/driver.go
+++ b/chdb/driver/driver.go
@@ -459,7 +459,15 @@ func (c *conn) QueryContext(ctx context.Context, query string, args []driver.Nam
 		if err != nil {
 			return nil, err
 		}
-		return c.driverType.PrepareStreamingRows(result, c.bufferSize, c.useUnsafe)
+		rows, err := c.driverType.PrepareStreamingRows(result, c.bufferSize, c.useUnsafe)
+		if err != nil {
+			// There is no Rows to close the stream from, and the stream holds the
+			// connection it was started on open — a sessionless query keeps a whole
+			// session for it — so release it here instead of at the next GC.
+			result.Free()
+			return nil, err
+		}
+		return rows, nil
 	}
 	result, err := c.QueryFun(compiledQuery, c.driverType.GetFormat(), c.udfPath)
 	if err != nil {

--- a/chdb/driver/parquet_streaming_test.go
+++ b/chdb/driver/parquet_streaming_test.go
@@ -31,6 +31,11 @@ func TestDbWithParquetStreaming(t *testing.T) {
 		foo int
 	)
 	defer rows.Close()
+	// Counted, because this sessionless path streams through chdb.QueryStream:
+	// when that helper closed its session too early the engine answered with no
+	// rows at all (or crashed), and a loop that only checks the rows it does see
+	// stayed green.
+	scanned := 0
 	for rows.Next() {
 		err := rows.Scan(&bar, &foo)
 		if err != nil {
@@ -39,7 +44,13 @@ func TestDbWithParquetStreaming(t *testing.T) {
 		if bar != 1 {
 			t.Errorf("expected error")
 		}
-
+		scanned++
+	}
+	if err := rows.Err(); err != nil {
+		t.Errorf("iterate rows fail, err: %s", err)
+	}
+	if scanned != 100000 {
+		t.Errorf("scanned %d rows, want 100000", scanned)
 	}
 
 }

--- a/chdb/wrapper.go
+++ b/chdb/wrapper.go
@@ -1,6 +1,9 @@
 package chdb
 
 import (
+	"runtime"
+	"sync"
+
 	chdbpurego "github.com/chdb-io/chdb-go/v2/chdb-purego"
 )
 
@@ -25,6 +28,12 @@ func Query(queryStr string, outputFormats ...string) (result chdbpurego.ChdbResu
 
 // QueryStream is like Query but returns a streaming result that can be read in
 // chunks, for large datasets that should not be fully materialized in memory.
+//
+// The returned stream owns the session it runs on, because a streaming result is
+// computed as it is read: every chunk is fetched through the connection that
+// started the query. The session is closed when the stream reaches its end, or
+// when Free/Cancel is called — so a caller that stops reading early must call
+// one of them (a dropped stream is closed by a finalizer, eventually).
 func QueryStream(queryStr string, outputFormats ...string) (result chdbpurego.ChdbStreamResult, err error) {
 	outputFormat := "CSV" // Default value
 	if len(outputFormats) > 0 {
@@ -34,8 +43,93 @@ func QueryStream(queryStr string, outputFormats ...string) (result chdbpurego.Ch
 	if err != nil {
 		return nil, err
 	}
-	defer sess.Close()
-	return sess.QueryStream(queryStr, outputFormat)
+	stream, err := sess.QueryStream(queryStr, outputFormat)
+	if err != nil {
+		sess.Close()
+		return nil, err
+	}
+	return newSessionStream(stream, sess), nil
+}
+
+// sessionStream keeps the session that QueryStream opened alive for as long as
+// the stream it produced can still be read.
+//
+// Closing the session as soon as QueryStream returned — what this used to do —
+// handed back a stream that reads through a freed connection: the stream handle
+// is only a cursor, and the engine state it points at belongs to the connection.
+// The symptom followed the engine rather than chdb-go, which is what made it
+// easy to miss: chdb-core v26.5 answered the first fetch with "Unexpected null
+// connection", v26.7 segfaulted.
+type sessionStream struct {
+	// mu serializes release against the reads, so a Free racing the last GetNext
+	// cannot close the session mid-fetch.
+	mu       sync.Mutex
+	stream   chdbpurego.ChdbStreamResult
+	sess     *Session
+	err      error // stream-level error, read before the stream is released
+	released bool
+}
+
+func newSessionStream(stream chdbpurego.ChdbStreamResult, sess *Session) *sessionStream {
+	s := &sessionStream{stream: stream, sess: sess}
+	// Backstop for a caller that abandons the stream without draining it: the
+	// session holds a native connection and pins the process-wide data path, so
+	// leaking it would also keep a later session on another path from opening.
+	runtime.SetFinalizer(s, (*sessionStream).release)
+	return s
+}
+
+// GetNext implements chdbpurego.ChdbStreamResult.
+func (s *sessionStream) GetNext() chdbpurego.ChdbResult {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.released {
+		return nil
+	}
+	chunk := s.stream.GetNext()
+	if chunk == nil {
+		// End of data: nothing more will be fetched through the connection, so
+		// release the session now rather than waiting for a Free the caller has
+		// no reason to make.
+		s.releaseLocked()
+	}
+	return chunk
+}
+
+// Error implements chdbpurego.ChdbStreamResult.
+func (s *sessionStream) Error() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.released {
+		return s.err
+	}
+	return s.stream.Error()
+}
+
+// Free implements chdbpurego.ChdbStreamResult.
+func (s *sessionStream) Free() { s.release() }
+
+// Cancel implements chdbpurego.ChdbStreamResult.
+func (s *sessionStream) Cancel() { s.release() }
+
+func (s *sessionStream) release() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.releaseLocked()
+}
+
+// releaseLocked frees the stream first and only then closes the session: the
+// stream handle is released through the connection that produced it, so the
+// order matters.
+func (s *sessionStream) releaseLocked() {
+	if s.released {
+		return
+	}
+	s.released = true
+	s.err = s.stream.Error()
+	s.stream.Free()
+	s.sess.Close()
+	runtime.SetFinalizer(s, nil)
 }
 
 // ephemeralSession returns a short-lived session for the package-level one-shot

--- a/chdb/wrapper_stream_test.go
+++ b/chdb/wrapper_stream_test.go
@@ -1,0 +1,129 @@
+package chdb
+
+import (
+	"runtime"
+	"testing"
+	"time"
+)
+
+// A streaming result is fetched chunk by chunk through the connection that
+// started the query, so the session QueryStream opens has to stay open until the
+// caller is done reading. Closing it right away — what QueryStream used to do —
+// left the stream reading through a freed connection: chdb-core v26.5 failed the
+// first fetch with "Unexpected null connection" and v26.7 segfaulted.
+func TestQueryStreamOutlivesTheSessionItOpened(t *testing.T) {
+	const wantRows = 200000
+	before := ActiveSessionRefs()
+
+	stream, err := QueryStream("SELECT number FROM system.numbers LIMIT 200000", "CSV")
+	if err != nil {
+		t.Fatalf("QueryStream() error: %v", err)
+	}
+	// Checked before the first fetch: reading a stream whose session is already
+	// gone is what crashes, so fail here instead of in the engine.
+	if refs := ActiveSessionRefs(); refs != before+1 {
+		t.Fatalf("open sessions after QueryStream = %d, want %d (the stream must keep its session open)", refs, before+1)
+	}
+
+	var (
+		rows   uint64
+		chunks int
+	)
+	for {
+		chunk := stream.GetNext()
+		if chunk == nil {
+			break
+		}
+		if err := chunk.Error(); err != nil {
+			t.Fatalf("chunk %d: %v", chunks, err)
+		}
+		rows += chunk.RowsRead()
+		chunks++
+		if chunks > 10000 {
+			// The engine keeps answering with empty chunks past end of data, so a
+			// stream that never reports the end would loop here forever.
+			t.Fatal("stream never reported end of data")
+		}
+	}
+	if rows != wantRows {
+		t.Errorf("streamed %d rows, want %d", rows, wantRows)
+	}
+	if chunks < 2 {
+		t.Errorf("streamed in %d chunks, want the result spread over several fetches", chunks)
+	}
+	if err := stream.Error(); err != nil {
+		t.Errorf("stream error after draining: %v", err)
+	}
+
+	// Draining the stream is enough to release the session, so a caller that
+	// reads to the end and never calls Free does not leak the connection.
+	if refs := ActiveSessionRefs(); refs != before {
+		t.Errorf("open sessions after draining = %d, want %d", refs, before)
+	}
+	// Reading past the end stays at the end instead of fetching through the
+	// connection that has just been closed.
+	if chunk := stream.GetNext(); chunk != nil {
+		t.Error("GetNext() past end of data returned a chunk, want nil")
+	}
+	// Free is still safe (and idempotent) after the stream released itself.
+	stream.Free()
+	stream.Free()
+}
+
+// A caller that stops reading early releases the session with Free/Cancel.
+func TestQueryStreamFreeReleasesTheSession(t *testing.T) {
+	before := ActiveSessionRefs()
+
+	stream, err := QueryStream("SELECT number FROM system.numbers LIMIT 200000", "CSV")
+	if err != nil {
+		t.Fatalf("QueryStream() error: %v", err)
+	}
+	if refs := ActiveSessionRefs(); refs != before+1 {
+		t.Fatalf("open sessions after QueryStream = %d, want %d (the stream must keep its session open)", refs, before+1)
+	}
+	if chunk := stream.GetNext(); chunk == nil {
+		stream.Free()
+		t.Fatal("GetNext() returned no chunk")
+	}
+
+	stream.Free()
+	if refs := ActiveSessionRefs(); refs != before {
+		t.Errorf("open sessions after Free = %d, want %d", refs, before)
+	}
+	if chunk := stream.GetNext(); chunk != nil {
+		t.Error("GetNext() after Free returned a chunk, want nil")
+	}
+}
+
+// An abandoned stream is collected: its session holds a native connection and
+// pins the process-wide data path, so it must not depend on the caller.
+func TestQueryStreamAbandonedStreamIsCollected(t *testing.T) {
+	before := ActiveSessionRefs()
+
+	func() {
+		stream, err := QueryStream("SELECT number FROM system.numbers LIMIT 200000", "CSV")
+		if err != nil {
+			t.Fatalf("QueryStream() error: %v", err)
+		}
+		if refs := ActiveSessionRefs(); refs != before+1 {
+			stream.Free()
+			t.Fatalf("open sessions after QueryStream = %d, want %d (the stream must keep its session open)", refs, before+1)
+		}
+		if chunk := stream.GetNext(); chunk == nil {
+			stream.Free()
+			t.Fatal("GetNext() returned no chunk")
+		}
+	}()
+
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		runtime.GC()
+		if ActiveSessionRefs() == before {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("open sessions after dropping the stream = %d, want %d", ActiveSessionRefs(), before)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
## The bug

The package-level `chdb.QueryStream` opened a session, deferred its `Close` and returned the stream — so the session was already closed by the time the caller read the first chunk:

```go
sess, err := ephemeralSession()
...
defer sess.Close()                               // closed on return
return sess.QueryStream(queryStr, outputFormat)  // ...and the stream is handed over
```

A streaming result is not a materialized buffer. libchdb computes it as it is read, and every chunk is fetched through the connection that started the query (`chdb_stream_fetch_result(conn, result)` — the header calls it an *active* connection handle), which makes the returned handle a cursor into state that connection owns. Reading it after the close is a use-after-free.

The symptom followed the **engine**, not chdb-go, which is what let this survive:

| | engine 26.5.1.1 | engine 26.7.2.1 |
|---|---|---|
| chdb-go v2.0.1 | first fetch errors `Unexpected null connection` | SIGSEGV |
| chdb-go v2.1.0 | first fetch errors `Unexpected null connection` | SIGSEGV |

`chdb/wrapper.go` is byte-identical between v2.0.1 and v2.1.0, so this is not a v2.1.0 regression — but a v2.0.1 user who upgrades and picks up the 26.7 engine (embedded module or a reinstalled libchdb) trades an error/empty result for a crash. On 26.5 the error only shows up if the caller checks `chunk.Error()`; code that iterates and sums rows just sees no data.

`database/sql` inherits it: a streaming connection opened without a session (`sql.Open("chdb", "driverType=PARQUET_STREAMING")`) streams through this helper.

`Session.QueryStream` was never affected — there the caller owns the session. `chdb.Query` is fine as well: its result is fully materialized before the session closes.

## The fix

The stream now **owns** the session and closes it when it reaches the end of the data, or when `Free`/`Cancel` is called. A finalizer is the backstop for a stream that is abandoned instead: the session holds a native connection and pins the process-wide data path, so releasing it cannot depend on the caller.

Two more faults of the same shape turned up on the way, both reachable without `QueryStream`:

- **Closing a connection while still holding one of its streams** walked into the same freed state, so the guard belongs one layer down as well. A stream now holds the connection rather than a copy of its handle, and fetch/cancel/destroy/error all go through it under the connection's read lock: a `Close` racing a fetch waits instead of freeing the connection under the engine, and a fetch after `Close` reports end of data instead of reading freed memory. Once the connection is gone the handle is dropped rather than cancelled and destroyed, because the engine retired the query along with it.
- **The engine does not stop at end of data** — asked again it keeps handing out empty chunks — so `for { c := GetNext(); if c == nil { break } }` never terminated against 26.7. The stream reports the end once and stays there.

Also: the streaming path in `database/sql` now frees the stream when `PrepareStreamingRows` fails, since there is no `Rows` left to close it from.

## Tests

New tests fail on the unfixed code *before* they reach the engine — the session is already closed when `QueryStream` returns — so they hold on both engine builds instead of only where the crash happens:

```
--- FAIL: TestQueryStreamOutlivesTheSessionItOpened
    wrapper_stream_test.go:25: open sessions after QueryStream = 0, want 1 (the stream must keep its session open)
```

- `chdb`: the stream outlives the session (200k rows over several fetches, session released on drain), `Free` releases it early, an abandoned stream is collected.
- `chdb-purego`: a stream survives its connection being closed, and end of data is reported once.
- `chdb/driver`: `TestDbWithParquetStreaming` exercised this exact sessionless path and stayed green because it counted no rows — it counts them now (its `TestMain` keeps another session open, which is why it never crashed).

Verified locally against **chdb-core v26.5.1.1 and v26.7.2.1**: full suite, race detector (`.github/scripts/race-test.sh`), `verify-as-user.sh`, CLI smoke — all green on both.

## Scope

Entirely a chdb-go fix — nothing here waits on an engine change. The guards are on the Go side because the C API faults rather than erroring when it is handed a closed connection: `chdb_query` documents "returns error result if connection is invalid or closed", `chdb_stream_fetch_result` and `chdb_stream_cancel_query` make no such promise.
