### PR TITLE
Handle embedded module tags in scheduled check

### DIFF
--- a/.github/workflows/engine-module-tag.yml
+++ b/.github/workflows/engine-module-tag.yml
@@ -71,14 +71,18 @@ jobs:
           failed=0
           for tag in $tags; do
             moddir=${tag%/*}
+            metadata="$moddir/engine_data.go"
+            if [ "${moddir##*/}" = "embedded" ]; then
+              metadata="$moddir/go.mod"
+            fi
             # The metadata as it is at that tag, not as it is on the default
             # branch, which carries placeholders.
-            if ! git checkout -q "$tag" -- "$moddir/engine_data.go" 2>/dev/null; then
-              echo "::error::$tag has no $moddir/engine_data.go"
+            if ! git checkout -q "$tag" -- "$metadata" 2>/dev/null; then
+              echo "::error::$tag has no $metadata"
               failed=1
               continue
             fi
             go run ./scripts/enginetag -verify "$tag" || failed=1
-            git checkout -q HEAD -- "$moddir/engine_data.go"
+            git checkout -q HEAD -- "$metadata"
           done
           exit "$failed"


### PR DESCRIPTION
## Summary

- let the scheduled `Engine module tag` check load `lib/embedded/go.mod` for embedded dispatch tags
- keep platform engine module tags on the existing `engine_data.go` metadata path
- allow the shared `enginetag -verify` logic to validate both tag shapes

## Why

`lib/embedded` is a dispatch module, not a platform engine module. It has no
`engine_data.go`; its version is validated through the platform module versions
declared in `go.mod`.

The push-time verifier already handles this, but the scheduled all-tags workflow
preloaded `engine_data.go` for every `lib/*` tag before calling the verifier. That
made every scheduled run fail on `lib/embedded/v0.260700.1`.

## Tests

- `GOCACHE=/private/tmp/chdb-go-fix.hLt8xp/go-build GOMODCACHE=/private/tmp/chdb-go-fix.hLt8xp/go-mod go test ./internal/enginetag ./scripts/enginetag`
- local equivalent of the scheduled all-tags loop, verifying:
  - `lib/darwin-amd64/v0.260700.1`
  - `lib/darwin-arm64/v0.260700.1`
  - `lib/embedded/v0.260700.1`
  - `lib/linux-amd64/v0.260700.1`
  - `lib/linux-arm64/v0.260700.1`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support `embedded` module directories in scheduled engine tag check
> Updates the shell script in [engine-module-tag.yml](https://github.com/chdb-io/chdb-go/pull/62/files#diff-bfb896a54da5ea27353780b6b31e61255c67deb49856fe72d3d93d592ebb7767) to read metadata from `go.mod` instead of `engine_data.go` when the module directory basename is `embedded`. All other module directories continue to use `engine_data.go`. The change introduces a `$metadata` variable that defaults to `$moddir/engine_data.go` and conditionally switches to `$moddir/go.mod` for `embedded` directories.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c435fc8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->