### PR TITLE
Fix db.Exec and Rows.ColumnTypes crashing in the SQL driver

### DIFF
--- a/chdb-purego/chdb.go
+++ b/chdb-purego/chdb.go
@@ -148,6 +148,10 @@ func (c *connection) Query(queryStr string, formatStr string) (result ChdbResult
 	}
 	errMsg := chdbResultError(res)
 	if errMsg != "" {
+		// The message is already copied into Go memory, and a failed query has no
+		// result for the caller to free — so free it here rather than keeping a
+		// result per failed query for the life of the process.
+		chdbDestroyQueryResult(res)
 		return nil, errors.New(errMsg)
 	}
 
@@ -170,6 +174,9 @@ func (c *connection) QueryStreaming(queryStr string, formatStr string) (result C
 		return newStreamingResult(c, res), nil
 	}
 	if s := chdbResultError(res); s != "" {
+		// Same as in Query: nobody is going to free a handle that never became a
+		// stream.
+		chdbDestroyQueryResult(res)
 		return nil, errors.New(s)
 	}
 

--- a/chdb/driver/column_types_test.go
+++ b/chdb/driver/column_types_test.go
@@ -1,0 +1,102 @@
+package chdbdriver
+
+import (
+	"database/sql"
+	"strings"
+	"testing"
+)
+
+// A ClickHouse Array, Map or Tuple arrives as a parquet group, and Kind() panics
+// on those: Rows.ColumnTypes() — which ORMs and generic row scanners call for
+// every query — used to die with "cannot call Kind on parquet group". Worse, it
+// panicked inside database/sql while it held the connection's lock.
+//
+// The columns still have no mapping, so reading them must fail with an error that
+// says so. An Array used to be worse than unsupported: the row came back with that
+// column NULL, the columns after it NULL too, and rows.Err() nil — data, not a
+// complaint.
+func TestGroupColumnsAreReportedNotFatal(t *testing.T) {
+	for _, driverType := range []string{"PARQUET", "PARQUET_STREAMING"} {
+		for _, tc := range []struct {
+			name  string
+			query string
+		}{
+			{"array", "SELECT 7 AS x, [1,2,3] AS arr"},
+			{"map", "SELECT map('k', 1) AS m"},
+			{"tuple", "SELECT tuple(1, 'a') AS t"},
+		} {
+			t.Run(driverType+"/"+tc.name, func(t *testing.T) {
+				db, err := sql.Open("chdb", "driverType="+driverType)
+				if err != nil {
+					t.Fatalf("open db fail, err:%s", err)
+				}
+				defer db.Close()
+
+				rows, err := db.Query(tc.query)
+				if err != nil {
+					t.Fatalf("run Query fail, err:%s", err)
+				}
+				defer rows.Close()
+
+				// The call that used to panic.
+				cts, err := rows.ColumnTypes()
+				if err != nil {
+					t.Fatalf("ColumnTypes fail, err:%s", err)
+				}
+				for i, ct := range cts {
+					// Callers build a scan destination from this with reflect.New,
+					// which panics on a nil type.
+					if ct.ScanType() == nil {
+						t.Errorf("column %d (%s) has no scan type", i, ct.Name())
+					}
+				}
+
+				if rows.Next() {
+					t.Error("Next() returned a row for a column type the driver cannot read")
+				}
+				err = rows.Err()
+				if err == nil {
+					t.Fatal("reading an unsupported column type reported no error")
+				}
+				if !strings.Contains(err.Error(), "column") {
+					t.Errorf("error %q does not say which column could not be read", err)
+				}
+			})
+		}
+	}
+}
+
+// The mapped types keep working, and their scan types stay what they were.
+func TestColumnTypesOfMappedColumns(t *testing.T) {
+	db, err := sql.Open("chdb", "driverType=PARQUET")
+	if err != nil {
+		t.Fatalf("open db fail, err:%s", err)
+	}
+	defer db.Close()
+
+	rows, err := db.Query("SELECT toInt32(-2) AS i, toUInt64(3) AS u, toFloat64(4.5) AS f, 'text' AS s, true AS b")
+	if err != nil {
+		t.Fatalf("run Query fail, err:%s", err)
+	}
+	defer rows.Close()
+
+	cts, err := rows.ColumnTypes()
+	if err != nil {
+		t.Fatalf("ColumnTypes fail, err:%s", err)
+	}
+	want := []string{"int32", "int64", "float64", "string", "bool"}
+	if len(cts) != len(want) {
+		t.Fatalf("got %d columns, want %d", len(cts), len(want))
+	}
+	for i, ct := range cts {
+		if ct.ScanType() == nil {
+			t.Fatalf("column %s has no scan type", ct.Name())
+		}
+		if got := ct.ScanType().String(); got != want[i] {
+			t.Errorf("column %s scan type = %s, want %s", ct.Name(), got, want[i])
+		}
+	}
+	if !rows.Next() {
+		t.Fatalf("no row returned, err:%v", rows.Err())
+	}
+}

--- a/chdb/driver/driver.go
+++ b/chdb/driver/driver.go
@@ -365,22 +365,18 @@ func (c *conn) Close() error {
 	return nil
 }
 
+// SetupQueryFun wires both entry points, streaming or not. Exec never streams —
+// it throws the result away — so it goes through QueryFun even on a streaming
+// connection, where QueryFun used to be left nil and turned every db.Exec into a
+// nil-func call.
 func (c *conn) SetupQueryFun() {
-	if c.isStreaming {
-		c.streamFun = chdb.QueryStream
-	} else {
-		c.QueryFun = chdb.Query
-	}
+	c.QueryFun = chdb.Query
+	c.streamFun = chdb.QueryStream
 
 	if c.session != nil {
-		if c.isStreaming {
-			c.streamFun = c.session.QueryStream
-		} else {
-			c.QueryFun = c.session.Query
-		}
-
+		c.QueryFun = c.session.Query
+		c.streamFun = c.session.QueryStream
 	}
-
 }
 
 func (c *conn) Query(query string, values []driver.Value) (driver.Rows, error) {
@@ -401,7 +397,7 @@ func (c *conn) ExecContext(ctx context.Context, query string, args []driver.Name
 		return nil, err
 	}
 
-	result, err := c.QueryFun(compiledQuery, c.driverType.String(), c.udfPath)
+	result, err := c.QueryFun(compiledQuery, c.driverType.GetFormat(), c.udfPath)
 	if err != nil {
 		return nil, err
 	}
@@ -476,9 +472,17 @@ func (c *conn) QueryContext(ctx context.Context, query string, args []driver.Nam
 
 	buf := result.Buf()
 	if len(buf) == 0 {
+		// Statements with no result set (DDL, SET, INSERT) land here. Nothing will
+		// read the result, so free it instead of leaving it to no one.
+		result.Free()
 		return nil, fmt.Errorf("result is nil")
 	}
-	return c.driverType.PrepareRows(result, buf, c.bufferSize, c.useUnsafe)
+	rows, err := c.driverType.PrepareRows(result, buf, c.bufferSize, c.useUnsafe)
+	if err != nil {
+		result.Free()
+		return nil, err
+	}
+	return rows, nil
 
 }
 

--- a/chdb/driver/exec_streaming_test.go
+++ b/chdb/driver/exec_streaming_test.go
@@ -1,0 +1,52 @@
+package chdbdriver
+
+import (
+	"database/sql"
+	"testing"
+)
+
+// Exec on a streaming connection used to be a nil-func call: SetupQueryFun wired
+// only streamFun when the driver type streams, and ExecContext goes through
+// QueryFun — so the first db.Exec on a PARQUET_STREAMING handle panicked with a
+// nil pointer dereference. Creating a table and inserting into it is the first
+// thing a caller does, streaming or not.
+func TestExecOnStreamingConnection(t *testing.T) {
+	db, err := sql.Open("chdb", "driverType=PARQUET_STREAMING")
+	if err != nil {
+		t.Fatalf("open db fail, err:%s", err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(
+		"CREATE TABLE IF NOT EXISTS TestExecOnStreamingConnection (id UInt32) ENGINE = MergeTree() ORDER BY id;"); err != nil {
+		t.Fatalf("create table fail, err:%s", err)
+	}
+	res, err := db.Exec("INSERT INTO TestExecOnStreamingConnection VALUES (1), (2), (3);")
+	if err != nil {
+		t.Fatalf("insert fail, err:%s", err)
+	}
+	if _, err := res.RowsAffected(); err != nil {
+		t.Errorf("RowsAffected fail, err:%s", err)
+	}
+
+	// And the streaming read path still works on the same handle.
+	rows, err := db.Query("SELECT id FROM TestExecOnStreamingConnection ORDER BY id;")
+	if err != nil {
+		t.Fatalf("run Query fail, err:%s", err)
+	}
+	defer rows.Close()
+	var ids []uint32
+	for rows.Next() {
+		var id uint32
+		if err := rows.Scan(&id); err != nil {
+			t.Fatalf("scan fail, err:%s", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate rows fail, err:%s", err)
+	}
+	if len(ids) != 3 {
+		t.Errorf("read back %v, want 3 rows", ids)
+	}
+}

--- a/chdb/driver/parquet.go
+++ b/chdb/driver/parquet.go
@@ -99,6 +99,17 @@ func (r *parquetRows) Next(dest []driver.Value) error {
 	var scanError error
 	r.curRecord.Range(func(columnIndex int, columnValues []parquet.Value) bool {
 		if len(columnValues) != 1 {
+			// A repeated column — a ClickHouse Array is the common one — carries a
+			// value per element, and this driver has no mapping for it. Returning
+			// false without an error left this column and every column after it as
+			// NULL, so the row read as data rather than as unsupported.
+			scanError = fmt.Errorf("could not read column %s: %d values in the row, want 1", r.columnDesc(columnIndex), len(columnValues))
+			return false
+		}
+		if columnIndex >= len(dest) {
+			// A single SQL column can span several parquet leaves; the row has more
+			// of them than database/sql gave slots for.
+			scanError = fmt.Errorf("could not read column %s: the row has more columns than the query reported", r.columnDesc(columnIndex))
 			return false
 		}
 		curVal := columnValues[0]
@@ -153,7 +164,7 @@ func (r *parquetRows) Next(dest []driver.Value) error {
 		case "TIMESTAMP(isAdjustedToUTC=false,unit=NANOS)", "TIME(isAdjustedToUTC=false,unit=NANOS)":
 			dest[columnIndex] = time.Unix(0, curVal.Int64())
 		default:
-			scanError = fmt.Errorf("could not cast to type: %s", r.ColumnTypeDatabaseTypeName(columnIndex))
+			scanError = fmt.Errorf("could not read column %s: unsupported type", r.columnDesc(columnIndex))
 			return false
 
 		}
@@ -181,7 +192,22 @@ func (r *parquetRows) ColumnTypePrecisionScale(index int) (precision, scale int6
 }
 
 func (r *parquetRows) ColumnTypeScanType(index int) reflect.Type {
-	switch r.schemaFields[index].Type().Kind() {
+	return parquetScanType(r.schemaFields[index])
+}
+
+// parquetScanType maps a column to the Go type this driver produces for it.
+//
+// Kind() panics on anything that is not a leaf — a ClickHouse Array, Map or Tuple
+// arrives as a parquet group — and database/sql calls ColumnTypeScanType for every
+// column of every query from Rows.ColumnTypes(), which is what ORMs and generic
+// row scanners use. So group columns are answered instead of asked about, and
+// anything without a mapping reports the empty interface: callers build a scan
+// destination out of this type, and a nil one panics in reflect.New.
+func parquetScanType(field parquet.Field) reflect.Type {
+	if !field.Leaf() {
+		return anyType
+	}
+	switch field.Type().Kind() {
 	case parquet.Boolean:
 		return reflect.TypeOf(false)
 	case parquet.Int32:
@@ -195,5 +221,17 @@ func (r *parquetRows) ColumnTypeScanType(index int) reflect.Type {
 	case parquet.ByteArray, parquet.FixedLenByteArray:
 		return reflect.TypeOf("")
 	}
-	return nil
+	return anyType
+}
+
+var anyType = reflect.TypeOf((*any)(nil)).Elem()
+
+// columnDesc names a column for an error message: by name and parquet type when
+// the index is one of the query's columns, by position when it is a leaf
+// underneath one (a single SQL column can span several).
+func (r *parquetRows) columnDesc(index int) string {
+	if index >= 0 && index < len(r.schemaFields) {
+		return fmt.Sprintf("%q (%s)", r.schemaFields[index].Name(), r.schemaFields[index].Type())
+	}
+	return fmt.Sprintf("at index %d", index)
 }

--- a/chdb/driver/parquet_streaming.go
+++ b/chdb/driver/parquet_streaming.go
@@ -121,6 +121,17 @@ func (r *parquetStreamingRows) Next(dest []driver.Value) error {
 	var scanError error
 	r.curRecord.Range(func(columnIndex int, columnValues []parquet.Value) bool {
 		if len(columnValues) != 1 {
+			// A repeated column — a ClickHouse Array is the common one — carries a
+			// value per element, and this driver has no mapping for it. Returning
+			// false without an error left this column and every column after it as
+			// NULL, so the row read as data rather than as unsupported.
+			scanError = fmt.Errorf("could not read column %s: %d values in the row, want 1", r.columnDesc(columnIndex), len(columnValues))
+			return false
+		}
+		if columnIndex >= len(dest) {
+			// A single SQL column can span several parquet leaves; the row has more
+			// of them than database/sql gave slots for.
+			scanError = fmt.Errorf("could not read column %s: the row has more columns than the query reported", r.columnDesc(columnIndex))
 			return false
 		}
 		curVal := columnValues[0]
@@ -175,7 +186,7 @@ func (r *parquetStreamingRows) Next(dest []driver.Value) error {
 		case "TIMESTAMP(isAdjustedToUTC=false,unit=NANOS)", "TIME(isAdjustedToUTC=false,unit=NANOS)":
 			dest[columnIndex] = time.Unix(0, curVal.Int64())
 		default:
-			scanError = fmt.Errorf("could not cast to type: %s", r.ColumnTypeDatabaseTypeName(columnIndex))
+			scanError = fmt.Errorf("could not read column %s: unsupported type", r.columnDesc(columnIndex))
 			return false
 
 		}
@@ -203,19 +214,15 @@ func (r *parquetStreamingRows) ColumnTypePrecisionScale(index int) (precision, s
 }
 
 func (r *parquetStreamingRows) ColumnTypeScanType(index int) reflect.Type {
-	switch r.schemaFields[index].Type().Kind() {
-	case parquet.Boolean:
-		return reflect.TypeOf(false)
-	case parquet.Int32:
-		return reflect.TypeOf(int32(0))
-	case parquet.Int64:
-		return reflect.TypeOf(int64(0))
-	case parquet.Float:
-		return reflect.TypeOf(float32(0))
-	case parquet.Double:
-		return reflect.TypeOf(float64(0))
-	case parquet.ByteArray, parquet.FixedLenByteArray:
-		return reflect.TypeOf("")
+	return parquetScanType(r.schemaFields[index])
+}
+
+// columnDesc names a column for an error message: by name and parquet type when
+// the index is one of the query's columns, by position when it is a leaf
+// underneath one (a single SQL column can span several).
+func (r *parquetStreamingRows) columnDesc(index int) string {
+	if index >= 0 && index < len(r.schemaFields) {
+		return fmt.Sprintf("%q (%s)", r.schemaFields[index].Name(), r.schemaFields[index].Type())
 	}
-	return nil
+	return fmt.Sprintf("at index %d", index)
 }


### PR DESCRIPTION
Found while auditing `main` after #59 for other crash-on-first-use paths through `database/sql`. Four findings, all in the SQL driver except the last.

## 1. `db.Exec` panics on a streaming connection (crash)

```go
db, _ := sql.Open("chdb", "driverType=PARQUET_STREAMING")
db.Exec("CREATE TABLE t (id UInt32) ENGINE = MergeTree() ORDER BY id")
// panic: runtime error: invalid memory address or nil pointer dereference
//   chdb/driver.(*conn).ExecContext  driver.go:404
```

`SetupQueryFun` wired `streamFun` when the driver type streams and `QueryFun` otherwise — but `ExecContext` goes through `QueryFun` either way, because Exec discards the result and has nothing to stream. So `QueryFun` stayed nil and the first `db.Exec` on a streaming handle was a nil-func call. Creating a table is the first thing a caller does, streaming or not.

Both entry points are wired now. Exec also asks for the driver type's *format* rather than its name — `DriverType.String()` answers `""` for `PARQUET_STREAMING`.

## 2. `Rows.ColumnTypes()` panics on Array/Map/Tuple columns (crash)

```go
rows, _ := db.Query("SELECT 7 AS x, [1,2,3] AS arr")
rows.ColumnTypes()
// panic: cannot call Kind on parquet group
//   parquet-go.groupType.Kind
//   chdb/driver.(*parquetRows).ColumnTypeScanType  parquet.go:184
//   database/sql.rowsColumnInfoSetupConnLocked
```

Those columns arrive as parquet groups, and `Kind()` panics on anything that is not a leaf. `database/sql` calls `ColumnTypeScanType` for every column of every query from `ColumnTypes()` — which is what ORMs and generic row scanners do — and it panicked inside `rowsColumnInfoSetupConnLocked`, i.e. while holding the connection's lock. Both `parquetRows` and `parquetStreamingRows` had it.

Group columns are now answered rather than asked about. A column with no mapping reports the empty interface instead of a nil type, because callers build a scan destination from it with `reflect.New` and a nil type panics there too.

## 3. An `Array` column read as NULL data instead of an error (silent wrong answer)

```
row: arr=<nil>(<nil>) x=<nil>(<nil>)
rows.Err() = <nil>
```

The `Range` callback returned `false` without setting an error when a column carried more than one value, which left that column **and every column after it** NULL, with no complaint. Reading an unsupported column is now an error naming the column and its parquet type:

```
could not read column "arr" (group): 3 values in the row, want 1
could not read column "m" (MAP): unsupported type
```

The same guard covers a row with more parquet leaves than the query has columns, which would otherwise have indexed past the destination slice.

## 4. Failed and result-less queries leaked their native result (unbounded)

The purego layer read the error message off the result handle and returned it without destroying the handle; the driver returned `"result is nil"` for statements with no result set the same way. Nobody was left holding either.

A loop of failing queries (`SELECT * FROM does_not_exist`), RSS delta:

| queries | before | after |
|---|---|---|
| 20 000 | +10.4 MB | +5.2 MB |
| 60 000 | +22.3 MB | +6.1 MB |

Linear before, flat after — what is left is engine cache, not per-query growth.

## Tests, on Linux and macOS

The two crashes are covered per scenario, for both driver types where both apply, plus a test that the mapped column types keep their scan types (guard on this change, not on the bug).

They fail on the code before this commit. Rather than assert that from Linux only, the tests ran against unfixed `main` in **#60** (draft, since closed) so CI would run them on both runners. Two runs were needed because the first panic kills the test binary before the second test starts:

| run | `build_linux` | `build_mac` (arm64) |
|---|---|---|
| [both tests](https://github.com/chdb-io/chdb-go/actions/runs/32194627738) | fail — `cannot call Kind on parquet group` | fail — `cannot call Kind on parquet group` |
| [Exec test alone](https://github.com/chdb-io/chdb-go/actions/runs/32194804217) | fail — nil dereference in `(*conn).ExecContext` | fail — nil dereference in `(*conn).ExecContext` |
| [this PR](https://github.com/chdb-io/chdb-go/actions/runs/32194765651) | **pass** | **pass** |

So both crashes and both fixes are demonstrated on `ubuntu-latest` and `macos-14` — and since the macOS runner is arm64, on both architectures.

Locally: full suite, race detector, and `verify-as-user.sh` green against **chdb-core v26.5.1.1 and v26.7.2.1**.

## Known gap, not in this PR

`Date`, `UUID`, `Decimal` and `Enum` columns cannot be read at all — they now fail with `could not read column "d" (DATE): unsupported type` instead of the older `could not cast to type: DATE`, but they still fail. A `Date` column is ordinary enough that this deserves its own change (`DATE` → `time.Time`, `UUID`/`ENUM` → string, `DECIMAL` → scaled string), which is a type-mapping decision rather than a crash fix.
