### PR TITLE
Keep a chDB database's authoritative state in object storage you own

### DIFF
--- a/.github/workflows/chdb.yml
+++ b/.github/workflows/chdb.yml
@@ -13,6 +13,15 @@ on:
 jobs:
   build_linux:
     runs-on: ubuntu-latest
+    # The durable suite's end-to-end tests need the management ABI, which
+    # arrived in the pinned engine. They skip without it, so that a developer
+    # on an older libchdb is not shown failures for it — but here the version
+    # is pinned, and a skip would mean lib.chdb.io fell back to
+    # releases/latest, which for a pre-release pin is an older engine. This
+    # turns that fallback into a failed job instead of a green one that tested
+    # nothing.
+    env:
+      CHDB_REQUIRE_DURABLE_ABI: "1"
     steps:
     - uses: actions/checkout@v4
     - name: Fetch library
@@ -35,6 +44,15 @@ jobs:
 
   build_mac:
     runs-on: macos-14
+    # The durable suite's end-to-end tests need the management ABI, which
+    # arrived in the pinned engine. They skip without it, so that a developer
+    # on an older libchdb is not shown failures for it — but here the version
+    # is pinned, and a skip would mean lib.chdb.io fell back to
+    # releases/latest, which for a pre-release pin is an older engine. This
+    # turns that fallback into a failed job instead of a green one that tested
+    # nothing.
+    env:
+      CHDB_REQUIRE_DURABLE_ABI: "1"
     steps:
     - uses: actions/checkout@v4
     - name: Fetch library

--- a/README.md
+++ b/README.md
@@ -292,6 +292,79 @@ db.SetMaxOpenConns(8)
 All connections in a process must share the same data path; opening a second,
 different data path while connections are still open returns an error.
 
+### Durable objects
+
+`chdb/durable` puts a chDB database's authoritative state in object storage you
+own — S3, R2, MinIO, or a directory — as a full checkpoint plus write-ahead-log
+segments, with one compare-and-set `head.json` that holds the manifest and the
+single-writer lease. Local MergeTree stays the hot working copy; the object is a
+folder of open-format files you can move between clouds, and read from the
+Python and Node bindings, which implement the same protocol.
+
+```go
+import "github.com/chdb-io/chdb-go/v2/chdb/durable"
+
+ns, err := durable.NewNamespace("s3://my-bucket/durable?region=eu-west-1",
+        durable.NamespaceOptions{Owner: "worker-1"})
+
+obj, existed, err := ns.Open(ctx, "tenant-123", durable.OpenOptions{Database: "mem"})
+defer obj.Close(ctx)
+
+if !existed {
+        _, err = obj.Execute(ctx, "CREATE TABLE events (id UInt64) ENGINE = MergeTree ORDER BY id")
+}
+ticket, err := obj.Execute(ctx, "INSERT INTO events VALUES (1)")
+err = obj.FlushThrough(ctx, ticket)   // now it survives losing this machine
+rows, err := obj.Query(ctx, "SELECT count() FROM events", "JSONEachRow")
+_, err = obj.Checkpoint(ctx)          // fold base + WAL into a fresh base
+```
+
+`Execute` means the statement ran locally and joined the WAL buffer — not that
+it left the machine. Durability is `Flush`, or `FlushThrough` for one
+statement's watermark. Because recovery re-executes logged SQL, log literals
+rather than `now()`, `rand()` or `generateUUIDv4()`; a checkpoint is the place
+for anything non-deterministic, since it snapshots actual state.
+
+Whether a statement may run is decided by ClickHouse's parser, not by this
+package: every `Query` and `Execute` is analysed first — how many statements,
+what class, does every write land in the object's own database, does the text
+embed a credential — and the answer is the gate. `BACKUP` and `RESTORE` are
+never assembled as text either. That needs **chdb-core v26.7.2-rc.2 or later**,
+where those three entry points were added; an older engine is refused at open
+rather than working partially. Note that the published [engine
+modules](#engine-modules) still carry v26.7.0, so a build using one needs
+`CHDB_LIB_PATH` or a machine install until they are repackaged.
+
+Two constraints are worth knowing before you design around it:
+
+- chdb-core binds one data path per process, so **one process holds one open
+  durable object at a time**. Fan-out across objects is sequential or spread
+  across worker processes.
+- The lease is *coordination*, not security. Access control is entirely your
+  object store's IAM: anyone who can write the prefix can read, modify or take
+  the lock. Give each tenant credentials scoped to its own prefix.
+
+Errors carry a frozen category, so a caller can branch on what happened:
+
+```go
+if errors.Is(err, durable.ErrLeaseHeld) { /* another writer is live */ }
+switch durable.CategoryOf(err) {
+case durable.CategoryCommitAmbiguous: // may or may not have committed
+case durable.CategoryCorrupt:         // a referenced object is missing or damaged
+}
+```
+
+The S3 backend uses only the standard library — `net/http` and a SigV4 signer —
+so importing `chdb-go` adds no cloud SDK to your `go.mod`. It covers the two
+operations the protocol needs and resolves credentials from explicit options,
+the standard environment variables, or `~/.aws/credentials`; for SSO or
+instance-role credentials, pass `durable.S3Options.Credentials` yourself or
+supply your own `durable.Backend`.
+
+The protocol is specified in `CHDB_DURABLE_V1_CONTRACT.md` in the
+[chdb](https://github.com/chdb-io/chdb) repository, which is the source of truth
+for all bindings.
+
 ### Golang API docs
 
 - See [lowApi.md](lowApi.md) for the low level APIs.

--- a/chdb-purego/admin.go
+++ b/chdb-purego/admin.go
@@ -1,0 +1,307 @@
+package chdbpurego
+
+import (
+	"errors"
+	"fmt"
+	"runtime"
+	"unsafe"
+)
+
+// The management corner of the C ABI: full database backup, restore, and
+// statement analysis, plus the engine's own version string.
+//
+// These three calls exist because a caller that manages a database cannot get
+// the answers anywhere else. Backup and restore take an identifier and a path
+// as separate arguments so that chDB builds the `BACKUP` / `RESTORE` AST with
+// its own quoting — a binding that concatenated the statement would be one
+// unusual database name away from running something else. Analysis is
+// ClickHouse's parser answering questions only a parser can answer: how many
+// executable statements a piece of text holds, and whether every persistent
+// write it performs lands in one named database. A prefix check or a regular
+// expression cannot see through `INSERT ... FORMAT` inline data and cannot
+// resolve an unqualified table name against the session's current database.
+//
+// They arrived in chdb-core v26.7.2-rc.2. On an older engine the symbols are
+// absent, and every entry point here returns ErrAdminABIUnavailable rather
+// than panicking inside purego at load time — the rest of the binding keeps
+// working, which is the whole reason the symbols are probed instead of
+// declared.
+
+// ErrAdminABIUnavailable reports that the loaded libchdb predates the backup,
+// restore and query-analysis symbols. Its message names the release that
+// introduced them, because the fix is always to move the engine.
+var ErrAdminABIUnavailable = errors.New(
+	"chdb: the loaded libchdb does not export chdb_backup_database_n, " +
+		"chdb_restore_database_n and chdb_classify_query_n; they were added in " +
+		"chdb-core v26.7.2-rc.2, so install or point CHDB_LIB_PATH at that release or later")
+
+// QueryClass says what a statement does to state that outlives it, as decided
+// by the ClickHouse parser. Values match chdb_query_class in the C ABI and
+// ascend by how restricted the statement is, so a batch classifies as the
+// maximum over its members.
+type QueryClass uint32
+
+const (
+	// QueryReadOnly covers SELECT, SHOW, DESCRIBE, EXPLAIN: leaves no trace.
+	QueryReadOnly QueryClass = 0
+	// QueryMutating covers INSERT, CREATE, ALTER, DROP and friends: changes a
+	// database, and `BACKUP DATABASE` captures the change.
+	QueryMutating QueryClass = 1
+	// QueryMutatingGlobal covers global UDFs, named collections, access
+	// entities and writes into `system`: persistent and replayable, but
+	// outside every database a checkpoint could capture.
+	QueryMutatingGlobal QueryClass = 2
+	// QueryControl covers USE, SET, SYSTEM, BACKUP, RESTORE, and statements
+	// writing outside the engine altogether.
+	QueryControl QueryClass = 3
+	// QueryUnknown means the text did not parse, or parsed into something this
+	// engine does not classify. A caller gating writes on the class must treat
+	// it as a refusal.
+	QueryUnknown QueryClass = 4
+)
+
+func (c QueryClass) String() string {
+	switch c {
+	case QueryReadOnly:
+		return "READ_ONLY"
+	case QueryMutating:
+		return "MUTATING"
+	case QueryMutatingGlobal:
+		return "MUTATING_GLOBAL"
+	case QueryControl:
+		return "CONTROL"
+	case QueryUnknown:
+		return "UNKNOWN"
+	}
+	return fmt.Sprintf("class %d", uint32(c))
+}
+
+// Analysis flag bits, matching chdb_query_analysis_flag.
+const (
+	analysisHasSecrets               uint32 = 1 << 0
+	analysisWritesOnlyTargetDatabase uint32 = 1 << 1
+	analysisChangesDatabaseLifecycle uint32 = 1 << 2
+)
+
+// QueryAnalysis is what ClassifyQuery reports: chdb_query_analysis_v1 with the
+// flag word already unpacked into named booleans.
+type QueryAnalysis struct {
+	// StatementCount is how many executable statements the text holds. Zero
+	// for empty input or text that did not parse; `a PARALLEL WITH b` counts
+	// as two, because both arms execute.
+	StatementCount uint32
+
+	// Class is what the statement does to state that outlives it.
+	Class QueryClass
+
+	// HasSecrets reports that the text carries a credential: a password, a
+	// named collection's key, an access key handed to a table function. Never
+	// set when Class is QueryUnknown, since nothing was proven about text that
+	// did not parse.
+	HasSecrets bool
+
+	// WritesOnlyTargetDatabase reports that every persistent write the
+	// statement performs lands in the database named in the call. Set only
+	// when the parser can prove it: a write to another database, to `system`,
+	// to a table function or to a file clears it, and a statement that writes
+	// nothing sets it vacuously. Never set when no target database was named.
+	WritesOnlyTargetDatabase bool
+
+	// ChangesDatabaseLifecycle reports that the statement creates, drops or
+	// renames a database rather than acting inside one.
+	ChangesDatabaseLifecycle bool
+}
+
+// queryAnalysisV1 mirrors chdb_query_analysis_v1. Its layout is the ABI, so
+// the fields stay in this order and at this width; the size the engine is told
+// about is sizeof this struct, which is what lets a newer engine fill only the
+// fields this build has room for.
+type queryAnalysisV1 struct {
+	structSize     uint32
+	statementCount uint32
+	flags          uint32
+	queryClass     uint32
+}
+
+// ChdbAdminConn is the management surface a connection offers when the engine
+// exports it.
+//
+// It is deliberately a second interface rather than three more methods on
+// ChdbConn: an interface in this package is something callers may implement
+// (a fake in a test, a wrapper that adds tracing), and widening ChdbConn
+// would break every one of them. Callers reach these methods with a type
+// assertion, which is also how they find out an engine is too old.
+type ChdbAdminConn interface {
+	// BackupDatabase writes a full archive of database to filePath.
+	//
+	// filePath must be absolute, its directory must already exist, and it must
+	// be inside the connection's `backups.allowed_path` — a connection that
+	// never set that option cannot write a backup anywhere. An existing
+	// destination is never overwritten; the call fails instead.
+	//
+	// The archive is always full. The C ABI also accepts a base archive to
+	// make the backup incremental, and that is deliberately not offered here:
+	// an incremental archive records the base's path as given, so it only
+	// restores on a machine where that path still holds the base.
+	BackupDatabase(database, filePath string) error
+
+	// RestoreDatabase restores database from an archive written by
+	// BackupDatabase. The path constraints match BackupDatabase's, and the
+	// archive must exist.
+	//
+	// RESTORE appends to an existing table rather than replacing it, so
+	// restore into a database that does not already hold the archive's tables.
+	// The connection's current database is left alone.
+	RestoreDatabase(database, filePath string) error
+
+	// ClassifyQuery says what sql would do, without running it. Nothing is
+	// executed and the session is untouched: no current database change, no
+	// settings change, no query log entry.
+	//
+	// targetDatabase names the database the caller considers its own and is
+	// what QueryAnalysis.WritesOnlyTargetDatabase is judged against; pass ""
+	// to skip that judgement, in which case the flag is never set.
+	//
+	// SQL that does not parse is reported as QueryUnknown with a statement
+	// count of zero and no error — what it is, is the answer.
+	ClassifyQuery(sql, targetDatabase string) (QueryAnalysis, error)
+}
+
+// Version returns the exact chdb_version() of the loaded engine, loading the
+// library if that has not happened yet.
+//
+// This is a property of the library rather than of a session, which is why it
+// takes no connection: a caller can establish whether an engine is new enough
+// before it opens anything.
+func Version() (string, error) {
+	if err := ensureLoaded(); err != nil {
+		return "", err
+	}
+	if chdbVersion == nil {
+		// chdb_version has been exported for far longer than the management
+		// symbols, so reaching this means something stranger than an old
+		// engine — say a stripped or partial build.
+		return "", errors.New("chdb: the loaded libchdb does not export chdb_version")
+	}
+	return chdbVersion(), nil
+}
+
+// AdminABIAvailable reports whether the loaded engine exports the backup,
+// restore and query-analysis symbols. It loads the library if needed.
+func AdminABIAvailable() (bool, error) {
+	if err := ensureLoaded(); err != nil {
+		return false, err
+	}
+	return adminABIAvailable(), nil
+}
+
+func adminABIAvailable() bool {
+	return chdbBackupDatabaseN != nil && chdbRestoreDatabaseN != nil && chdbClassifyQueryN != nil
+}
+
+// cString copies s into a NUL-terminated buffer and returns a pointer to it
+// with the length of s in bytes.
+//
+// Both halves are handed to the engine: the `_n` entry points take an explicit
+// length and read exactly that many bytes, so SQL holding a NUL byte survives.
+// The terminator is there only so the buffer is also a valid C string for
+// anything that treats it as one.
+//
+// An empty s yields a nil pointer and a zero length, which is how the ABI
+// spells "not given" for an optional argument.
+func cString(s string) (*byte, uint, []byte) {
+	if s == "" {
+		return nil, 0, nil
+	}
+	buf := make([]byte, len(s)+1)
+	copy(buf, s)
+	return &buf[0], uint(len(s)), buf
+}
+
+// resultError turns the chdb_result a management call returns into an error and
+// destroys it. The result carries the engine's own message, and it has to be
+// destroyed on both paths — a failed backup still allocates one.
+func resultError(res *chdb_result, what string) error {
+	if res == nil {
+		return fmt.Errorf("chdb: %s returned no result", what)
+	}
+	defer chdbDestroyQueryResult(res)
+	if msg := chdbResultError(res); msg != "" {
+		return fmt.Errorf("chdb: %s failed: %s", what, msg)
+	}
+	return nil
+}
+
+// Each of the three holds the connection's read lock for the whole native
+// call, the same as Query does. All of them dereference c.conn to reach the
+// engine, and a Close racing one of them would free that connection while the
+// engine is still inside it — a backup or a restore is long enough for the
+// window to be wide rather than theoretical.
+
+// BackupDatabase implements ChdbAdminConn.
+func (c *connection) BackupDatabase(database, filePath string) error {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.conn == nil {
+		return fmt.Errorf("invalid connection")
+	}
+	if !adminABIAvailable() {
+		return ErrAdminABIUnavailable
+	}
+	db, dbLen, dbBuf := cString(database)
+	fp, fpLen, fpBuf := cString(filePath)
+	// NULL base: V1 backups are always full. See BackupDatabase's contract.
+	res := chdbBackupDatabaseN(c.conn.internal_data, db, dbLen, fp, fpLen, nil, 0)
+	runtime.KeepAlive(dbBuf)
+	runtime.KeepAlive(fpBuf)
+	return resultError(res, "chdb_backup_database_n")
+}
+
+// RestoreDatabase implements ChdbAdminConn.
+func (c *connection) RestoreDatabase(database, filePath string) error {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.conn == nil {
+		return fmt.Errorf("invalid connection")
+	}
+	if !adminABIAvailable() {
+		return ErrAdminABIUnavailable
+	}
+	db, dbLen, dbBuf := cString(database)
+	fp, fpLen, fpBuf := cString(filePath)
+	res := chdbRestoreDatabaseN(c.conn.internal_data, db, dbLen, fp, fpLen)
+	runtime.KeepAlive(dbBuf)
+	runtime.KeepAlive(fpBuf)
+	return resultError(res, "chdb_restore_database_n")
+}
+
+// ClassifyQuery implements ChdbAdminConn.
+func (c *connection) ClassifyQuery(sql, targetDatabase string) (QueryAnalysis, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.conn == nil {
+		return QueryAnalysis{}, fmt.Errorf("invalid connection")
+	}
+	if !adminABIAvailable() {
+		return QueryAnalysis{}, ErrAdminABIUnavailable
+	}
+	out := queryAnalysisV1{structSize: uint32(unsafe.Sizeof(queryAnalysisV1{}))}
+	q, qLen, qBuf := cString(sql)
+	db, dbLen, dbBuf := cString(targetDatabase)
+	state := chdbClassifyQueryN(c.conn.internal_data, q, qLen, db, dbLen, &out)
+	runtime.KeepAlive(qBuf)
+	runtime.KeepAlive(dbBuf)
+	if state != 0 {
+		// CHDBError here means the call was malformed or the connection is
+		// closed, not that the SQL was bad — unparseable SQL succeeds and
+		// reports UNKNOWN.
+		return QueryAnalysis{}, fmt.Errorf("chdb: chdb_classify_query_n could not analyse the statement")
+	}
+	return QueryAnalysis{
+		StatementCount:           out.statementCount,
+		Class:                    QueryClass(out.queryClass),
+		HasSecrets:               out.flags&analysisHasSecrets != 0,
+		WritesOnlyTargetDatabase: out.flags&analysisWritesOnlyTargetDatabase != 0,
+		ChangesDatabaseLifecycle: out.flags&analysisChangesDatabaseLifecycle != 0,
+	}, nil
+}

--- a/chdb-purego/admin_test.go
+++ b/chdb-purego/admin_test.go
@@ -14,13 +14,7 @@ import (
 func adminConn(t *testing.T) (ChdbAdminConn, string) {
 	t.Helper()
 
-	available, err := AdminABIAvailable()
-	if err != nil {
-		t.Skipf("libchdb did not load: %v", err)
-	}
-	if !available {
-		t.Skip("libchdb predates the backup/restore/classify ABI (chdb-core v26.7.2-rc.2)")
-	}
+	requireAdminABI(t)
 
 	root := t.TempDir()
 	backups := filepath.Join(root, "backups")
@@ -54,9 +48,10 @@ func run(t *testing.T, conn ChdbAdminConn, sql string) {
 }
 
 func TestVersionIsAChdbRelease(t *testing.T) {
+	requireAdminABI(t)
 	version, err := Version()
 	if err != nil {
-		t.Skipf("libchdb did not load: %v", err)
+		t.Fatalf("libchdb did not load: %v", err)
 	}
 	// Not compared against a pin: the point is that the engine answers with
 	// something version-shaped, since it is what a durable object records as
@@ -221,4 +216,37 @@ func TestBackupQuotesTheDatabaseName(t *testing.T) {
 	if got := strings.TrimSpace(res.String()); got != "7" {
 		t.Fatalf("restored %q, want 7", got)
 	}
+}
+
+// requireAdminABI reports whether the loaded engine has the management ABI,
+// and decides what a missing one means.
+//
+// Absent, it is a skip: this package still works on an older libchdb and a
+// developer who has one installed should not see failures for it. Under
+// CHDB_REQUIRE_DURABLE_ABI it is a failure instead, which is what CI sets —
+// there the engine version is pinned, so a skip would mean the installer
+// quietly fell back to a release without the ABI. lib.chdb.io does exactly
+// that on a failed download: it retries against releases/latest, and the
+// pinned engine is a pre-release, so "latest" is an older one. A suite that is
+// green whether or not it ran is not a check.
+func requireAdminABI(t *testing.T) {
+	t.Helper()
+	available, err := AdminABIAvailable()
+	required := os.Getenv("CHDB_REQUIRE_DURABLE_ABI") != ""
+	if err != nil {
+		if required {
+			t.Fatalf("libchdb did not load: %v", err)
+		}
+		t.Skipf("libchdb did not load: %v", err)
+	}
+	if available {
+		return
+	}
+	version, _ := Version()
+	message := "the loaded libchdb predates the backup/restore/classify ABI " +
+		"(added in chdb-core v26.7.2-rc.2); it reports " + version
+	if required {
+		t.Fatal("CHDB_REQUIRE_DURABLE_ABI is set but " + message)
+	}
+	t.Skip(message)
 }

--- a/chdb-purego/admin_test.go
+++ b/chdb-purego/admin_test.go
@@ -1,0 +1,224 @@
+package chdbpurego
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// adminConn opens a connection whose backups are allowed inside a temporary
+// directory, and returns it with that directory. A connection that never set
+// `backups.allowed_path` cannot write a backup anywhere, so the option is not
+// optional for these tests.
+func adminConn(t *testing.T) (ChdbAdminConn, string) {
+	t.Helper()
+
+	available, err := AdminABIAvailable()
+	if err != nil {
+		t.Skipf("libchdb did not load: %v", err)
+	}
+	if !available {
+		t.Skip("libchdb predates the backup/restore/classify ABI (chdb-core v26.7.2-rc.2)")
+	}
+
+	root := t.TempDir()
+	backups := filepath.Join(root, "backups")
+	if err := os.MkdirAll(backups, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	conn, err := NewConnectionFromConnString(
+		filepath.Join(root, "data") + "?backups.allowed_path=" + backups)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(conn.Close)
+
+	admin, ok := conn.(ChdbAdminConn)
+	if !ok {
+		t.Fatal("connection does not implement ChdbAdminConn")
+	}
+	return admin, backups
+}
+
+func run(t *testing.T, conn ChdbAdminConn, sql string) {
+	t.Helper()
+	res, err := conn.(ChdbConn).Query(sql, "CSV")
+	if err != nil {
+		t.Fatalf("%s: %v", sql, err)
+	}
+	if res != nil {
+		res.Free()
+	}
+}
+
+func TestVersionIsAChdbRelease(t *testing.T) {
+	version, err := Version()
+	if err != nil {
+		t.Skipf("libchdb did not load: %v", err)
+	}
+	// Not compared against a pin: the point is that the engine answers with
+	// something version-shaped, since it is what a durable object records as
+	// its producer and its minimum reader.
+	if version == "" || !strings.ContainsRune(version, '.') {
+		t.Fatalf("chdb_version() returned %q, which is not a release", version)
+	}
+	t.Logf("engine version %s", version)
+}
+
+func TestClassifyQueryReportsWhatCoreDecides(t *testing.T) {
+	conn, _ := adminConn(t)
+	run(t, conn, "CREATE DATABASE IF NOT EXISTS mem")
+	run(t, conn, "CREATE TABLE IF NOT EXISTS mem.t (a Int32) ENGINE = MergeTree ORDER BY a")
+
+	cases := []struct {
+		name string
+		sql  string
+		want QueryAnalysis
+	}{
+		{
+			name: "select",
+			sql:  "SELECT 1",
+			want: QueryAnalysis{StatementCount: 1, Class: QueryReadOnly, WritesOnlyTargetDatabase: true},
+		},
+		{
+			name: "insert into the target database",
+			sql:  "INSERT INTO mem.t VALUES (1)",
+			want: QueryAnalysis{StatementCount: 1, Class: QueryMutating, WritesOnlyTargetDatabase: true},
+		},
+		{
+			name: "insert into another database",
+			sql:  "INSERT INTO other.t VALUES (1)",
+			want: QueryAnalysis{StatementCount: 1, Class: QueryMutating},
+		},
+		{
+			name: "two statements",
+			sql:  "INSERT INTO mem.t VALUES (1); INSERT INTO mem.t VALUES (2)",
+			want: QueryAnalysis{StatementCount: 2, Class: QueryMutating, WritesOnlyTargetDatabase: true},
+		},
+		{
+			name: "inline data holding a semicolon",
+			sql:  "INSERT INTO mem.t FORMAT CSV 1;2\n",
+			want: QueryAnalysis{StatementCount: 1, Class: QueryMutating, WritesOnlyTargetDatabase: true},
+		},
+		{
+			name: "database lifecycle",
+			sql:  "DROP DATABASE mem",
+			want: QueryAnalysis{
+				StatementCount: 1, Class: QueryMutating,
+				WritesOnlyTargetDatabase: true, ChangesDatabaseLifecycle: true,
+			},
+		},
+		{
+			name: "session control",
+			sql:  "SET max_threads = 1",
+			want: QueryAnalysis{StatementCount: 1, Class: QueryControl},
+		},
+		{
+			name: "global mutation",
+			sql:  "CREATE FUNCTION plus_one AS (x) -> x + 1",
+			want: QueryAnalysis{StatementCount: 1, Class: QueryMutatingGlobal},
+		},
+		{
+			name: "does not parse",
+			sql:  "this is not sql",
+			want: QueryAnalysis{StatementCount: 0, Class: QueryUnknown},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := conn.ClassifyQuery(tc.sql, "mem")
+			if err != nil {
+				t.Fatalf("classify: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("analysis of %q\n got %+v\nwant %+v", tc.sql, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClassifyQueryWithoutATargetNeverProvesTheDatabase(t *testing.T) {
+	conn, _ := adminConn(t)
+	got, err := conn.ClassifyQuery("SELECT 1", "")
+	if err != nil {
+		t.Fatalf("classify: %v", err)
+	}
+	if got.WritesOnlyTargetDatabase {
+		t.Fatal("no target database was named, so the flag must not be set")
+	}
+}
+
+func TestBackupAndRestoreRoundTrip(t *testing.T) {
+	conn, backups := adminConn(t)
+	run(t, conn, "CREATE DATABASE mem")
+	run(t, conn, "CREATE TABLE mem.t (a Int32) ENGINE = MergeTree ORDER BY a")
+	run(t, conn, "INSERT INTO mem.t VALUES (1), (2), (3)")
+
+	archive := filepath.Join(backups, "mem.tar.gz")
+	if err := conn.BackupDatabase("mem", archive); err != nil {
+		t.Fatalf("backup: %v", err)
+	}
+	if _, err := os.Stat(archive); err != nil {
+		t.Fatalf("backup produced no archive: %v", err)
+	}
+
+	// An archive names the database it came from, so it restores under that
+	// name and no other: `RESTORE DATABASE copy` from an archive of `mem`
+	// fails with BACKUP_ENTRY_NOT_FOUND. Dropping the database first is what
+	// gives restore the empty target it needs — and is why a durable object
+	// restores into a fresh scratch directory rather than over live state.
+	run(t, conn, "DROP DATABASE mem")
+	if err := conn.RestoreDatabase("mem", archive); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	res, err := conn.(ChdbConn).Query("SELECT sum(a) FROM mem.t", "CSV")
+	if err != nil {
+		t.Fatalf("query the restored database: %v", err)
+	}
+	defer res.Free()
+	if got := strings.TrimSpace(res.String()); got != "6" {
+		t.Fatalf("restored database holds %q, want 6", got)
+	}
+}
+
+func TestBackupRefusesToOverwrite(t *testing.T) {
+	conn, backups := adminConn(t)
+	run(t, conn, "CREATE DATABASE mem")
+
+	archive := filepath.Join(backups, "once.tar.gz")
+	if err := conn.BackupDatabase("mem", archive); err != nil {
+		t.Fatalf("first backup: %v", err)
+	}
+	if err := conn.BackupDatabase("mem", archive); err == nil {
+		t.Fatal("a second backup to the same path must fail rather than overwrite")
+	}
+}
+
+// A database name needing quotes is the case a binding that built the SQL
+// itself would get wrong, so it is the case worth asserting core handles.
+func TestBackupQuotesTheDatabaseName(t *testing.T) {
+	conn, backups := adminConn(t)
+	run(t, conn, "CREATE DATABASE `my-db`")
+	run(t, conn, "CREATE TABLE `my-db`.t (a Int32) ENGINE = MergeTree ORDER BY a")
+	run(t, conn, "INSERT INTO `my-db`.t VALUES (7)")
+
+	archive := filepath.Join(backups, "quoted.tar.gz")
+	if err := conn.BackupDatabase("my-db", archive); err != nil {
+		t.Fatalf("backup: %v", err)
+	}
+	run(t, conn, "DROP DATABASE `my-db`")
+	if err := conn.RestoreDatabase("my-db", archive); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+	res, err := conn.(ChdbConn).Query("SELECT a FROM `my-db`.t", "CSV")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer res.Free()
+	if got := strings.TrimSpace(res.String()); got != "7" {
+		t.Fatalf("restored %q, want 7", got)
+	}
+}

--- a/chdb-purego/binding.go
+++ b/chdb-purego/binding.go
@@ -103,6 +103,13 @@ var (
 	chdbResultStorageBytesRead func(result *chdb_result) uint64
 	chdbResultError            func(result *chdb_result) string
 
+	// Management ABI, added in chdb-core v26.7.2-rc.2. Bound only when the
+	// loaded engine exports it; see admin.go and bindAdminSymbols.
+	chdbVersion          func() string
+	chdbBackupDatabaseN  func(conn unsafe.Pointer, database *byte, databaseLen uint, filePath *byte, filePathLen uint, baseFilePath *byte, baseFilePathLen uint) *chdb_result
+	chdbRestoreDatabaseN func(conn unsafe.Pointer, database *byte, databaseLen uint, filePath *byte, filePathLen uint) *chdb_result
+	chdbClassifyQueryN   func(conn unsafe.Pointer, sql *byte, sqlLen uint, targetDatabase *byte, targetDatabaseLen uint, out *queryAnalysisV1) int32
+
 	// Process-wide signal handler control. See issue #30: by default libchdb
 	// installs its own SIGSEGV/SIGABRT/SIGBUS/SIGILL handlers when a
 	// connection is opened, which overwrites the Go runtime's handlers and
@@ -186,6 +193,8 @@ func bindSymbols(libchdb uintptr) {
 	purego.RegisterLibFunc(&chdbResultStorageBytesRead, libchdb, "chdb_result_storage_bytes_read")
 	purego.RegisterLibFunc(&chdbResultError, libchdb, "chdb_result_error")
 
+	bindAdminSymbols(libchdb)
+
 	// Signal handler protection (issue #30). The required API was added in
 	// libchdb v26.x via chdb-core#11. Pre-check the symbol with Dlsym so
 	// that older libchdb builds — which don't export
@@ -241,4 +250,40 @@ func guardSignalHandlers() func() {
 	}
 	saved := snapshotSignalHandlers()
 	return func() { restoreSignalHandlers(saved) }
+}
+
+// bindAdminSymbols binds the backup, restore and query-analysis entry points
+// when the loaded engine has them.
+//
+// Each symbol is probed with Dlsym first, the way the signal-handler API is,
+// because RegisterLibFunc panics on a missing symbol — and a panic here fires
+// during the first call that needs the engine at all, leaving a caller who
+// only wanted to run a SELECT on an older libchdb with a dead process and no
+// way to handle it. Probing turns "engine too old" into an error the one
+// caller who needs these symbols receives, which is what admin.go returns.
+//
+// chdb_version is probed alongside them even though it has been exported for
+// much longer, so that one code path covers every symbol this file resolves
+// by name rather than by declaration.
+func bindAdminSymbols(libchdb uintptr) {
+	if has(libchdb, "chdb_version") {
+		purego.RegisterLibFunc(&chdbVersion, libchdb, "chdb_version")
+	}
+	// All three or none: the durable control plane needs analysis to decide
+	// what it may run and backup/restore to move state, so an engine with a
+	// subset is no more usable than one with none, and binding a subset would
+	// only move the failure to a less obvious place.
+	if has(libchdb, "chdb_backup_database_n") &&
+		has(libchdb, "chdb_restore_database_n") &&
+		has(libchdb, "chdb_classify_query_n") {
+		purego.RegisterLibFunc(&chdbBackupDatabaseN, libchdb, "chdb_backup_database_n")
+		purego.RegisterLibFunc(&chdbRestoreDatabaseN, libchdb, "chdb_restore_database_n")
+		purego.RegisterLibFunc(&chdbClassifyQueryN, libchdb, "chdb_classify_query_n")
+	}
+}
+
+// has reports whether libchdb exports name.
+func has(libchdb uintptr, name string) bool {
+	sym, err := purego.Dlsym(libchdb, name)
+	return err == nil && sym != 0
 }

--- a/chdb.h
+++ b/chdb.h
@@ -12,6 +12,14 @@ extern "C" {
 
 #define CHDB_EXPORT __attribute__((visibility("default")))
 
+#define CHDB_VERSION "26.7.2-rc.2"
+
+/**
+ * Returns the version of the linked chDB library.
+ * @return Null-terminated version string, e.g. "26.7.2"
+ */
+CHDB_EXPORT const char * chdb_version(void);
+
 #ifndef CHDB_NO_DEPRECATED
 // WARNING: The following structs are deprecated and will be removed in a future version.
 struct local_result
@@ -50,13 +58,12 @@ struct local_result_v2
 
 /**
  * Connection structure for chDB
- * Contains server instance, connection state, and query processing queue
+ * Contains ChdbClient instance and connection state
  */
 struct chdb_conn
 {
-    void * server; /* ClickHouse LocalServer instance */
+    void * server; /* ChdbClient instance */
     bool connected; /* Connection state flag */
-    void * queue; /* Query processing queue */
 };
 
 typedef struct
@@ -65,6 +72,88 @@ typedef struct
 } chdb_streaming_result;
 
 #endif
+
+// Return state enumeration for chDB API functions
+typedef enum chdb_state
+{
+    CHDBSuccess = 0,
+    CHDBError = 1
+} chdb_state;
+
+// What a statement does to state that outlives it, as decided by the
+// ClickHouse parser -- see chdb_classify_query_n().
+//
+// The classes answer two questions a caller replaying statements has to keep
+// apart: does this change anything that outlives the statement, and would
+// `BACKUP DATABASE <db>` carry the change?
+//
+//                            outlives it?   `BACKUP DATABASE` carries it?
+//   READ_ONLY                     no              --
+//   MUTATING                      yes             yes
+//   MUTATING_GLOBAL               yes             NO
+//   CONTROL                    session only, or not replayable at all
+//
+// MUTATING_GLOBAL is the class that catches people out. `CREATE FUNCTION`,
+// `CREATE USER` and a named collection all change something real and are
+// worth replaying, but they live beside the databases rather than inside one,
+// so a checkpoint of the database does not hold them. A caller that files
+// them with the MUTATING statements and later checkpoints loses them without
+// an error -- the failure surfaces much later, somewhere else. Keep them
+// where a checkpoint cannot truncate them.
+//
+// Values ascend by how restricted the statement is, so a batch of statements
+// classifies as the maximum over its members.
+typedef enum chdb_query_class
+{
+    // SELECT, SHOW, DESCRIBE, EXPLAIN, EXISTS, CHECK: leaves no trace.
+    CHDB_QUERY_READ_ONLY = 0,
+    // INSERT, CREATE, ALTER, DROP, TRUNCATE, RENAME, UPDATE, DELETE, OPTIMIZE:
+    // changes a database, and `BACKUP DATABASE` captures the change.
+    CHDB_QUERY_MUTATING = 1,
+    // Global UDFs, named collections, workloads, resources, access management,
+    // and writes into the `system` database: persistent, replayable, and
+    // outside every database a checkpoint could capture.
+    CHDB_QUERY_MUTATING_GLOBAL = 2,
+    // USE, SET, ATTACH, DETACH, SYSTEM, BACKUP, RESTORE, KILL, transaction
+    // control, and statements writing outside the engine altogether
+    // (INTO OUTFILE, INSERT INTO FUNCTION): either session-scoped, so
+    // replaying makes no sense, or not something a caller should be issuing
+    // through a managed connection at all.
+    CHDB_QUERY_CONTROL = 3,
+    // Did not parse, or parsed into a statement this version does not classify.
+    // Callers gating writes on the class must treat it as a refusal.
+    CHDB_QUERY_UNKNOWN = 4
+} chdb_query_class;
+
+// Facts about a statement beyond its class -- see chdb_classify_query_n().
+typedef enum chdb_query_analysis_flag
+{
+    // The text carries a credential: a named collection's key, a password, an
+    // access key handed to a table function. Never set when the class is
+    // UNKNOWN, since nothing was proven about text that did not parse.
+    CHDB_QUERY_HAS_SECRETS = 1u << 0,
+    // Every persistent write the statement performs lands in the database the
+    // caller named. Set only when that can be proven: an unqualified name is
+    // resolved through the connection's current database first, and any write
+    // to another database, to `system`, to a table function, or to a file
+    // clears it. A statement that writes nothing sets it vacuously.
+    CHDB_QUERY_WRITES_ONLY_TARGET_DATABASE = 1u << 1,
+    // The statement creates, drops or renames a database rather than acting
+    // inside one. That is a change to the container, which a caller managing
+    // an object per database has to handle itself rather than log.
+    CHDB_QUERY_CHANGES_DATABASE_LIFECYCLE = 1u << 2
+} chdb_query_analysis_flag;
+
+// What chdb_classify_query_n() reports. Versioned by size: set struct_size to
+// sizeof the struct you compiled against, and a newer engine will fill only
+// the fields you have room for.
+typedef struct chdb_query_analysis_v1
+{
+    uint32_t struct_size;      // caller sets to sizeof(chdb_query_analysis_v1)
+    uint32_t statement_count;  // executable statements; PARALLEL WITH arms count
+    uint32_t flags;            // chdb_query_analysis_flag, OR-ed
+    uint32_t query_class;      // chdb_query_class, as a fixed-width ABI field
+} chdb_query_analysis_v1;
 
 // Opaque handle for query results.
 // Internal data structure managed by chDB implementation.
@@ -82,6 +171,32 @@ typedef struct chdb_connection_
 	void * internal_data;
 } * chdb_connection;
 
+// Holds an arrow array stream.
+typedef struct chdb_arrow_stream_
+{
+	void * internal_data;
+} * chdb_arrow_stream;
+
+// Holds an arrow schema.
+typedef struct chdb_arrow_schema_
+{
+	void * internal_data;
+} * chdb_arrow_schema;
+
+// Holds an arrow array.
+typedef struct chdb_arrow_array_
+{
+	void * internal_data;
+} * chdb_arrow_array;
+
+// Opaque handle for a streaming INSERT (chdb_stream_insert family).
+// Internal data structure managed by chDB implementation.
+// Users should only interact through API functions.
+typedef struct chdb_insert_stream_
+{
+	void * internal_data;
+} * chdb_insert_stream;
+
 #ifndef CHDB_NO_DEPRECATED
 // WARNING: The following interfaces are deprecated and will be removed in a future version.
 CHDB_EXPORT struct local_result * query_stable(int argc, char ** argv);
@@ -92,8 +207,17 @@ CHDB_EXPORT void free_result_v2(struct local_result_v2 * result);
 
 /**
  * Creates a new chDB connection.
- * Only one active connection is allowed per process.
- * Creating a new connection with different path requires closing existing connection.
+ * The engine uses one storage path per process: multiple connections to that
+ * same path may be open at once. Connecting with a different path requires
+ * closing all existing connections first.
+ *
+ * Arguments naming a ClickHouse query-level setting (--<setting>=<value>,
+ * e.g. --max_threads=4 or --output_format_json_quote_denormals=1) apply to
+ * this connection only, exactly as if it had executed SET <setting> = <value>:
+ * concurrent connections to the same path each keep their own settings.
+ * An invalid value for a known setting fails the connection. Server-level
+ * options (--path=..., --user_scripts_path=..., logging options, ...) are consumed by
+ * the connection that boots the engine and ignored afterwards.
  *
  * @param argc Number of command-line arguments
  * @param argv Command-line arguments array (--path=<db_path> to specify database location)
@@ -123,6 +247,21 @@ CHDB_EXPORT void close_conn(struct chdb_conn ** conn);
 CHDB_EXPORT struct local_result_v2 * query_conn(struct chdb_conn * conn, const char * query, const char * format);
 
 /**
+ * Executes a query on the given connection with explicit length parameters.
+ * @brief Thread-safe query execution with binary-safe string handling
+ * @param conn Connection to execute query on
+ * @param query SQL query string to execute (may contain null bytes)
+ * @param query_len Length of query string in bytes
+ * @param format Output format string (e.g., "CSV", default format)
+ * @param format_len Length of format string in bytes
+ * @return Query result structure containing output or error message
+ * @note Returns error result if connection is invalid or closed
+ * @note This function is binary-safe and can handle queries containing null bytes
+ */
+CHDB_EXPORT struct local_result_v2 *
+query_conn_n(struct chdb_conn * conn, const char * query, size_t query_len, const char * format, size_t format_len);
+
+/**
  * Executes a streaming query on the given connection.
  * @brief Initializes streaming query execution and returns result handle
  * @param conn Connection to execute query on
@@ -134,12 +273,28 @@ CHDB_EXPORT struct local_result_v2 * query_conn(struct chdb_conn * conn, const c
 CHDB_EXPORT chdb_streaming_result * query_conn_streaming(struct chdb_conn * conn, const char * query, const char * format);
 
 /**
+ * Executes a streaming query on the given connection with explicit length parameters.
+ * @brief Initializes streaming query execution with binary-safe string handling
+ * @param conn Connection to execute query on
+ * @param query SQL query string to execute (may contain null bytes)
+ * @param query_len Length of query string in bytes
+ * @param format Output format string (e.g., "CSV", default format)
+ * @param format_len Length of format string in bytes
+ * @return Streaming result handle containing query state or error message
+ * @note Returns error result if connection is invalid or closed
+ * @note This function is binary-safe and can handle queries containing null bytes
+ * @note Use chdb_streaming_fetch_result() to retrieve data chunks from the streaming query
+ */
+CHDB_EXPORT chdb_streaming_result *
+query_conn_streaming_n(struct chdb_conn * conn, const char * query, size_t query_len, const char * format, size_t format_len);
+
+/**
  * Retrieves error message from streaming result.
  * @brief Gets error message associated with streaming query execution
  * @param result Streaming result handle from query_conn_streaming()
  * @return Null-terminated error message string, or NULL if no error occurred
  */
- CHDB_EXPORT const char * chdb_streaming_result_error(chdb_streaming_result * result);
+CHDB_EXPORT const char * chdb_streaming_result_error(chdb_streaming_result * result);
 
 /**
  * Fetches next chunk of streaming results.
@@ -148,6 +303,14 @@ CHDB_EXPORT chdb_streaming_result * query_conn_streaming(struct chdb_conn * conn
  * @param result Streaming result handle from query_conn_streaming()
  * @return Materialized result chunk with data
  * @note Returns empty result when stream ends
+ * @note Fetching past the natural end of the stream is safe and idempotent:
+ *       every further call returns a fresh empty, non-error result. Fetching
+ *       after chdb_streaming_cancel_query() or after a mid-stream error still
+ *       returns an error result.
+ * @note Not thread-safe per connection: a connection runs one statement at a
+ *       time, so fetches (and cancel) on a streaming handle must be serialized
+ *       by the caller — do not fetch the same stream from multiple threads
+ *       concurrently.
  */
 CHDB_EXPORT struct local_result_v2 * chdb_streaming_fetch_result(struct chdb_conn * conn, chdb_streaming_result * result);
 
@@ -171,8 +334,17 @@ CHDB_EXPORT void chdb_streaming_cancel_query(struct chdb_conn * conn, chdb_strea
 
 /**
  * Creates a new chDB connection.
- * Only one active connection is allowed per process.
- * Creating a new connection with different path requires closing existing connection.
+ * The engine uses one storage path per process: multiple connections to that
+ * same path may be open at once. Connecting with a different path requires
+ * closing all existing connections first.
+ *
+ * Arguments naming a ClickHouse query-level setting (--<setting>=<value>,
+ * e.g. --max_threads=4 or --output_format_json_quote_denormals=1) apply to
+ * this connection only, exactly as if it had executed SET <setting> = <value>:
+ * concurrent connections to the same path each keep their own settings.
+ * An invalid value for a known setting fails the connection. Server-level
+ * options (--path=..., --user_scripts_path=..., logging options, ...) are consumed by
+ * the connection that boots the engine and ignored afterwards.
  *
  * @param argc Number of command-line arguments
  * @param argv Command-line arguments array (--path=<db_path> to specify database location)
@@ -202,6 +374,21 @@ CHDB_EXPORT chdb_connection * chdb_connect(int argc, char ** argv);
 CHDB_EXPORT chdb_result * chdb_query(chdb_connection conn, const char * query, const char * format);
 
 /**
+ * Executes a query on the given connection with explicit length parameters.
+ * @brief Thread-safe query execution with binary-safe string handling
+ * @param conn Connection to execute query on
+ * @param query SQL query string to execute (may contain null bytes)
+ * @param query_len Length of query string in bytes
+ * @param format Output format string (e.g., "CSV", default format)
+ * @param format_len Length of format string in bytes
+ * @return Query result structure containing output or error message
+ * @note Returns error result if connection is invalid or closed
+ * @note This function is binary-safe and can handle queries containing null bytes
+ * @note Use chdb_result_* functions to access result data and metadata
+ */
+CHDB_EXPORT chdb_result * chdb_query_n(chdb_connection conn, const char * query, size_t query_len, const char * format, size_t format_len);
+
+/**
  * @brief Execute a query with command-line interface
  * @param argc Argument count (same as main()'s argc)
  * @param argv Argument vector (same as main()'s argv)
@@ -221,12 +408,136 @@ CHDB_EXPORT chdb_result * chdb_query_cmdline(int argc, char ** argv);
 CHDB_EXPORT chdb_result * chdb_stream_query(chdb_connection conn, const char * query, const char * format);
 
 /**
+ * Executes a streaming query with explicit string lengths (binary-safe).
+ * @brief Initializes streaming query execution with specified buffer lengths
+ * @param conn Connection to execute query on
+ * @param query SQL query buffer (may contain null bytes)
+ * @param query_len Length of query buffer in bytes
+ * @param format Output format buffer (may contain null bytes)
+ * @param format_len Length of format buffer in bytes
+ * @return Streaming result handle containing query state or error message
+ * @note Strings do not need to be null-terminated
+ * @note Use this function when dealing with queries/formats containing null bytes
+ */
+CHDB_EXPORT chdb_result *
+chdb_stream_query_n(chdb_connection conn, const char * query, size_t query_len, const char * format, size_t format_len);
+
+/**
+ * Executes a query with server-side named parameter binding.
+ * @brief Binds {name:Type} placeholders before query execution; values are NOT interpolated into SQL.
+ * @param conn Connection to execute query on
+ * @param query SQL query string (NUL-terminated, e.g. "SELECT {x:Int64} AS v")
+ * @param format Output format string (e.g. "CSV", "JSON")
+ * @param param_names Array of param_count NUL-terminated parameter names (must match {name:Type} placeholders)
+ * @param param_values Array of param_count NUL-terminated parameter values
+ * @param param_count Number of name/value pairs in the arrays
+ * @return Query result structure containing output or error message
+ * @note Parameter values are passed to the engine as strings; the engine resolves the type from the
+ *       {name:Type} placeholder. This avoids SQL injection (no string interpolation) and enables
+ *       server-side query-plan caching.
+ * @note On duplicate parameter names, the last value wins (NameToNameMap semantics).
+ * @note Parameters are scoped to this single call and cleared on return (RAII).
+ * @note Use chdb_query_with_params_n for binary-safe values containing NUL bytes.
+ */
+CHDB_EXPORT chdb_result * chdb_query_with_params(
+    chdb_connection conn,
+    const char * query,
+    const char * format,
+    const char * const * param_names,
+    const char * const * param_values,
+    size_t param_count);
+
+/**
+ * Executes a query with server-side named parameter binding and explicit string lengths.
+ * @brief Binary-safe variant of chdb_query_with_params() — values may contain NUL bytes.
+ * @param conn Connection to execute query on
+ * @param query SQL query buffer (may contain NUL bytes)
+ * @param query_len Length of query buffer in bytes
+ * @param format Output format buffer (may contain NUL bytes)
+ * @param format_len Length of format buffer in bytes
+ * @param param_names Array of param_count parameter names (each name_lens[i] bytes long)
+ * @param param_name_lens Array of param_count byte lengths for param_names
+ * @param param_values Array of param_count parameter value buffers (each value_lens[i] bytes long)
+ * @param param_value_lens Array of param_count byte lengths for param_values
+ * @param param_count Number of name/value pairs
+ * @return Query result structure containing output or error message
+ * @note Strings do not need to be NUL-terminated.
+ */
+CHDB_EXPORT chdb_result * chdb_query_with_params_n(
+    chdb_connection conn,
+    const char * query,
+    size_t query_len,
+    const char * format,
+    size_t format_len,
+    const char * const * param_names,
+    const size_t * param_name_lens,
+    const char * const * param_values,
+    const size_t * param_value_lens,
+    size_t param_count);
+
+/**
+ * Executes a streaming query with server-side named parameter binding.
+ * @brief Initializes streaming query execution with parameter binding.
+ * @param conn Connection to execute query on
+ * @param query SQL query string (NUL-terminated)
+ * @param format Output format string (e.g. "CSV", "JSON")
+ * @param param_names Array of param_count NUL-terminated parameter names
+ * @param param_values Array of param_count NUL-terminated parameter values
+ * @param param_count Number of name/value pairs
+ * @return Streaming result handle containing query state or error message
+ * @note Parameters are bound on the connection before streaming starts and cleared once the
+ *       streaming initialization returns (the engine has already captured the parameter values).
+ */
+CHDB_EXPORT chdb_result * chdb_stream_query_with_params(
+    chdb_connection conn,
+    const char * query,
+    const char * format,
+    const char * const * param_names,
+    const char * const * param_values,
+    size_t param_count);
+
+/**
+ * Executes a streaming query with server-side named parameter binding and explicit string lengths.
+ * @brief Binary-safe variant of chdb_stream_query_with_params().
+ * @param conn Connection to execute query on
+ * @param query SQL query buffer (may contain NUL bytes)
+ * @param query_len Length of query buffer in bytes
+ * @param format Output format buffer (may contain NUL bytes)
+ * @param format_len Length of format buffer in bytes
+ * @param param_names Array of param_count parameter names
+ * @param param_name_lens Array of param_count byte lengths for param_names
+ * @param param_values Array of param_count parameter value buffers
+ * @param param_value_lens Array of param_count byte lengths for param_values
+ * @param param_count Number of name/value pairs
+ * @return Streaming result handle containing query state or error message
+ */
+CHDB_EXPORT chdb_result * chdb_stream_query_with_params_n(
+    chdb_connection conn,
+    const char * query,
+    size_t query_len,
+    const char * format,
+    size_t format_len,
+    const char * const * param_names,
+    const size_t * param_name_lens,
+    const char * const * param_values,
+    const size_t * param_value_lens,
+    size_t param_count);
+
+/**
  * Fetches next chunk of streaming results.
  * @brief Iterates through streaming query results
  * @param conn Active connection handle
  * @param result Streaming result handle from query_conn_streaming()
  * @return Materialized result chunk with data
  * @note Returns empty result when stream ends
+ * @note Fetching past the natural end of the stream is safe and idempotent:
+ *       every further call returns a fresh empty, non-error result. Fetching
+ *       after chdb_stream_cancel_query() or after a mid-stream error still
+ *       returns an error result.
+ * @note Not thread-safe per connection: a connection runs one statement at a
+ *       time, so fetches (and cancel) on a streaming handle must be serialized
+ *       by the caller — do not fetch the same stream from multiple threads
+ *       concurrently.
  */
 CHDB_EXPORT chdb_result * chdb_stream_fetch_result(chdb_connection conn, chdb_result * result);
 
@@ -243,6 +554,125 @@ CHDB_EXPORT void chdb_stream_cancel_query(chdb_connection conn, chdb_result * re
  * @param result The result handle to destroy
  */
 CHDB_EXPORT void chdb_destroy_query_result(chdb_result * result);
+
+//===--------------------------------------------------------------------===//
+// Streaming INSERT (write side)
+//===--------------------------------------------------------------------===//
+
+/**
+ * Begins a streaming INSERT on the given connection.
+ * @brief Write-side counterpart of chdb_stream_query(): send the INSERT, then push data in chunks
+ * @param conn Active connection handle
+ * @param query INSERT statement without FORMAT clause or inline data (e.g., "INSERT INTO t (a, b)")
+ * @param format Input format of the appended data (e.g., "CSV", "JSONEachRow", "Parquet")
+ * @return Insert stream handle, never NULL; check chdb_stream_insert_error() for init failure
+ * @note The connection accepts no other statement while the stream is open
+ */
+CHDB_EXPORT chdb_insert_stream chdb_stream_insert(chdb_connection conn, const char * query, const char * format);
+
+/**
+ * Begins a streaming INSERT with explicit string lengths (binary-safe).
+ * @brief Variant of chdb_stream_insert() with specified buffer lengths
+ * @param conn Active connection handle
+ * @param query INSERT statement without FORMAT clause or inline data
+ * @param query_len Length of the query string in bytes
+ * @param format Input format of the appended data
+ * @param format_len Length of the format string in bytes
+ * @return Insert stream handle, never NULL; check chdb_stream_insert_error() for init failure
+ */
+CHDB_EXPORT chdb_insert_stream chdb_stream_insert_n(
+    chdb_connection conn, const char * query, size_t query_len, const char * format, size_t format_len);
+
+/**
+ * Begins a streaming INSERT with server-side named parameter binding.
+ * @brief Variant of chdb_stream_insert() for INSERT statements with {name:Type}
+ *        placeholders, e.g. "INSERT INTO FUNCTION file({path:String}, {format:String}, {structure:String})"
+ * @param conn Active connection handle
+ * @param query INSERT statement without FORMAT clause or inline data
+ * @param format Input format of the appended data (e.g., "CSV", "JSONEachRow", "Parquet")
+ * @param param_names Array of param_count NUL-terminated parameter names
+ * @param param_values Array of param_count NUL-terminated parameter values
+ * @param param_count Number of name/value pairs
+ * @return Insert stream handle, never NULL; check chdb_stream_insert_error() for init failure
+ * @note Parameters are bound on the connection for the duration of stream
+ *       initialization and cleared once it returns (the engine has already
+ *       captured the parameter values).
+ */
+CHDB_EXPORT chdb_insert_stream chdb_stream_insert_with_params(
+    chdb_connection conn,
+    const char * query,
+    const char * format,
+    const char * const * param_names,
+    const char * const * param_values,
+    size_t param_count);
+
+/**
+ * Begins a streaming INSERT with named parameter binding and explicit string lengths.
+ * @brief Binary-safe variant of chdb_stream_insert_with_params().
+ * @param conn Active connection handle
+ * @param query INSERT statement buffer (may contain NUL bytes)
+ * @param query_len Length of query buffer in bytes
+ * @param format Input format buffer
+ * @param format_len Length of format buffer in bytes
+ * @param param_names Array of param_count parameter names
+ * @param param_name_lens Array of param_count byte lengths for param_names
+ * @param param_values Array of param_count parameter value buffers
+ * @param param_value_lens Array of param_count byte lengths for param_values
+ * @param param_count Number of name/value pairs
+ * @return Insert stream handle, never NULL; check chdb_stream_insert_error() for init failure
+ */
+CHDB_EXPORT chdb_insert_stream chdb_stream_insert_with_params_n(
+    chdb_connection conn,
+    const char * query,
+    size_t query_len,
+    const char * format,
+    size_t format_len,
+    const char * const * param_names,
+    const size_t * param_name_lens,
+    const char * const * param_values,
+    const size_t * param_value_lens,
+    size_t param_count);
+
+/**
+ * Appends one chunk of raw format-encoded data to the insert stream.
+ * @brief Pushes data to the streaming INSERT (binary-safe, may block for backpressure)
+ * @param stream Insert stream handle from chdb_stream_insert()
+ * @param data Chunk bytes in the stream's input format; copied, the caller retains ownership
+ * @param len Length of the chunk in bytes
+ * @return CHDBSuccess on success, CHDBError if the stream already failed or was finalized
+ */
+CHDB_EXPORT chdb_state chdb_stream_append(chdb_insert_stream stream, const void * data, size_t len);
+
+/**
+ * Finalizes the streaming INSERT and commits the data.
+ * @brief Signals end-of-input and returns write statistics
+ * @param stream Insert stream handle from chdb_stream_insert()
+ * @return Result with rows/bytes written, or an error; free with chdb_destroy_query_result()
+ * @note Does not free the stream handle; call chdb_destroy_insert_stream() as well
+ */
+CHDB_EXPORT chdb_result * chdb_stream_done(chdb_insert_stream stream);
+
+/**
+ * Cancels ongoing streaming INSERT.
+ * @brief Aborts the insert stream without committing (ClickHouse-default semantics, no rollback)
+ * @param stream Insert stream handle to cancel
+ * @note The handle is freed by chdb_destroy_insert_stream(), not here
+ */
+CHDB_EXPORT void chdb_stream_cancel_insert(chdb_insert_stream stream);
+
+/**
+ * Retrieves error message from the insert stream.
+ * @param stream The insert stream handle
+ * @return Null-terminated error description, NULL if no error
+ */
+CHDB_EXPORT const char * chdb_stream_insert_error(chdb_insert_stream stream);
+
+/**
+ * Destroys an insert stream handle and releases all associated resources.
+ * @param stream The insert stream handle to destroy
+ * @note Required for every handle, even on error paths; cancels first if not finalized
+ */
+CHDB_EXPORT void chdb_destroy_insert_stream(chdb_insert_stream stream);
 
 /**
  * Gets pointer to the result data buffer
@@ -294,11 +724,368 @@ CHDB_EXPORT uint64_t chdb_result_storage_rows_read(chdb_result * result);
 CHDB_EXPORT uint64_t chdb_result_storage_bytes_read(chdb_result * result);
 
 /**
+ * Gets rows written by the query (INSERT write progress)
+ * Note: includes rows written by cascaded materialized views, same semantics
+ * as X-ClickHouse-Summary.written_rows on the HTTP interface — not just the
+ * input rows accepted by the target table.
+ * @param result The query result handle
+ * @return Number of rows written, 0 for read-only queries
+ */
+CHDB_EXPORT uint64_t chdb_result_rows_written(chdb_result * result);
+
+/**
+ * Gets bytes written by the query (INSERT write progress)
+ * Note: includes bytes written by cascaded materialized views, same semantics
+ * as X-ClickHouse-Summary.written_bytes on the HTTP interface.
+ * @param result The query result handle
+ * @return Number of bytes written, 0 for read-only queries
+ */
+CHDB_EXPORT uint64_t chdb_result_bytes_written(chdb_result * result);
+
+/**
  * Retrieves error message from query execution
  * @param result The query result handle
  * @return Null-terminated error description, NULL if no error
  */
 CHDB_EXPORT const char * chdb_result_error(chdb_result * result);
+
+//===--------------------------------------------------------------------===//
+// Arrow Integration
+//===--------------------------------------------------------------------===//
+
+/**
+ * Options controlling Arrow C Data Interface output (chdb_query_arrow family).
+ * Pass NULL to any chdb_query_arrow / chdb_stream_query_arrow variant for
+ * the default contract (unsupported_as_binary=0,
+ * low_cardinality_as_dictionary=0, string_as_string=1).
+ *
+ * Type mapping note: DateTime columns export as Arrow uint32 (Unix
+ * seconds), matching ClickHouse's format="ArrowStream" behavior — the
+ * timezone is not carried on the Arrow type. Callers that want a
+ * timezone-tagged Arrow timestamp should request DateTime64 in SQL,
+ * e.g. `SELECT toDateTime64(col, 0, 'UTC')`, which the kernel maps to
+ * arrow::timestamp(SECOND, 'UTC').
+ *
+ * - unsupported_as_binary: 0 (default) throws UNKNOWN_TYPE for types with
+ *   no faithful Arrow mapping (JSON/Object, Dynamic, AggregateFunction).
+ *   1 silently degrades them to arrow::binary() like the engine default.
+ * - low_cardinality_as_dictionary: 0 (default) materializes LowCardinality
+ *   columns to their base type T. 1 emits an Arrow dictionary array
+ *   (requires consumer to handle cross-batch dictionary stability).
+ * - string_as_string: 1 (default) emits Arrow utf8 for String columns.
+ *   0 emits Arrow binary.
+ */
+typedef struct chdb_arrow_options
+{
+    int unsupported_as_binary;
+    int low_cardinality_as_dictionary;
+    int string_as_string;
+} chdb_arrow_options;
+
+/**
+ * Executes a query and exports the entire result as an Arrow C Data
+ * Interface stream into the caller-allocated out_stream. Zero-copy where
+ * possible (no IPC serialization, no lz4 round-trip).
+ *
+ * Ownership: out_stream is filled and ownership of its release() callback
+ * transfers to the caller. The underlying ClickHouse buffers are kept
+ * alive by the stream's private_data and are released atomically when the
+ * caller invokes out_stream->release(out_stream).
+ *
+ * @param conn Active connection
+ * @param query Null-terminated SQL query
+ * @param out_stream Caller-allocated ArrowArrayStream (struct from arrow/c/abi.h)
+ * @param options Knobs controlling type mapping; pass NULL for defaults
+ * @return chdb_result with elapsed/rows_read/bytes_read/storage_* metrics or
+ *         an error (buffer/length are NULL/0 — the data is in out_stream)
+ */
+CHDB_EXPORT chdb_result * chdb_query_arrow(
+    chdb_connection conn, const char * query,
+    chdb_arrow_stream out_stream, const chdb_arrow_options * options);
+
+/**
+ * Binary-safe variant of chdb_query_arrow with explicit query length.
+ */
+CHDB_EXPORT chdb_result * chdb_query_arrow_n(
+    chdb_connection conn, const char * query, size_t query_len,
+    chdb_arrow_stream out_stream, const chdb_arrow_options * options);
+
+/**
+ * Initializes a streaming Arrow query and returns a stream handle. Each
+ * subsequent chdb_stream_fetch_arrow() call pulls one record batch with a
+ * stable schema across the lifetime of the stream. Cancel/destroy via the
+ * shared chdb_stream_cancel_query / chdb_destroy_query_result functions.
+ */
+CHDB_EXPORT chdb_result * chdb_stream_query_arrow(
+    chdb_connection conn, const char * query,
+    const chdb_arrow_options * options);
+
+/**
+ * Binary-safe variant of chdb_stream_query_arrow with explicit query length.
+ */
+CHDB_EXPORT chdb_result * chdb_stream_query_arrow_n(
+    chdb_connection conn, const char * query, size_t query_len,
+    const chdb_arrow_options * options);
+
+/**
+ * chdb_stream_query_arrow() with server-side {name:Type} parameter binding
+ * (chdb_query_with_params semantics, no SQL interpolation). Parameters are
+ * bound before streaming init and cleared once it returns; fetch, cancel
+ * and destroy work exactly like chdb_stream_query_arrow().
+ */
+CHDB_EXPORT chdb_result * chdb_stream_query_arrow_with_params(
+    chdb_connection conn, const char * query,
+    const chdb_arrow_options * options,
+    const char * const * param_names,
+    const char * const * param_values,
+    size_t param_count);
+
+/**
+ * Binary-safe variant of chdb_stream_query_arrow_with_params.
+ */
+CHDB_EXPORT chdb_result * chdb_stream_query_arrow_with_params_n(
+    chdb_connection conn, const char * query, size_t query_len,
+    const chdb_arrow_options * options,
+    const char * const * param_names,
+    const size_t * param_name_lens,
+    const char * const * param_values,
+    const size_t * param_value_lens,
+    size_t param_count);
+
+/**
+ * Pulls the next record batch from a streaming Arrow query into the
+ * caller-allocated out_batch (a single-batch ArrowArrayStream). When the
+ * stream is exhausted out_batch->get_next() will return a released array
+ * on first call. Schema and (if enabled) LowCardinality dictionaries stay
+ * stable across all fetches because the converter and cached dictionary
+ * values are persisted on the stream handle.
+ *
+ * @param conn Active connection
+ * @param stream_result Stream handle from chdb_stream_query_arrow{,_n}
+ * @param out_batch Caller-allocated ArrowArrayStream filled with one batch
+ * @return CHDBSuccess on success, CHDBError on protocol error
+ */
+CHDB_EXPORT chdb_state chdb_stream_fetch_arrow(
+    chdb_connection conn, chdb_result * stream_result,
+    chdb_arrow_stream out_batch);
+
+/**
+ * Registers an Arrow stream as an arrow stream table function with the given name
+ * @param conn The connection on which to execute the registration
+ * @param table_name Name to register for the arrow stream table function
+ * @param arrow_stream chdb Arrow stream handle
+ * @return CHDBSuccess on success, CHDBError on failure
+ */
+CHDB_EXPORT chdb_state chdb_arrow_scan(
+    chdb_connection conn, const char * table_name,
+    chdb_arrow_stream arrow_stream);
+
+/**
+ * Registers an Arrow array as an arrow stream table function with the given name
+ * @param conn The connection on which to execute the registration
+ * @param table_name Name to register for the arrow stream table function
+ * @param arrow_schema chdb Arrow schema handle
+ * @param arrow_array chdb Arrow array handle
+ * @return CHDBSuccess on success, CHDBError on failure
+ */
+CHDB_EXPORT chdb_state chdb_arrow_array_scan(
+    chdb_connection conn, const char * table_name,
+    chdb_arrow_schema arrow_schema, chdb_arrow_array arrow_array);
+
+/**
+ * Unregisters an arrow stream table function that was previously registered via chdb_arrow_scan
+ * @param conn The connection on which to execute the unregister operation
+ * @param table_name Name of the arrow stream table function to unregister
+ * @return CHDBSuccess on success, CHDBError on failure
+ */
+CHDB_EXPORT chdb_state chdb_arrow_unregister_table(chdb_connection conn, const char * table_name);
+
+//===--------------------------------------------------------------------===//
+// Backup, Restore and Statement Classification
+//===--------------------------------------------------------------------===//
+
+/**
+ * Backs a database up into a single archive file.
+ *
+ * The database name and the destination path are separate arguments and chDB
+ * quotes each one for the position it goes in, so a caller never builds
+ * `BACKUP ...` text and a name holding a backtick, a quote or a path holding
+ * an apostrophe cannot change what runs.
+ *
+ * The destination is subject to the `backups.allowed_path` configuration
+ * parameter, exactly as a hand-written `BACKUP ... TO File(...)` is; a
+ * connection that never set it cannot write a backup anywhere. Set it when
+ * connecting, e.g. `--backups.allowed_path=/var/lib/chdb/backups`.
+ *
+ * file_path must be absolute and its directory must already exist. Both are
+ * checked here rather than left to the engine: `backups.allowed_path`
+ * resolves a relative value against the data directory and a relative
+ * file_path then resolves against that, so a relative path lands somewhere no
+ * caller intended, and the engine reports a missing directory by naming the
+ * allow-list rather than the directory.
+ *
+ * An existing destination is never overwritten -- the call fails instead. Give
+ * every backup its own name and delete the ones you no longer want.
+ *
+ * Passing base_file_path makes the backup incremental against that archive:
+ * only what changed since it is written, and the new archive records the base
+ * it needs. Note that the recorded reference is the base's path as given here,
+ * so a caller that moves its archives between machines or into object storage
+ * has to keep that path reachable, or stay with full backups. NULL, or a
+ * length of zero, means a full backup.
+ *
+ * @param conn Connection whose engine performs the backup
+ * @param database Database name, unquoted (e.g. `my-db`, not `` `my-db` ``)
+ * @param database_len Length of database in bytes
+ * @param file_path Destination archive path, unquoted and absolute
+ * @param file_path_len Length of file_path in bytes
+ * @param base_file_path Existing archive to make this backup incremental
+ *                       against, unquoted and absolute; NULL for a full backup
+ * @param base_file_path_len Length of base_file_path in bytes; 0 for a full backup
+ * @return Query result; check chdb_result_error() and destroy it with
+ *         chdb_destroy_query_result() as for any other result
+ */
+CHDB_EXPORT chdb_result * chdb_backup_database_n(
+    chdb_connection conn,
+    const char * database,
+    size_t database_len,
+    const char * file_path,
+    size_t file_path_len,
+    const char * base_file_path,
+    size_t base_file_path_len);
+
+/**
+ * Restores a database from an archive written by chdb_backup_database_n().
+ *
+ * Quoting, the absolute-path requirement, the `backups.allowed_path`
+ * constraint and the result lifecycle match chdb_backup_database_n(); the
+ * archive itself must exist. The current database of the session is left
+ * alone: restoring into `mem` does not make `mem` current, so a caller that
+ * wants to query the restored database has to say so.
+ *
+ * An incremental archive names its base internally, so there is no base
+ * argument here -- but that name is the path the backup was written against,
+ * and the restore fails if nothing is there.
+ *
+ * RESTORE appends to an existing table rather than replacing it, so restore
+ * into a database that does not already hold the tables in the archive.
+ *
+ * @param conn Connection whose engine performs the restore
+ * @param database Database name, unquoted
+ * @param database_len Length of database in bytes
+ * @param file_path Source archive path, unquoted
+ * @param file_path_len Length of file_path in bytes
+ * @return Query result; check chdb_result_error() and destroy it with
+ *         chdb_destroy_query_result()
+ */
+CHDB_EXPORT chdb_result * chdb_restore_database_n(
+    chdb_connection conn,
+    const char * database,
+    size_t database_len,
+    const char * file_path,
+    size_t file_path_len);
+
+/**
+ * Says what a statement would do, without running it.
+ *
+ * Parses the SQL with the connection's own parser and settings -- the same
+ * parser that would execute it -- and reports what it found. Nothing is
+ * executed and the session is left untouched: no current database change, no
+ * settings change, no query log entry.
+ *
+ * The report answers the questions a caller has to settle before it decides
+ * whether to run a statement and whether to record it:
+ *
+ *   statement_count  How many executable statements the text holds. Zero for
+ *                    empty input or text that did not parse. A batch is more
+ *                    than one, and so is `a PARALLEL WITH b`, because both
+ *                    arms execute. A caller that logs statements one at a
+ *                    time needs this: only a count of one is a statement it
+ *                    can replay on its own.
+ *   query_class      What the statement does to state that outlives it; see
+ *                    chdb_query_class. A batch takes the maximum over its
+ *                    members.
+ *   flags            See chdb_query_analysis_flag.
+ *
+ * target_database names the database the caller considers its own, and is
+ * what CHDB_QUERY_WRITES_ONLY_TARGET_DATABASE is judged against. Pass NULL to
+ * skip that judgement, in which case the flag is never set.
+ *
+ * SQL that does not parse reports CHDB_QUERY_UNKNOWN with no flags and a count
+ * of zero, and still returns CHDBSuccess -- what it is, is the answer, not an
+ * error.
+ *
+ * @param conn Connection supplying the parser dialect, parser settings, and
+ *             the current database used to resolve unqualified names
+ * @param sql SQL text to analyse (may contain null bytes)
+ * @param sql_len Length of sql in bytes
+ * @param target_database The caller's own database, unquoted; may be NULL
+ * @param target_database_len Length of target_database in bytes
+ * @param out_analysis Receives the report. Set out_analysis->struct_size to
+ *                     sizeof(chdb_query_analysis_v1) before the call; every
+ *                     field that fits is written on success
+ * @return CHDBSuccess, or CHDBError if conn or out_analysis is null, the
+ *         connection is closed, or struct_size is smaller than this engine's
+ *         minimum
+ */
+CHDB_EXPORT chdb_state chdb_classify_query_n(
+    chdb_connection conn,
+    const char * sql,
+    size_t sql_len,
+    const char * target_database,
+    size_t target_database_len,
+    chdb_query_analysis_v1 * out_analysis);
+
+//===--------------------------------------------------------------------===//
+// Signal Handler Control
+//===--------------------------------------------------------------------===//
+
+/**
+ * Controls whether chDB installs process-wide signal handlers.
+ * Call BEFORE chdb_connect() or query_stable() to prevent chDB
+ * from installing process-wide signal handlers.
+ *
+ * @param enabled 1 to enable signal handlers (default), 0 to disable them
+ */
+CHDB_EXPORT void chdb_set_signal_handlers_enabled(int enabled);
+
+/**
+ * Resets all signal handlers installed by chDB back to SIG_DFL.
+ * Useful when signal handlers were already installed and need to be removed,
+ * e.g. to let the embedding process manage its own signal handling.
+ */
+CHDB_EXPORT void chdb_reset_signal_handlers(void);
+
+//===--------------------------------------------------------------------===//
+// Engine Shutdown
+//===--------------------------------------------------------------------===//
+
+/**
+ * Stops the engine: joins every thread chDB started, so that no chDB thread is
+ * alive once this returns. Call it before the host runs a teardown sequence of
+ * its own — global destructors, a finalizing language runtime, a sanitizer exit
+ * handler — which would otherwise race the still-running engine threads.
+ *
+ * Close every connection and destroy every result first. While a connection is
+ * still open this does nothing and returns CHDBError, because tearing the engine
+ * down under a live connection would leave it dangling.
+ *
+ * Once it starts, the library is closed for business for the rest of the process,
+ * whether or not it manages to stop every thread: chdb_connect() then fails and
+ * query_stable() must not be called. Calling this again is harmless -- it returns
+ * CHDBSuccess if the engine is already stopped, and otherwise retries.
+ *
+ * Safe to call from any thread and concurrently with itself and with
+ * chdb_connect(): callers are serialized, and a connect racing a shutdown either
+ * gets in first and is counted, or arrives later and is refused.
+ *
+ * Skipping it stays as safe as it has always been for a process that just exits:
+ * the threads left running are reaped by process exit.
+ *
+ * @return CHDBSuccess once no chDB thread is left running, CHDBError if a
+ *         connection is still open or some thread could not be stopped
+ */
+CHDB_EXPORT chdb_state chdb_shutdown(void);
 
 #ifdef __cplusplus
 }

--- a/chdb/admin.go
+++ b/chdb/admin.go
@@ -1,0 +1,113 @@
+package chdb
+
+import (
+	"fmt"
+
+	chdbpurego "github.com/chdb-io/chdb-go/v2/chdb-purego"
+)
+
+// Management operations on a session: full database backup, restore, and
+// saying what a statement would do without running it.
+//
+// They are separate from Query for the same reason they are separate in the C
+// ABI: each one takes its arguments as values rather than as SQL text, so the
+// engine builds the statement and does its own quoting. A caller managing a
+// database it did not name itself — a durable object, a snapshot tool, a
+// tenant-per-database service — cannot safely interpolate that name into
+// `BACKUP DATABASE ...`, and does not have to.
+//
+// All three need an engine from chdb-core v26.7.2-rc.2 or later. On anything
+// older they return chdbpurego.ErrAdminABIUnavailable, whose message names
+// that release.
+
+// EngineVersion returns the exact chdb_version() of the loaded engine, loading
+// libchdb if that has not happened yet. It needs no session, because the
+// version belongs to the library rather than to a connection.
+func EngineVersion() (string, error) {
+	return chdbpurego.Version()
+}
+
+// admin returns this session's management surface, or an error explaining why
+// there is not one. The caller holds no lock; each method takes the read lock
+// itself, the same as Query.
+func (s *Session) admin() (chdbpurego.ChdbAdminConn, error) {
+	if s.closed || s.conn == nil {
+		return nil, fmt.Errorf("chdb: management operation on a closed session")
+	}
+	admin, ok := s.conn.(chdbpurego.ChdbAdminConn)
+	if !ok {
+		return nil, chdbpurego.ErrAdminABIUnavailable
+	}
+	return admin, nil
+}
+
+// BackupDatabase writes a full archive of database to filePath.
+//
+// filePath must be absolute and its parent directory must already exist, and
+// it must sit inside the `backups.allowed_path` this session was opened with —
+// a session that never set it cannot write a backup anywhere:
+//
+//	sess, _ := chdb.NewSession("/var/lib/app/data?backups.allowed_path=/var/lib/app/backups")
+//	err := sess.BackupDatabase("orders", "/var/lib/app/backups/orders.tar.gz")
+//
+// An existing destination is never overwritten; the call fails instead. Give
+// every archive its own name.
+//
+// The archive is always a full backup. chDB can also write one incrementally
+// against an existing archive, and that is not offered here: such an archive
+// records the base's path as it was given, so it restores only where that path
+// still holds the base — which rules out moving it to another machine or into
+// object storage.
+func (s *Session) BackupDatabase(database, filePath string) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	admin, err := s.admin()
+	if err != nil {
+		return err
+	}
+	return admin.BackupDatabase(database, filePath)
+}
+
+// RestoreDatabase restores database from an archive written by BackupDatabase.
+//
+// An archive names the database it was taken from, and restores under that
+// name and no other — restoring an archive of `orders` as `orders_copy` fails
+// rather than renaming it. RESTORE also appends to a table that already
+// exists, so the target must not already hold the archive's tables; the usual
+// shape is to restore into a fresh data directory. The session's current
+// database is left alone.
+func (s *Session) RestoreDatabase(database, filePath string) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	admin, err := s.admin()
+	if err != nil {
+		return err
+	}
+	return admin.RestoreDatabase(database, filePath)
+}
+
+// ClassifyQuery says what sql would do, without running it: how many
+// executable statements it holds, what class they fall into, whether the text
+// carries a credential, and whether every persistent write lands in
+// targetDatabase.
+//
+// The answers come from ClickHouse's own parser with this session's settings
+// and current database, which is the only thing that can give them. A prefix
+// check cannot see through `INSERT ... FORMAT` inline data, and no amount of
+// pattern matching resolves an unqualified table name.
+//
+// Nothing is executed and the session is untouched: no current database
+// change, no settings change, no query log entry. Pass "" for targetDatabase
+// to skip the write-target judgement, in which case
+// QueryAnalysis.WritesOnlyTargetDatabase is never set. SQL that does not parse
+// is reported as chdbpurego.QueryUnknown with a statement count of zero and no
+// error — what it is, is the answer.
+func (s *Session) ClassifyQuery(sql, targetDatabase string) (chdbpurego.QueryAnalysis, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	admin, err := s.admin()
+	if err != nil {
+		return chdbpurego.QueryAnalysis{}, err
+	}
+	return admin.ClassifyQuery(sql, targetDatabase)
+}

--- a/chdb/durable/backend.go
+++ b/chdb/durable/backend.go
@@ -1,0 +1,150 @@
+package durable
+
+import (
+	"context"
+	"io"
+)
+
+// The object-storage contract every durable backend must satisfy
+// (contract §5.1).
+//
+// The interface is small on purpose. Only two properties are load-bearing,
+// and both are properties a provider either has or does not:
+//
+//  1. **Real conditional operations.** PutBytesIfAbsent must be an atomic
+//     create and ReplaceIfMatch an atomic compare-and-swap. Simulating either
+//     with a read followed by a write is not a weaker implementation, it is a
+//     broken one: the window between the two is exactly where two writers
+//     both conclude they are the only writer.
+//  2. **Streaming.** A checkpoint is a full database archive. Requiring it to
+//     pass through a []byte puts a ceiling on database size that has nothing
+//     to do with the database. So checkpoints move as files and readers; only
+//     the head and WAL segments — both bounded by the protocol — move as
+//     bytes.
+//
+// A third property is expressed in the return values rather than the methods:
+// every mutating call can answer "ambiguous". A request whose response was
+// lost is not a failure, and reporting it as one would make a caller retry a
+// commit that already happened. The state machine resolves ambiguity by
+// re-reading (contract §5.8), which is only possible if the backend admits it.
+//
+// Deleting is absent by design: V1 has no destroy and no garbage collection,
+// so nothing in the protocol has the authority to remove an object.
+//
+// Every method takes a context. What it can cancel is honest about the layer
+// it sits in: storage transfers and the boundaries between operation phases
+// respect it, and a native query already in flight does not — chDB's query API
+// has no cancellation to forward it to.
+
+// PutOutcome is the result of a conditional create.
+type PutOutcome int
+
+const (
+	// PutCreated means the object was created by this call.
+	PutCreated PutOutcome = iota
+	// PutAlreadyExists means the key was already there. For a key minted per
+	// attempt this means *we* created it earlier, on a try whose response
+	// never arrived.
+	PutAlreadyExists
+	// PutAmbiguous means the request may or may not have landed, and the
+	// caller has to re-read to find out.
+	PutAmbiguous
+)
+
+func (o PutOutcome) String() string {
+	switch o {
+	case PutCreated:
+		return "created"
+	case PutAlreadyExists:
+		return "already-exists"
+	case PutAmbiguous:
+		return "ambiguous"
+	}
+	return "unknown"
+}
+
+// ReplaceStatus is the result of a conditional replace.
+type ReplaceStatus int
+
+const (
+	// ReplaceDone means the compare-and-swap succeeded, and ReplaceOutcome
+	// carries the new token.
+	ReplaceDone ReplaceStatus = iota
+	// ReplaceNotMatched means the stored token no longer matched: someone else
+	// wrote first.
+	ReplaceNotMatched
+	// ReplaceAmbiguous means the outcome is unknown.
+	ReplaceAmbiguous
+)
+
+func (s ReplaceStatus) String() string {
+	switch s {
+	case ReplaceDone:
+		return "replaced"
+	case ReplaceNotMatched:
+		return "not-replaced"
+	case ReplaceAmbiguous:
+		return "ambiguous"
+	}
+	return "unknown"
+}
+
+// ReplaceOutcome is what a conditional replace reports. ETag is set only when
+// Status is ReplaceDone.
+type ReplaceOutcome struct {
+	Status ReplaceStatus
+	ETag   string
+}
+
+// Backend is a key/value store scoped to one object's prefix.
+//
+// Keys are relative, "/"-separated and validated by IsValidObjectKey: they
+// arrive from a head.json that came out of object storage, so they are
+// untrusted input, and an implementation that resolves them against a
+// directory must refuse a traversal rather than trust the caller.
+//
+// The "found" return distinguishes an absent key from a failure. It is a
+// separate value rather than a sentinel error because absence is a normal,
+// expected answer at nearly every call site — a cold object, a probe for a
+// head — and a caller that has to unwrap an error to learn something ordinary
+// eventually forgets to.
+type Backend interface {
+	// Describe is a human-readable location of the object prefix, for logs and
+	// errors. It must never contain credentials.
+	Describe() string
+
+	// GetBytes reads a whole object.
+	GetBytes(ctx context.Context, key string) (data []byte, found bool, err error)
+
+	// GetBytesWithETag reads a whole object together with its CAS token. The
+	// two must describe the same version: pairing an old body with a new token
+	// would let a compare-and-swap succeed against state nobody read.
+	GetBytesWithETag(ctx context.Context, key string) (data []byte, etag string, found bool, err error)
+
+	// OpenReader opens a byte stream for a potentially large object, so a
+	// checkpoint download never has to be resident. The caller closes it.
+	OpenReader(ctx context.Context, key string) (r io.ReadCloser, found bool, err error)
+
+	// PutBytesIfAbsent atomically creates an object from bytes. It never
+	// overwrites.
+	PutBytesIfAbsent(ctx context.Context, key string, data []byte) (PutOutcome, error)
+
+	// PutFileIfAbsent atomically creates an object by uploading a local file.
+	// It never overwrites.
+	//
+	// digest is the file's already-computed length and SHA-256 — the protocol
+	// requires both to be known before publishing, so they are passed rather
+	// than recomputed. A backend may use them to sign or verify the upload
+	// without a second pass over the file.
+	PutFileIfAbsent(ctx context.Context, key, localPath string, digest Digest) (PutOutcome, error)
+
+	// ReplaceIfMatch atomically replaces an object only if its stored token
+	// still equals etag.
+	ReplaceIfMatch(ctx context.Context, key string, data []byte, etag string) (ReplaceOutcome, error)
+}
+
+// BackendFactory builds a backend bound to one object's prefix.
+//
+// A namespace owns the factory and hands each object its own scoped backend,
+// so no code below the namespace can address a key outside its object.
+type BackendFactory func(ctx context.Context, objectID string) (Backend, error)

--- a/chdb/durable/backend_local.go
+++ b/chdb/durable/backend_local.go
@@ -1,0 +1,496 @@
+package durable
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Local-filesystem backend.
+//
+// This is the backend every test uses, and the one a developer gets from a
+// file:// namespace URL. That makes its conditional operations load-bearing
+// rather than a convenience: if they were approximations, every scenario that
+// passes here would prove nothing about the ones that run against a real
+// object store.
+//
+// # Conditional create
+//
+// link(2) is the primitive. It fails with EEXIST atomically, so writing to a
+// unique scratch file and then linking it into place is a true
+// create-if-absent — with the full contents already in the file at the moment
+// the name appears. Rename would have been simpler and wrong: it clobbers.
+//
+// # Conditional replace
+//
+// POSIX has no compare-and-swap on file contents, and the usual workarounds
+// are worse than the problem. A lock file turns a crash into a stuck object
+// that needs a staleness heuristic to recover; read-compare-rename has the
+// race it is meant to prevent.
+//
+// So the one mutable key is stored as a chain of immutable versions with a
+// symlink naming the current one:
+//
+//	head.json                -> symlink to .head-versions/7.json
+//	.head-versions/7.json    immutable
+//	.head-versions/6.json    immutable
+//
+// The ETag is the version number. Replacing against ETag v7 means creating
+// .head-versions/8.json, and link(2) lets exactly one racer do that — so the
+// EEXIST *is* the compare-and-swap failure. The symlink is then swapped in
+// with an atomic rename. A writer that wins the create and dies before the
+// rename has still legitimately won: a racer reading version 7 will fail to
+// create 8 and correctly report not-replaced.
+//
+// Version numbers only ever move forward, because creating version N+1
+// requires having read version N, which requires the symlink to already point
+// at it.
+//
+// # Reading what another binding wrote
+//
+// An object produced elsewhere has a plain head.json file and no version
+// chain. That reads fine — the ETag is then a content digest — and the first
+// ReplaceIfMatch adopts it into the chain: verify the plain file still hashes
+// to the ETag, create .head-versions/1.json exclusively, swap the symlink.
+// Adoption is atomic against other adopters, since only one can win the
+// create.
+//
+// # What this backend is for, and what that rules out
+//
+// Development and conformance. Recovery on another machine needs storage
+// neither machine owns, which is the S3 backend; a directory on one host
+// cannot be a remote authority. That scope decides which hardening belongs
+// here and which is noise.
+//
+// Two things it does defend, because they are real regardless of scope:
+//
+//   - **Keys out of head.json.** A head is fetched from object storage and is
+//     therefore untrusted input. A key containing "..", an absolute path or an
+//     empty component would steer a read or a publish outside the object, so
+//     pathFor refuses it.
+//   - **Losing data it said it had written.** Publishing without flushing is a
+//     correctness bug, and a test baseline that can silently roll back is not
+//     a baseline. The promise has to hold all the way down: flushing a file
+//     and its immediate parent is worthless if the parent is itself a fresh,
+//     unflushed entry in a directory above, so a publish that creates
+//     directories flushes the chain it created.
+//
+// What it does not defend against is a hostile local filesystem — a symlink
+// planted in the object prefix, say, to redirect a write. Whoever can do that
+// can already rewrite the objects directly, so guarding it buys no privilege
+// boundary.
+
+const (
+	// versionsDir is where the mutable key's version chain lives, relative to
+	// the object prefix. One directory, because V1 has exactly one mutable
+	// key. It is dot-prefixed so it cannot collide with a protocol key, and a
+	// reader that only understands plain files still sees a correct head.json
+	// through the symlink.
+	versionsDir = ".head-versions"
+	// tmpDir is scratch for partially written files.
+	tmpDir = ".tmp"
+)
+
+var versionTarget = regexp.MustCompile(`^` + regexp.QuoteMeta(versionsDir) + `/(\d+)\.json$`)
+
+func init() {
+	// file:///abs/path — the URL form. An opaque "local:/path" is accepted too
+	// for symmetry with the other bindings' namespace URLs.
+	local := func(_ context.Context, u *url.URL, objectID string) (Backend, error) {
+		root := u.Path
+		if root == "" {
+			root = u.Opaque
+		}
+		if !filepath.IsAbs(root) {
+			return nil, newError(CategoryBackend,
+				"durable: a %s namespace needs an absolute path, got %q", u.Scheme, u.String())
+		}
+		return NewLocalBackend(filepath.Join(root, objectID))
+	}
+	RegisterBackendScheme("file", local)
+	RegisterBackendScheme("local", local)
+}
+
+// LocalBackend stores one object as a directory.
+type LocalBackend struct {
+	root string
+}
+
+// NewLocalBackend binds a backend to one object's directory, creating it if
+// needed.
+func NewLocalBackend(root string) (*LocalBackend, error) {
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return nil, wrapError(CategoryBackend, err, "durable: cannot resolve %q", root)
+	}
+	if err := os.MkdirAll(abs, 0o700); err != nil {
+		return nil, wrapError(CategoryBackend, err, "durable: cannot create %q", abs)
+	}
+	return &LocalBackend{root: abs}, nil
+}
+
+// Describe implements Backend.
+func (b *LocalBackend) Describe() string { return "file://" + b.root }
+
+// pathFor resolves a protocol key under the object root, refusing anything
+// that is not a plain relative key.
+func (b *LocalBackend) pathFor(key string) (string, error) {
+	if !IsValidObjectKey(key) {
+		return "", newError(CategoryBackend, "durable: refusing to resolve invalid key %q", key)
+	}
+	full := filepath.Join(b.root, key)
+	// Join already cleans the path, and IsValidObjectKey has refused every
+	// component that could climb; this is the belt to that braces.
+	if full != b.root && !strings.HasPrefix(full, b.root+string(os.PathSeparator)) {
+		return "", newError(CategoryBackend, "durable: key %q escapes the object root", key)
+	}
+	return full, nil
+}
+
+// GetBytes implements Backend.
+func (b *LocalBackend) GetBytes(_ context.Context, key string) ([]byte, bool, error) {
+	path, err := b.pathFor(key)
+	if err != nil {
+		return nil, false, err
+	}
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, wrapError(CategoryBackend, err, "durable: cannot read %s", key)
+	}
+	return data, true, nil
+}
+
+// GetBytesWithETag implements Backend.
+//
+// For the mutable key the token is the version the symlink points at, so it
+// describes exactly the bytes returned. For anything else — and for a plain
+// head.json written by another binding — it is a content digest, which
+// describes the same version for the same reason.
+func (b *LocalBackend) GetBytesWithETag(ctx context.Context, key string) ([]byte, string, bool, error) {
+	path, err := b.pathFor(key)
+	if err != nil {
+		return nil, "", false, err
+	}
+	if key == HeadKey {
+		if version, ok, err := b.currentVersion(); err != nil {
+			return nil, "", false, err
+		} else if ok {
+			data, err := os.ReadFile(filepath.Join(b.root, versionsDir, strconv.FormatInt(version, 10)+".json"))
+			if err != nil {
+				// The symlink names a version that is not there. Reading it as
+				// absent would hand a fresh writer a cold object on top of a
+				// live one, so it is a failure instead.
+				return nil, "", false, wrapError(CategoryCorrupt, err,
+					"durable: %s points at version %d, which cannot be read", key, version)
+			}
+			return data, versionETag(version), true, nil
+		}
+	}
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, "", false, nil
+	}
+	if err != nil {
+		return nil, "", false, wrapError(CategoryBackend, err, "durable: cannot read %s", key)
+	}
+	return data, digestETag(digestOf(data)), true, nil
+}
+
+// OpenReader implements Backend.
+func (b *LocalBackend) OpenReader(_ context.Context, key string) (io.ReadCloser, bool, error) {
+	path, err := b.pathFor(key)
+	if err != nil {
+		return nil, false, err
+	}
+	f, err := os.Open(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, wrapError(CategoryBackend, err, "durable: cannot open %s", key)
+	}
+	return f, true, nil
+}
+
+// PutBytesIfAbsent implements Backend.
+func (b *LocalBackend) PutBytesIfAbsent(_ context.Context, key string, data []byte) (PutOutcome, error) {
+	path, err := b.pathFor(key)
+	if err != nil {
+		return PutAmbiguous, err
+	}
+	staged, err := b.stage(func(f *os.File) error {
+		_, err := f.Write(data)
+		return err
+	})
+	if err != nil {
+		return PutAmbiguous, err
+	}
+	defer os.Remove(staged)
+	return b.publish(staged, path, key)
+}
+
+// PutFileIfAbsent implements Backend.
+//
+// The digest is not used here: a local publish is a copy inside one
+// filesystem, so there is nothing to sign and nothing a second read of the
+// same bytes would establish. It is part of the interface because a remote
+// backend does need it.
+func (b *LocalBackend) PutFileIfAbsent(_ context.Context, key, localPath string, _ Digest) (PutOutcome, error) {
+	path, err := b.pathFor(key)
+	if err != nil {
+		return PutAmbiguous, err
+	}
+	source, err := os.Open(localPath)
+	if err != nil {
+		return PutAmbiguous, wrapError(CategoryBackend, err, "durable: cannot read %s", localPath)
+	}
+	defer source.Close()
+	staged, err := b.stage(func(f *os.File) error {
+		_, err := io.Copy(f, source)
+		return err
+	})
+	if err != nil {
+		return PutAmbiguous, err
+	}
+	defer os.Remove(staged)
+	return b.publish(staged, path, key)
+}
+
+// ReplaceIfMatch implements Backend.
+func (b *LocalBackend) ReplaceIfMatch(_ context.Context, key string, data []byte, etag string) (ReplaceOutcome, error) {
+	if key != HeadKey {
+		// Every other key in the protocol is immutable, so a conditional
+		// replace against one is a bug rather than a race. Reporting it as a
+		// failed compare-and-swap would send the caller into a reconcile that
+		// can never settle.
+		return ReplaceOutcome{}, newError(CategoryBackend,
+			"durable: %s is immutable; only %s can be replaced", key, HeadKey)
+	}
+	if _, err := b.pathFor(key); err != nil {
+		return ReplaceOutcome{}, err
+	}
+	if err := os.MkdirAll(filepath.Join(b.root, versionsDir), 0o700); err != nil {
+		return ReplaceOutcome{}, wrapError(CategoryBackend, err, "durable: cannot create the version chain")
+	}
+
+	next, err := b.nextVersionFor(etag)
+	if err != nil {
+		return ReplaceOutcome{}, err
+	}
+	if next == 0 {
+		return ReplaceOutcome{Status: ReplaceNotMatched}, nil
+	}
+
+	staged, err := b.stage(func(f *os.File) error {
+		_, err := f.Write(data)
+		return err
+	})
+	if err != nil {
+		return ReplaceOutcome{}, err
+	}
+	defer os.Remove(staged)
+
+	target := filepath.Join(b.root, versionsDir, strconv.FormatInt(next, 10)+".json")
+	outcome, err := b.publish(staged, target, key)
+	if err != nil {
+		return ReplaceOutcome{}, err
+	}
+	if outcome != PutCreated {
+		// Somebody else created this version. That is the compare-and-swap
+		// losing, told by the filesystem rather than guessed at.
+		return ReplaceOutcome{Status: ReplaceNotMatched}, nil
+	}
+
+	if err := b.pointHeadAt(next); err != nil {
+		// The version exists and is durable; only the pointer is behind. A
+		// reader still sees the previous head, and another writer holding the
+		// previous ETag will fail to create this same version — so the
+		// compare-and-swap has been won but not published, which is exactly
+		// what ambiguous means.
+		return ReplaceOutcome{Status: ReplaceAmbiguous}, nil
+	}
+	return ReplaceOutcome{Status: ReplaceDone, ETag: versionETag(next)}, nil
+}
+
+func versionETag(version int64) string {
+	return "v" + strconv.FormatInt(version, 10)
+}
+
+func digestETag(digest Digest) string {
+	return "sha256:" + digest.SHA256
+}
+
+// currentVersion reports which version the head symlink names, if it is a
+// chain at all.
+func (b *LocalBackend) currentVersion() (int64, bool, error) {
+	target, err := os.Readlink(filepath.Join(b.root, HeadKey))
+	if err != nil {
+		// Not a symlink, or not there: either way this is not a chain, and the
+		// caller falls back to reading a plain file.
+		return 0, false, nil
+	}
+	m := versionTarget.FindStringSubmatch(filepath.ToSlash(target))
+	if m == nil {
+		return 0, false, nil
+	}
+	version, err := strconv.ParseInt(m[1], 10, 64)
+	if err != nil {
+		return 0, false, nil
+	}
+	return version, true, nil
+}
+
+// nextVersionFor decides which version a replace against etag would create,
+// or 0 when the token no longer describes the stored head.
+func (b *LocalBackend) nextVersionFor(etag string) (int64, error) {
+	current, isChain, err := b.currentVersion()
+	if err != nil {
+		return 0, err
+	}
+	if isChain {
+		if etag != versionETag(current) {
+			return 0, nil
+		}
+		return current + 1, nil
+	}
+
+	// No chain yet: this is either a cold object created through
+	// PutBytesIfAbsent or one another binding wrote. Adopting it into the
+	// chain is only sound if the plain file is still exactly what the caller
+	// read.
+	data, err := os.ReadFile(filepath.Join(b.root, HeadKey))
+	if errors.Is(err, os.ErrNotExist) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, wrapError(CategoryBackend, err, "durable: cannot read %s", HeadKey)
+	}
+	if etag != digestETag(digestOf(data)) {
+		return 0, nil
+	}
+	return 1, nil
+}
+
+// pointHeadAt swaps the head symlink to name one version, atomically.
+func (b *LocalBackend) pointHeadAt(version int64) error {
+	link := filepath.Join(b.root, tmpDir, "head-"+uuid8()+".link")
+	if err := os.MkdirAll(filepath.Join(b.root, tmpDir), 0o700); err != nil {
+		return err
+	}
+	relative := versionsDir + "/" + strconv.FormatInt(version, 10) + ".json"
+	if err := os.Symlink(relative, link); err != nil {
+		return err
+	}
+	if err := os.Rename(link, filepath.Join(b.root, HeadKey)); err != nil {
+		os.Remove(link)
+		return err
+	}
+	return syncDir(b.root)
+}
+
+// stage writes content to a unique scratch file, flushed, and returns its
+// path. The caller publishes or removes it.
+func (b *LocalBackend) stage(write func(*os.File) error) (string, error) {
+	dir := filepath.Join(b.root, tmpDir)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", wrapError(CategoryBackend, err, "durable: cannot create a staging directory")
+	}
+	path := filepath.Join(dir, uuid8()+".part")
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return "", wrapError(CategoryBackend, err, "durable: cannot stage a write")
+	}
+	writeErr := write(f)
+	if writeErr == nil {
+		// Flush before the name appears. Publishing bytes that are only in the
+		// page cache would let a crash roll back a write this backend has
+		// already reported as done.
+		writeErr = f.Sync()
+	}
+	if closeErr := f.Close(); writeErr == nil {
+		writeErr = closeErr
+	}
+	if writeErr != nil {
+		os.Remove(path)
+		return "", wrapError(CategoryBackend, writeErr, "durable: cannot stage a write")
+	}
+	return path, nil
+}
+
+// publish links a staged file into place, reporting whether the name was free.
+func (b *LocalBackend) publish(staged, target, key string) (PutOutcome, error) {
+	created, err := ensureDirChain(b.root, filepath.Dir(target))
+	if err != nil {
+		return PutAmbiguous, wrapError(CategoryBackend, err, "durable: cannot create a directory for %s", key)
+	}
+	if err := os.Link(staged, target); err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return PutAlreadyExists, nil
+		}
+		return PutAmbiguous, wrapError(CategoryBackend, err, "durable: cannot publish %s", key)
+	}
+	// Flush the whole chain of directories this publish brought into
+	// existence, innermost first. Flushing only the immediate parent is
+	// worthless when the parent is itself a fresh, unflushed entry above.
+	for i := len(created) - 1; i >= 0; i-- {
+		if err := syncDir(created[i]); err != nil {
+			return PutAmbiguous, wrapError(CategoryBackend, err, "durable: cannot flush %s", created[i])
+		}
+	}
+	if err := syncDir(filepath.Dir(target)); err != nil {
+		return PutAmbiguous, wrapError(CategoryBackend, err, "durable: cannot flush the directory of %s", key)
+	}
+	return PutCreated, nil
+}
+
+// ensureDirChain creates dir under root and returns the directories it had to
+// create, outermost first.
+func ensureDirChain(root, dir string) ([]string, error) {
+	var missing []string
+	for current := dir; strings.HasPrefix(current, root) && current != root; current = filepath.Dir(current) {
+		if _, err := os.Stat(current); err == nil {
+			break
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return nil, err
+		}
+		missing = append([]string{current}, missing...)
+	}
+	if len(missing) == 0 {
+		return nil, nil
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, err
+	}
+	return missing, nil
+}
+
+// syncDir flushes a directory entry, so a name this backend created survives
+// power loss.
+func syncDir(dir string) error {
+	f, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if err := f.Sync(); err != nil {
+		// Some filesystems refuse fsync on a directory. That is not a reason
+		// to fail a publish whose data is already flushed; the name may just
+		// be less durable than the bytes.
+		var pathErr *os.PathError
+		if errors.As(err, &pathErr) {
+			return nil
+		}
+		return fmt.Errorf("fsync %s: %w", dir, err)
+	}
+	return nil
+}

--- a/chdb/durable/backend_local_test.go
+++ b/chdb/durable/backend_local_test.go
@@ -1,0 +1,314 @@
+package durable
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func localBackend(t *testing.T) *LocalBackend {
+	t.Helper()
+	backend, err := NewLocalBackend(filepath.Join(t.TempDir(), "object"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return backend
+}
+
+func TestLocalBackendConditionalCreate(t *testing.T) {
+	ctx := context.Background()
+	backend := localBackend(t)
+
+	outcome, err := backend.PutBytesIfAbsent(ctx, "wal/1-1-aaaa1111.jsonl", []byte("first\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome != PutCreated {
+		t.Fatalf("first create reported %s", outcome)
+	}
+
+	// Never overwrites. This is the property the whole immutable-key scheme
+	// rests on: a retry after a lost response must not replace what landed.
+	outcome, err = backend.PutBytesIfAbsent(ctx, "wal/1-1-aaaa1111.jsonl", []byte("second\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome != PutAlreadyExists {
+		t.Fatalf("second create reported %s, want already-exists", outcome)
+	}
+	data, found, err := backend.GetBytes(ctx, "wal/1-1-aaaa1111.jsonl")
+	if err != nil || !found {
+		t.Fatalf("read back: found=%v err=%v", found, err)
+	}
+	if string(data) != "first\n" {
+		t.Fatalf("the object holds %q; the second create overwrote it", data)
+	}
+}
+
+func TestLocalBackendReportsAMissingKey(t *testing.T) {
+	ctx := context.Background()
+	backend := localBackend(t)
+
+	if _, found, err := backend.GetBytes(ctx, HeadKey); err != nil || found {
+		t.Fatalf("a cold object should report the head as absent: found=%v err=%v", found, err)
+	}
+	if _, _, found, err := backend.GetBytesWithETag(ctx, HeadKey); err != nil || found {
+		t.Fatalf("found=%v err=%v", found, err)
+	}
+	if _, found, err := backend.OpenReader(ctx, "wal/1-1-aaaa1111.jsonl"); err != nil || found {
+		t.Fatalf("found=%v err=%v", found, err)
+	}
+}
+
+func TestLocalBackendCompareAndSwap(t *testing.T) {
+	ctx := context.Background()
+	backend := localBackend(t)
+
+	if _, err := backend.PutBytesIfAbsent(ctx, HeadKey, []byte(`{"v":1}`)); err != nil {
+		t.Fatal(err)
+	}
+	_, etag, found, err := backend.GetBytesWithETag(ctx, HeadKey)
+	if err != nil || !found {
+		t.Fatalf("found=%v err=%v", found, err)
+	}
+
+	outcome, err := backend.ReplaceIfMatch(ctx, HeadKey, []byte(`{"v":2}`), etag)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.Status != ReplaceDone {
+		t.Fatalf("replace reported %s", outcome.Status)
+	}
+
+	// The old token no longer matches, which is the fence: a superseded
+	// writer's next commit fails rather than clobbering.
+	stale, err := backend.ReplaceIfMatch(ctx, HeadKey, []byte(`{"v":3}`), etag)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stale.Status != ReplaceNotMatched {
+		t.Fatalf("a stale token reported %s, want not-replaced", stale.Status)
+	}
+
+	data, current, _, err := backend.GetBytesWithETag(ctx, HeadKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != `{"v":2}` {
+		t.Fatalf("the head holds %q; a stale replace got through", data)
+	}
+	if current != outcome.ETag {
+		t.Fatalf("the read token %q does not match the one the replace returned %q",
+			current, outcome.ETag)
+	}
+}
+
+// Only one racer may win, and it has to be told by the filesystem rather than
+// by a read-then-write window.
+func TestLocalBackendCompareAndSwapHasExactlyOneWinner(t *testing.T) {
+	ctx := context.Background()
+	backend := localBackend(t)
+
+	if _, err := backend.PutBytesIfAbsent(ctx, HeadKey, []byte(`{"v":0}`)); err != nil {
+		t.Fatal(err)
+	}
+	_, etag, _, err := backend.GetBytesWithETag(ctx, HeadKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const racers = 12
+	var (
+		wg      sync.WaitGroup
+		mu      sync.Mutex
+		winners int
+	)
+	for i := 0; i < racers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			outcome, err := backend.ReplaceIfMatch(ctx, HeadKey, []byte(`{"v":1}`), etag)
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				t.Errorf("racer %d: %v", i, err)
+				return
+			}
+			if outcome.Status == ReplaceDone {
+				winners++
+			}
+		}(i)
+	}
+	wg.Wait()
+	if winners != 1 {
+		t.Fatalf("%d racers won the compare-and-swap, want exactly 1", winners)
+	}
+}
+
+// A conditional create of the same unique key must also have one winner: it is
+// what the object layer relies on when two processes race to create a cold
+// object.
+func TestLocalBackendConditionalCreateHasExactlyOneWinner(t *testing.T) {
+	ctx := context.Background()
+	backend := localBackend(t)
+
+	const racers = 12
+	var (
+		wg      sync.WaitGroup
+		mu      sync.Mutex
+		winners int
+	)
+	for i := 0; i < racers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			outcome, err := backend.PutBytesIfAbsent(ctx, HeadKey, []byte(`{"v":0}`))
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			if outcome == PutCreated {
+				winners++
+			}
+		}()
+	}
+	wg.Wait()
+	if winners != 1 {
+		t.Fatalf("%d racers created the head, want exactly 1", winners)
+	}
+}
+
+// An object produced by another binding has a plain head.json and no version
+// chain. It must read, and the first replace must adopt it — otherwise a Go
+// writer could never take over an object a Python or Node writer created.
+func TestLocalBackendAdoptsAForeignPlainHead(t *testing.T) {
+	ctx := context.Background()
+	root := filepath.Join(t.TempDir(), "object")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, HeadKey), []byte(foreignHead), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	backend, err := NewLocalBackend(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, etag, found, err := backend.GetBytesWithETag(ctx, HeadKey)
+	if err != nil || !found {
+		t.Fatalf("found=%v err=%v", found, err)
+	}
+	if string(data) != foreignHead {
+		t.Fatal("the foreign head did not read back verbatim")
+	}
+	if _, _, err := parseHead(data); err != nil {
+		t.Fatalf("the foreign head does not parse: %v", err)
+	}
+
+	outcome, err := backend.ReplaceIfMatch(ctx, HeadKey, []byte(`{"adopted":true}`), etag)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.Status != ReplaceDone {
+		t.Fatalf("adopting a foreign head reported %s", outcome.Status)
+	}
+	// A reader that only understands plain files still sees a correct
+	// head.json, through the symlink.
+	after, err := os.ReadFile(filepath.Join(root, HeadKey))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != `{"adopted":true}` {
+		t.Fatalf("head.json holds %q after adoption", after)
+	}
+	// And the old digest token is now stale.
+	stale, err := backend.ReplaceIfMatch(ctx, HeadKey, []byte(`{"no":true}`), etag)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stale.Status != ReplaceNotMatched {
+		t.Fatalf("the pre-adoption token still matched: %s", stale.Status)
+	}
+}
+
+// A key out of a head is untrusted input, and the local backend resolves keys
+// against a directory — so a traversal would be a real escape.
+func TestLocalBackendRefusesKeysThatEscape(t *testing.T) {
+	ctx := context.Background()
+	backend := localBackend(t)
+
+	for _, key := range []string{"../escape", "/etc/passwd", "a/../../b", ""} {
+		if _, _, err := backend.GetBytes(ctx, key); err == nil {
+			t.Errorf("reading %q should be refused", key)
+		}
+		if _, err := backend.PutBytesIfAbsent(ctx, key, []byte("x")); err == nil {
+			t.Errorf("writing %q should be refused", key)
+		}
+	}
+}
+
+// Every key but the head is immutable, so a conditional replace against one is
+// a bug rather than a race. Reporting it as a failed compare-and-swap would
+// send the caller into a reconcile that can never settle.
+func TestLocalBackendRefusesToReplaceAnImmutableKey(t *testing.T) {
+	ctx := context.Background()
+	backend := localBackend(t)
+	if _, err := backend.ReplaceIfMatch(ctx, "wal/1-1-aaaa1111.jsonl", []byte("x"), "v1"); err == nil {
+		t.Fatal("replacing a WAL segment should be refused")
+	}
+}
+
+func TestLocalBackendPublishesAFile(t *testing.T) {
+	ctx := context.Background()
+	backend := localBackend(t)
+
+	source := filepath.Join(t.TempDir(), "archive.tar.gz")
+	body := []byte("pretend this is a chdb archive")
+	if err := os.WriteFile(source, body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	digest := digestOf(body)
+
+	outcome, err := backend.PutFileIfAbsent(ctx, "checkpoints/1-1-aaaa1111.tar.gz", source, digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome != PutCreated {
+		t.Fatalf("publishing a file reported %s", outcome)
+	}
+
+	reader, found, err := backend.OpenReader(ctx, "checkpoints/1-1-aaaa1111.tar.gz")
+	if err != nil || !found {
+		t.Fatalf("found=%v err=%v", found, err)
+	}
+	defer reader.Close()
+	observed, err := drainDigest(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if observed != digest {
+		t.Fatalf("the published file digests to %+v, want %+v", observed, digest)
+	}
+
+	// And again: unique keys mean this only happens on a retry, which must not
+	// replace what landed.
+	outcome, err = backend.PutFileIfAbsent(ctx, "checkpoints/1-1-aaaa1111.tar.gz", source, digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome != PutAlreadyExists {
+		t.Fatalf("republishing reported %s, want already-exists", outcome)
+	}
+}
+
+func TestLocalBackendDescribeCarriesNoSecret(t *testing.T) {
+	backend := localBackend(t)
+	if got := backend.Describe(); got == "" {
+		t.Fatal("Describe must say where the object is")
+	}
+}

--- a/chdb/durable/backend_s3.go
+++ b/chdb/durable/backend_s3.go
@@ -1,0 +1,510 @@
+package durable
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// S3-compatible backend — AWS S3, Cloudflare R2, MinIO, and anything else
+// that speaks the same two operations.
+//
+// This is the backend that makes the whole thing mean something. A local
+// directory cannot be a remote authority: when the machine holding it is gone,
+// so is the object. Recovering a database on a *different* machine needs the
+// head, the checkpoints and the WAL to live somewhere neither machine owns.
+//
+// # Conditional writes are the whole contract
+//
+// The protocol needs a real atomic create and a real atomic compare-and-swap;
+// simulating either with a HEAD followed by a PUT is not a weaker version, it
+// is the bug the protocol exists to prevent. S3 provides both as preconditions
+// on PutObject:
+//
+//	PutBytesIfAbsent  ->  PUT with If-None-Match: *
+//	ReplaceIfMatch    ->  PUT with If-Match: <etag>
+//
+// A precondition failure is a compare-and-swap outcome, not a transport error,
+// and it is reported as one. Everything the state machine does with
+// PutAlreadyExists and ReplaceNotMatched depends on that distinction being
+// made here rather than upstream.
+//
+// # No retries here, on purpose
+//
+// The object layer already knows how to settle an uncertain write: the keys it
+// publishes are unique per attempt, so it re-reads and compares a digest, and
+// its head commits re-read and look for their own intent. A retry loop in the
+// backend would sit underneath all of that and turn a request that landed into
+// a precondition failure — which is recoverable, but only because the layer
+// above never trusts a status code on its own. Leaving the retry to the layer
+// that can prove what happened keeps one deadline and one attempt count for
+// the whole commit, which is what the contract asks for (§5.8).
+//
+// # ETags stay opaque, and carry one assumption worth naming
+//
+// An S3 ETag is quoted, and it is only an MD5 for single-part uploads — not on
+// R2, not for multipart, not necessarily forever. It is stored and handed back
+// exactly as received and never parsed, which is what the contract requires.
+//
+// Being a content hash has a consequence a version counter would not have:
+// writing *byte-identical* content does not advance the ETag, so the token
+// used for that write stays valid afterwards and a second racer holding it can
+// also win. Durable is safe from this because every head write changes the
+// bytes — a lease acquisition moves the generation, a heartbeat moves
+// expires_at, and a flush or checkpoint moves manifest.seq. That is a real
+// dependency rather than a coincidence, so it is written down here: anything
+// that made a head write idempotent at the byte level would break
+// compare-and-swap on any content-hash-ETag provider.
+//
+// # V1 limits
+//
+// Single PutObject only, so an object caps at 5 GiB and a larger checkpoint
+// fails with limit_exceeded rather than silently truncating. Multipart upload
+// is the fix and is not here yet.
+
+// MaxSinglePutBytes is the ceiling for one PutObject. Beyond it a checkpoint
+// needs multipart upload.
+const MaxSinglePutBytes int64 = 5 * 1024 * 1024 * 1024
+
+// S3Options configures an S3-compatible backend.
+type S3Options struct {
+	Bucket string
+
+	// Prefix is the key prefix for this object, without a leading slash. It
+	// may be empty.
+	Prefix string
+
+	Region string
+
+	// Endpoint overrides the AWS endpoint, for MinIO, R2, or an S3-compatible
+	// gateway. It must include a scheme.
+	Endpoint string
+
+	// PathStyle puts the bucket in the path rather than the hostname. It
+	// defaults to true when Endpoint is set, because that is what a local
+	// MinIO wants, and false against AWS.
+	PathStyle *bool
+
+	// Credentials, when set, take precedence over the environment and the
+	// shared credentials file.
+	Credentials credentials
+
+	// HTTPClient overrides the client. The default has a 5-minute timeout,
+	// which a checkpoint of a large database may need to raise.
+	HTTPClient *http.Client
+}
+
+// S3Backend stores one object under a bucket prefix.
+type S3Backend struct {
+	bucket    string
+	prefix    string
+	region    string
+	endpoint  *url.URL
+	pathStyle bool
+	creds     credentials
+	client    *http.Client
+	describe  string
+}
+
+func init() {
+	// s3://<bucket>/<prefix>?region=&endpoint=&pathStyle=
+	//
+	// The query parameters are what make one implementation serve three
+	// providers:
+	//
+	//	AWS    s3://my-bucket/durable?region=eu-west-1
+	//	R2     s3://my-bucket/durable?region=auto&endpoint=https://<id>.r2.cloudflarestorage.com
+	//	MinIO  s3://my-bucket/durable?endpoint=http://127.0.0.1:9000
+	//
+	// Credentials are deliberately not among them. They come from the
+	// environment or the shared credentials file, because a namespace URL is
+	// the sort of thing that gets logged, put in a config file and pasted into
+	// an issue.
+	RegisterBackendScheme("s3", func(_ context.Context, u *url.URL, objectID string) (Backend, error) {
+		bucket := u.Host
+		if bucket == "" {
+			return nil, newError(CategoryBackend, "durable: an s3 namespace URL needs a bucket: %s", u)
+		}
+		basePrefix := strings.Trim(u.Path, "/")
+		prefix := objectID
+		if basePrefix != "" {
+			prefix = basePrefix + "/" + objectID
+		}
+		query := u.Query()
+		options := S3Options{
+			Bucket:   bucket,
+			Prefix:   prefix,
+			Region:   query.Get("region"),
+			Endpoint: query.Get("endpoint"),
+		}
+		if raw := query.Get("pathStyle"); raw != "" {
+			pathStyle := raw == "true" || raw == "1"
+			options.PathStyle = &pathStyle
+		}
+		return NewS3Backend(options)
+	})
+}
+
+// NewS3Backend binds a backend to one object's key prefix.
+func NewS3Backend(options S3Options) (*S3Backend, error) {
+	if options.Bucket == "" {
+		return nil, newError(CategoryBackend, "durable: the S3 backend needs a bucket")
+	}
+	creds, err := resolveCredentials(options.Credentials)
+	if err != nil {
+		return nil, err
+	}
+	region := options.Region
+	if region == "" {
+		region = os.Getenv("AWS_REGION")
+	}
+	if region == "" {
+		region = os.Getenv("AWS_DEFAULT_REGION")
+	}
+	if region == "" {
+		// The signature needs a region whether or not the provider cares which
+		// one. us-east-1 is what an S3-compatible store that ignores regions
+		// expects to be told.
+		region = "us-east-1"
+	}
+
+	backend := &S3Backend{
+		bucket: options.Bucket,
+		prefix: strings.Trim(options.Prefix, "/"),
+		region: region,
+		creds:  creds,
+		client: options.HTTPClient,
+	}
+	if backend.client == nil {
+		backend.client = &http.Client{Timeout: 5 * time.Minute}
+	}
+	if options.Endpoint != "" {
+		endpoint, err := url.Parse(options.Endpoint)
+		if err != nil {
+			return nil, wrapError(CategoryBackend, err, "durable: %q is not an endpoint URL",
+				options.Endpoint)
+		}
+		if endpoint.Scheme == "" || endpoint.Host == "" {
+			return nil, newError(CategoryBackend,
+				"durable: an S3 endpoint needs a scheme and a host, got %q", options.Endpoint)
+		}
+		backend.endpoint = endpoint
+		backend.pathStyle = true
+	}
+	if options.PathStyle != nil {
+		backend.pathStyle = *options.PathStyle
+	}
+	// Never the credentials, and never a presigned anything: this string ends
+	// up in error messages and logs.
+	backend.describe = "s3://" + backend.bucket + "/" + backend.prefix
+	return backend, nil
+}
+
+// Describe implements Backend.
+func (b *S3Backend) Describe() string { return b.describe }
+
+// keyFor prefixes a protocol key, refusing one that is not a plain relative
+// key.
+func (b *S3Backend) keyFor(key string) (string, error) {
+	if !IsValidObjectKey(key) {
+		return "", newError(CategoryBackend, "durable: refusing to resolve invalid key %q", key)
+	}
+	if b.prefix == "" {
+		return key, nil
+	}
+	return b.prefix + "/" + key, nil
+}
+
+// urlFor builds the request URL and the Host header value for a key.
+func (b *S3Backend) urlFor(key string) (*url.URL, string, error) {
+	fullKey, err := b.keyFor(key)
+	if err != nil {
+		return nil, "", err
+	}
+	out := &url.URL{}
+	switch {
+	case b.endpoint != nil && b.pathStyle:
+		out.Scheme = b.endpoint.Scheme
+		out.Host = b.endpoint.Host
+		out.Path = strings.TrimSuffix(b.endpoint.Path, "/") + "/" + b.bucket + "/" + fullKey
+	case b.endpoint != nil:
+		out.Scheme = b.endpoint.Scheme
+		out.Host = b.bucket + "." + b.endpoint.Host
+		out.Path = strings.TrimSuffix(b.endpoint.Path, "/") + "/" + fullKey
+	case b.pathStyle:
+		out.Scheme = "https"
+		out.Host = "s3." + b.region + ".amazonaws.com"
+		out.Path = "/" + b.bucket + "/" + fullKey
+	default:
+		out.Scheme = "https"
+		out.Host = b.bucket + ".s3." + b.region + ".amazonaws.com"
+		out.Path = "/" + fullKey
+	}
+	return out, out.Host, nil
+}
+
+// send signs and performs one request.
+func (b *S3Backend) send(req *http.Request, payloadHash string) (*http.Response, error) {
+	signRequest(req, b.creds, b.region, payloadHash, time.Now())
+	return b.client.Do(req)
+}
+
+func (b *S3Backend) newRequest(ctx context.Context, method, key string, body io.Reader) (*http.Request, error) {
+	target, host, err := b.urlFor(key)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, method, target.String(), body)
+	if err != nil {
+		return nil, wrapError(CategoryBackend, err, "durable: cannot build a request for %s", key)
+	}
+	req.Host = host
+	return req, nil
+}
+
+// GetBytes implements Backend.
+func (b *S3Backend) GetBytes(ctx context.Context, key string) ([]byte, bool, error) {
+	data, _, found, err := b.GetBytesWithETag(ctx, key)
+	return data, found, err
+}
+
+// GetBytesWithETag implements Backend.
+func (b *S3Backend) GetBytesWithETag(ctx context.Context, key string) ([]byte, string, bool, error) {
+	req, err := b.newRequest(ctx, http.MethodGet, key, nil)
+	if err != nil {
+		return nil, "", false, err
+	}
+	resp, err := b.send(req, sha256Hex(nil))
+	if err != nil {
+		return nil, "", false, b.transportError("reading "+key, err)
+	}
+	defer drainAndClose(resp)
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, "", false, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", false, b.statusError("reading "+key, resp)
+	}
+	etag := resp.Header.Get("ETag")
+	if etag == "" {
+		// An absent ETag leaves nothing to compare-and-swap against, so it is
+		// a hard failure rather than an empty token that silently never
+		// matches.
+		return nil, "", false, newError(CategoryBackend,
+			"durable: %s came back from %s without an ETag; this provider cannot support "+
+				"compare-and-swap", key, b.describe)
+	}
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, "", false, b.transportError("reading the body of "+key, err)
+	}
+	return data, etag, true, nil
+}
+
+// OpenReader implements Backend. The caller closes the reader, which is also
+// what releases the connection.
+func (b *S3Backend) OpenReader(ctx context.Context, key string) (io.ReadCloser, bool, error) {
+	req, err := b.newRequest(ctx, http.MethodGet, key, nil)
+	if err != nil {
+		return nil, false, err
+	}
+	resp, err := b.send(req, sha256Hex(nil))
+	if err != nil {
+		return nil, false, b.transportError("opening "+key, err)
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		drainAndClose(resp)
+		return nil, false, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		err := b.statusError("opening "+key, resp)
+		drainAndClose(resp)
+		return nil, false, err
+	}
+	return resp.Body, true, nil
+}
+
+// PutBytesIfAbsent implements Backend.
+func (b *S3Backend) PutBytesIfAbsent(ctx context.Context, key string, data []byte) (PutOutcome, error) {
+	if err := b.assertWithinSinglePut(key, int64(len(data))); err != nil {
+		return PutAmbiguous, err
+	}
+	req, err := b.newRequest(ctx, http.MethodPut, key, strings.NewReader(string(data)))
+	if err != nil {
+		return PutAmbiguous, err
+	}
+	req.ContentLength = int64(len(data))
+	req.Header.Set("If-None-Match", "*")
+	return b.conditionalPut(req, key, sha256Hex(data))
+}
+
+// PutFileIfAbsent implements Backend.
+func (b *S3Backend) PutFileIfAbsent(ctx context.Context, key, localPath string, digest Digest) (PutOutcome, error) {
+	if err := b.assertWithinSinglePut(key, digest.Size); err != nil {
+		return PutAmbiguous, err
+	}
+	f, err := os.Open(localPath)
+	if err != nil {
+		return PutAmbiguous, wrapError(CategoryBackend, err, "durable: cannot read %s", localPath)
+	}
+	defer f.Close()
+
+	req, err := b.newRequest(ctx, http.MethodPut, key, f)
+	if err != nil {
+		return PutAmbiguous, err
+	}
+	// Not optional: without a length the request goes out chunked, and SigV4
+	// header signing of a chunked body is a different signing scheme.
+	req.ContentLength = digest.Size
+	req.Header.Set("If-None-Match", "*")
+	// The digest the manifest records is the digest that signs the upload, so
+	// a checkpoint archive is never read twice.
+	return b.conditionalPut(req, key, digest.SHA256)
+}
+
+// ReplaceIfMatch implements Backend.
+func (b *S3Backend) ReplaceIfMatch(ctx context.Context, key string, data []byte, etag string) (ReplaceOutcome, error) {
+	if err := b.assertWithinSinglePut(key, int64(len(data))); err != nil {
+		return ReplaceOutcome{}, err
+	}
+	req, err := b.newRequest(ctx, http.MethodPut, key, strings.NewReader(string(data)))
+	if err != nil {
+		return ReplaceOutcome{}, err
+	}
+	req.ContentLength = int64(len(data))
+	req.Header.Set("If-Match", etag)
+
+	resp, err := b.send(req, sha256Hex(data))
+	if err != nil {
+		if isAmbiguousTransportError(err) {
+			return ReplaceOutcome{Status: ReplaceAmbiguous}, nil
+		}
+		return ReplaceOutcome{}, b.transportError("replacing "+key, err)
+	}
+	defer drainAndClose(resp)
+
+	if isPreconditionFailure(resp.StatusCode) {
+		return ReplaceOutcome{Status: ReplaceNotMatched}, nil
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		// The target is gone, so the compare-and-swap did not match. Reporting
+		// it as anything else would send the caller looking for its own intent
+		// in a head that no longer exists.
+		return ReplaceOutcome{Status: ReplaceNotMatched}, nil
+	}
+	if resp.StatusCode >= 500 {
+		return ReplaceOutcome{Status: ReplaceAmbiguous}, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return ReplaceOutcome{}, b.statusError("replacing "+key, resp)
+	}
+	newETag := resp.Header.Get("ETag")
+	if newETag == "" {
+		// The write landed but the new token is unknown, so the next
+		// compare-and-swap would have nothing to present. Re-reading is the
+		// honest way out.
+		return ReplaceOutcome{Status: ReplaceAmbiguous}, nil
+	}
+	return ReplaceOutcome{Status: ReplaceDone, ETag: newETag}, nil
+}
+
+func (b *S3Backend) conditionalPut(req *http.Request, key, payloadHash string) (PutOutcome, error) {
+	resp, err := b.send(req, payloadHash)
+	if err != nil {
+		if isAmbiguousTransportError(err) {
+			return PutAmbiguous, nil
+		}
+		return PutAmbiguous, b.transportError("creating "+key, err)
+	}
+	defer drainAndClose(resp)
+
+	switch {
+	case isPreconditionFailure(resp.StatusCode):
+		return PutAlreadyExists, nil
+	case resp.StatusCode >= 500:
+		return PutAmbiguous, nil
+	case resp.StatusCode == http.StatusOK:
+		return PutCreated, nil
+	default:
+		return PutAmbiguous, b.statusError("creating "+key, resp)
+	}
+}
+
+func (b *S3Backend) assertWithinSinglePut(key string, size int64) error {
+	if size > MaxSinglePutBytes {
+		return &Error{
+			Category: CategoryLimitExceeded,
+			Message: fmt.Sprintf("durable: %s is %d bytes, over the %d-byte ceiling for a single "+
+				"PutObject; multipart upload is not implemented, so checkpoint more often or "+
+				"reduce the database", key, size, MaxSinglePutBytes),
+			Limit:    MaxSinglePutBytes,
+			Observed: size,
+		}
+	}
+	return nil
+}
+
+// isPreconditionFailure reports whether a status means someone else got there
+// first.
+//
+// S3 answers 412 for If-Match and for If-None-Match: * against an object that
+// already exists; a race between two conditional writes can also surface as
+// 409 ConditionalRequestConflict. Both mean the same thing to the protocol.
+func isPreconditionFailure(status int) bool {
+	return status == http.StatusPreconditionFailed || status == http.StatusConflict
+}
+
+// isAmbiguousTransportError reports whether a request that failed in transport
+// could still have been committed.
+//
+// The distinction is the difference between a retry and a commit_ambiguous. A
+// timeout or a reset connection may have reached the service; a refused
+// connection or an unresolvable host did not. Guessing "did not" when it did
+// is how a caller ends up publishing twice, so anything genuinely in doubt
+// counts as in doubt — the two cases below are the only ones ruled out.
+func isAmbiguousTransportError(err error) bool {
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return false
+	}
+	if errors.Is(err, syscall.ECONNREFUSED) {
+		return false
+	}
+	return true
+}
+
+func (b *S3Backend) transportError(what string, err error) error {
+	// The message names what failed and where, never the credentials that
+	// signed it. The cause is attached for a caller that wants the detail.
+	return wrapError(CategoryBackend, err, "durable: %s failed against %s", what, b.describe)
+}
+
+// statusError turns an unexpected status into a backend error, carrying the
+// beginning of the provider's own message. S3 answers with an XML document
+// whose Code and Message are what an operator needs; the cap is there because
+// an error body is not a place to trust a length.
+func (b *S3Backend) statusError(what string, resp *http.Response) error {
+	var detail string
+	if body, err := io.ReadAll(io.LimitReader(resp.Body, 2048)); err == nil && len(body) > 0 {
+		detail = ": " + strings.TrimSpace(string(body))
+	}
+	return newError(CategoryBackend, "durable: %s failed against %s (HTTP %d)%s",
+		what, b.describe, resp.StatusCode, detail)
+}
+
+// drainAndClose releases a response so its connection can be reused. Closing
+// without reading leaves the connection unusable, which turns every request
+// after an error into a fresh TCP handshake.
+func drainAndClose(resp *http.Response) {
+	io.Copy(io.Discard, io.LimitReader(resp.Body, 64*1024))
+	resp.Body.Close()
+}

--- a/chdb/durable/backend_s3_test.go
+++ b/chdb/durable/backend_s3_test.go
@@ -1,0 +1,609 @@
+package durable
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// AWS publishes the intermediate signing key for one worked example. It is the
+// only independent check available for the HMAC chain, and it is worth having:
+// a wrong link produces a signature the service simply rejects, with nothing
+// in the rejection to say which link was wrong.
+//
+// From "Examples of how to derive a signing key for Signature Version 4".
+func TestSigningKeyMatchesTheAWSExample(t *testing.T) {
+	got := hex.EncodeToString(signingKey(
+		"wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY", "20120215", "us-east-1", "iam"))
+	const want = "f4780e2d9f65fa895f9c67b32ce1baf0b0d8a43505a000a1a9e090d414db404d"
+	if got != want {
+		t.Fatalf("derived key\n got %s\nwant %s", got, want)
+	}
+}
+
+// Canonicalisation escapes everything outside the unreserved set and leaves
+// "/" alone. net/url gets both of these wrong for this purpose: QueryEscape
+// turns a space into "+", and EscapedPath keeps whatever the caller wrote.
+func TestURIEncodePathFollowsTheCanonicalRules(t *testing.T) {
+	cases := map[string]string{
+		"/wal/3-9-acde5678.jsonl": "/wal/3-9-acde5678.jsonl",
+		"/a b":                    "/a%20b",
+		"/test$file.text":         "/test%24file.text",
+		"/a+b":                    "/a%2Bb",
+		"/a~b-c.d_e":              "/a~b-c.d_e",
+		"/nested/key/with/slash":  "/nested/key/with/slash",
+		"/héllo":                  "/h%C3%A9llo",
+	}
+	for input, want := range cases {
+		if got := uriEncodePath(input); got != want {
+			t.Errorf("uriEncodePath(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+// A stand-in S3 that implements exactly the two operations this backend uses,
+// with real preconditions — and checks the signature envelope of everything it
+// receives.
+type fakeS3 struct {
+	t *testing.T
+
+	mu      sync.Mutex
+	objects map[string][]byte
+	etags   map[string]string
+	counter int
+
+	// failNext makes the next matching request answer with a status, once.
+	failNext map[string]int
+
+	requests []string
+}
+
+func newFakeS3(t *testing.T) (*fakeS3, *httptest.Server) {
+	s := &fakeS3{
+		t:        t,
+		objects:  map[string][]byte{},
+		etags:    map[string]string{},
+		failNext: map[string]int{},
+	}
+	server := httptest.NewServer(s)
+	t.Cleanup(server.Close)
+	return s, server
+}
+
+func (s *fakeS3) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.requests = append(s.requests, r.Method+" "+r.URL.Path)
+
+	body, _ := io.ReadAll(r.Body)
+
+	// Every request must be signed, and the payload hash must describe the
+	// body that actually arrived — the whole reason the backend is handed a
+	// digest instead of computing one.
+	auth := r.Header.Get("Authorization")
+	if !strings.HasPrefix(auth, "AWS4-HMAC-SHA256 Credential=") {
+		s.t.Errorf("%s %s arrived unsigned: %q", r.Method, r.URL.Path, auth)
+	}
+	if !strings.Contains(auth, "SignedHeaders=") || !strings.Contains(auth, "Signature=") {
+		s.t.Errorf("the Authorization header is malformed: %q", auth)
+	}
+	sum := sha256.Sum256(body)
+	if got := r.Header.Get("X-Amz-Content-Sha256"); got != hex.EncodeToString(sum[:]) {
+		s.t.Errorf("%s %s declared payload hash %q, body hashes to %q",
+			r.Method, r.URL.Path, got, hex.EncodeToString(sum[:]))
+	}
+	if r.Header.Get("X-Amz-Date") == "" {
+		s.t.Errorf("%s %s carries no X-Amz-Date", r.Method, r.URL.Path)
+	}
+	// A precondition decides whether the request mutates anything, so it has
+	// to be inside the signature.
+	for _, header := range []string{"If-None-Match", "If-Match"} {
+		if r.Header.Get(header) != "" &&
+			!strings.Contains(strings.ToLower(auth), strings.ToLower(header)) {
+			s.t.Errorf("%s was sent but not signed: %q", header, auth)
+		}
+	}
+
+	key := r.URL.Path
+	if status, ok := s.failNext[r.Method+" "+key]; ok {
+		delete(s.failNext, r.Method+" "+key)
+		w.WriteHeader(status)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		data, ok := s.objects[key]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("ETag", s.etags[key])
+		w.WriteHeader(http.StatusOK)
+		w.Write(data)
+	case http.MethodPut:
+		_, exists := s.objects[key]
+		if r.Header.Get("If-None-Match") == "*" && exists {
+			w.WriteHeader(http.StatusPreconditionFailed)
+			return
+		}
+		if match := r.Header.Get("If-Match"); match != "" {
+			if !exists {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			if s.etags[key] != match {
+				w.WriteHeader(http.StatusPreconditionFailed)
+				return
+			}
+		}
+		s.counter++
+		etag := fmt.Sprintf("%q", fmt.Sprintf("etag-%d", s.counter))
+		s.objects[key] = body
+		s.etags[key] = etag
+		w.Header().Set("ETag", etag)
+		w.WriteHeader(http.StatusOK)
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *fakeS3) get(key string) ([]byte, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	data, ok := s.objects[key]
+	return data, ok
+}
+
+func (s *fakeS3) fail(method, path string, status int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.failNext[method+" "+path] = status
+}
+
+func s3Fixture(t *testing.T) (*fakeS3, *S3Backend) {
+	t.Helper()
+	fake, server := newFakeS3(t)
+	backend, err := NewS3Backend(S3Options{
+		Bucket:      "my-bucket",
+		Prefix:      "durable/orders",
+		Region:      "eu-west-1",
+		Endpoint:    server.URL,
+		Credentials: credentials{AccessKeyID: "AKIDEXAMPLE", SecretAccessKey: "secret"},
+		HTTPClient:  server.Client(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fake, backend
+}
+
+func TestS3BackendConditionalCreateAndReplace(t *testing.T) {
+	ctx := context.Background()
+	fake, backend := s3Fixture(t)
+
+	outcome, err := backend.PutBytesIfAbsent(ctx, HeadKey, []byte(`{"v":1}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome != PutCreated {
+		t.Fatalf("create reported %s", outcome)
+	}
+	if data, ok := fake.get("/my-bucket/durable/orders/head.json"); !ok || string(data) != `{"v":1}` {
+		t.Fatalf("the object landed at the wrong key or with the wrong body: %q ok=%v", data, ok)
+	}
+
+	// A precondition failure is a compare-and-swap outcome, not a transport
+	// error. Everything the state machine does with already-exists depends on
+	// that distinction being made here.
+	outcome, err = backend.PutBytesIfAbsent(ctx, HeadKey, []byte(`{"v":2}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome != PutAlreadyExists {
+		t.Fatalf("a second create reported %s, want already-exists", outcome)
+	}
+
+	data, etag, found, err := backend.GetBytesWithETag(ctx, HeadKey)
+	if err != nil || !found {
+		t.Fatalf("found=%v err=%v", found, err)
+	}
+	if string(data) != `{"v":1}` {
+		t.Fatalf("read back %q", data)
+	}
+
+	replaced, err := backend.ReplaceIfMatch(ctx, HeadKey, []byte(`{"v":3}`), etag)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if replaced.Status != ReplaceDone || replaced.ETag == "" {
+		t.Fatalf("replace reported %+v", replaced)
+	}
+
+	stale, err := backend.ReplaceIfMatch(ctx, HeadKey, []byte(`{"v":4}`), etag)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stale.Status != ReplaceNotMatched {
+		t.Fatalf("a stale token reported %s, want not-replaced", stale.Status)
+	}
+}
+
+func TestS3BackendReportsAMissingKey(t *testing.T) {
+	ctx := context.Background()
+	_, backend := s3Fixture(t)
+
+	if _, found, err := backend.GetBytes(ctx, HeadKey); err != nil || found {
+		t.Fatalf("found=%v err=%v", found, err)
+	}
+	if _, found, err := backend.OpenReader(ctx, "wal/1-1-aaaa1111.jsonl"); err != nil || found {
+		t.Fatalf("found=%v err=%v", found, err)
+	}
+	// A compare-and-swap against a key that is gone did not match; reporting
+	// it otherwise would send the caller looking for its own intent in a head
+	// that no longer exists.
+	outcome, err := backend.ReplaceIfMatch(ctx, HeadKey, []byte(`{}`), `"etag-1"`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome.Status != ReplaceNotMatched {
+		t.Fatalf("replacing a missing key reported %s", outcome.Status)
+	}
+}
+
+// A 5xx may or may not have committed, and the honest answer is the one the
+// state machine can resolve by re-reading.
+func TestS3BackendReportsServerErrorsAsAmbiguous(t *testing.T) {
+	ctx := context.Background()
+	fake, backend := s3Fixture(t)
+
+	fake.fail(http.MethodPut, "/my-bucket/durable/orders/head.json", http.StatusInternalServerError)
+	outcome, err := backend.PutBytesIfAbsent(ctx, HeadKey, []byte(`{"v":1}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome != PutAmbiguous {
+		t.Fatalf("a 500 on create reported %s, want ambiguous", outcome)
+	}
+
+	if _, err := backend.PutBytesIfAbsent(ctx, HeadKey, []byte(`{"v":1}`)); err != nil {
+		t.Fatal(err)
+	}
+	_, etag, _, err := backend.GetBytesWithETag(ctx, HeadKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fake.fail(http.MethodPut, "/my-bucket/durable/orders/head.json", http.StatusServiceUnavailable)
+	replaced, err := backend.ReplaceIfMatch(ctx, HeadKey, []byte(`{"v":2}`), etag)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if replaced.Status != ReplaceAmbiguous {
+		t.Fatalf("a 503 on replace reported %s, want ambiguous", replaced.Status)
+	}
+}
+
+func TestS3BackendSurfacesRealFailures(t *testing.T) {
+	ctx := context.Background()
+	fake, backend := s3Fixture(t)
+
+	fake.fail(http.MethodGet, "/my-bucket/durable/orders/head.json", http.StatusForbidden)
+	if _, _, err := backend.GetBytes(ctx, HeadKey); !errors.Is(err, ErrBackend) {
+		t.Fatalf("a 403 gave category %q, want backend: %v", CategoryOf(err), err)
+	}
+}
+
+// A connection that was refused never reached the service, so a caller may
+// retry it freely. Anything less certain counts as in doubt.
+func TestS3BackendDistinguishesTransportFailuresThatNeverLanded(t *testing.T) {
+	ctx := context.Background()
+	fake, server := newFakeS3(t)
+	_ = fake
+	client := server.Client()
+	server.Close()
+
+	backend, err := NewS3Backend(S3Options{
+		Bucket:      "my-bucket",
+		Region:      "eu-west-1",
+		Endpoint:    server.URL,
+		Credentials: credentials{AccessKeyID: "AKIDEXAMPLE", SecretAccessKey: "secret"},
+		HTTPClient:  client,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := backend.PutBytesIfAbsent(ctx, HeadKey, []byte(`{}`)); !errors.Is(err, ErrBackend) {
+		t.Fatalf("a refused connection gave category %q, want backend: %v", CategoryOf(err), err)
+	}
+}
+
+func TestS3BackendUploadsAFileWithoutRehashingIt(t *testing.T) {
+	ctx := context.Background()
+	fake, backend := s3Fixture(t)
+
+	archive := filepath.Join(t.TempDir(), "checkpoint.tar.gz")
+	body := strings.Repeat("archive bytes ", 1000)
+	if err := os.WriteFile(archive, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	digest := digestOf([]byte(body))
+
+	outcome, err := backend.PutFileIfAbsent(ctx, "checkpoints/1-1-aaaa1111.tar.gz", archive, digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if outcome != PutCreated {
+		t.Fatalf("upload reported %s", outcome)
+	}
+	// The fake asserts that the declared payload hash matches the body it
+	// received, so reaching here proves the manifest's digest signed the
+	// upload.
+	stored, ok := fake.get("/my-bucket/durable/orders/checkpoints/1-1-aaaa1111.tar.gz")
+	if !ok || string(stored) != body {
+		t.Fatalf("the archive did not arrive intact: ok=%v %d bytes", ok, len(stored))
+	}
+}
+
+func TestS3BackendRefusesAnObjectOverTheSinglePutCeiling(t *testing.T) {
+	ctx := context.Background()
+	_, backend := s3Fixture(t)
+	// The refusal happens before the file is opened, which is why the path
+	// need not exist: a checkpoint too large for one PutObject is a limit, not
+	// a missing file.
+	_, err := backend.PutFileIfAbsent(ctx, "checkpoints/1-1-aaaa1111.tar.gz", "unused",
+		Digest{Size: MaxSinglePutBytes + 1, SHA256: strings.Repeat("0", 64)})
+	if !errors.Is(err, ErrLimitExceeded) {
+		t.Fatalf("category is %q, want limit_exceeded: %v", CategoryOf(err), err)
+	}
+}
+
+func TestS3BackendURLShapes(t *testing.T) {
+	base := S3Options{
+		Bucket:      "my-bucket",
+		Prefix:      "durable/orders",
+		Region:      "eu-west-1",
+		Credentials: credentials{AccessKeyID: "AKIDEXAMPLE", SecretAccessKey: "secret"},
+	}
+	pathStyle := true
+	virtual := false
+
+	cases := []struct {
+		name    string
+		options S3Options
+		want    string
+	}{
+		{
+			name:    "AWS is virtual-hosted",
+			options: base,
+			want:    "https://my-bucket.s3.eu-west-1.amazonaws.com/durable/orders/head.json",
+		},
+		{
+			name:    "AWS path-style on request",
+			options: withPathStyle(base, &pathStyle),
+			want:    "https://s3.eu-west-1.amazonaws.com/my-bucket/durable/orders/head.json",
+		},
+		{
+			// What a local MinIO wants, and the reason an endpoint implies it.
+			name:    "a custom endpoint is path-style by default",
+			options: withEndpoint(base, "http://127.0.0.1:9000"),
+			want:    "http://127.0.0.1:9000/my-bucket/durable/orders/head.json",
+		},
+		{
+			name:    "a custom endpoint can be virtual-hosted",
+			options: withPathStyle(withEndpoint(base, "https://account.r2.cloudflarestorage.com"), &virtual),
+			want:    "https://my-bucket.account.r2.cloudflarestorage.com/durable/orders/head.json",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			backend, err := NewS3Backend(tc.options)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, _, err := backend.urlFor(HeadKey)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.String() != tc.want {
+				t.Fatalf("URL is %s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func withEndpoint(options S3Options, endpoint string) S3Options {
+	options.Endpoint = endpoint
+	return options
+}
+
+func withPathStyle(options S3Options, pathStyle *bool) S3Options {
+	options.PathStyle = pathStyle
+	return options
+}
+
+// The namespace URL is the sort of thing that gets logged, so it carries no
+// credentials — and Describe, which goes into error messages, carries none
+// either.
+func TestS3SchemeParsesANamespaceURL(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "AKIDEXAMPLE")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "secret")
+
+	u, err := url.Parse("s3://my-bucket/durable?region=us-west-2&endpoint=http://127.0.0.1:9000")
+	if err != nil {
+		t.Fatal(err)
+	}
+	factory, ok := lookupScheme("s3")
+	if !ok {
+		t.Fatal("the s3 scheme is not registered")
+	}
+	backend, err := factory(context.Background(), u, "orders")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s3, ok := backend.(*S3Backend)
+	if !ok {
+		t.Fatalf("the factory built a %T", backend)
+	}
+	if s3.region != "us-west-2" || s3.prefix != "durable/orders" || s3.bucket != "my-bucket" {
+		t.Fatalf("the URL parsed to %+v", s3)
+	}
+	if strings.Contains(s3.Describe(), "secret") || strings.Contains(s3.Describe(), "AKIDEXAMPLE") {
+		t.Fatalf("Describe leaks a credential: %s", s3.Describe())
+	}
+}
+
+func TestS3BackendNeedsCredentials(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", filepath.Join(t.TempDir(), "absent"))
+
+	_, err := NewS3Backend(S3Options{Bucket: "my-bucket"})
+	if !errors.Is(err, ErrBackend) {
+		t.Fatalf("category is %q, want backend: %v", CategoryOf(err), err)
+	}
+	// The message has to say what to do about it.
+	if !strings.Contains(err.Error(), "AWS_ACCESS_KEY_ID") {
+		t.Errorf("the message does not name a way to fix it: %v", err)
+	}
+}
+
+func TestCredentialsComeFromTheSharedFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "credentials")
+	body := `
+# a comment
+[default]
+aws_access_key_id = DEFAULTKEY
+aws_secret_access_key = defaultsecret
+
+[profile staging]
+aws_access_key_id = STAGINGKEY
+aws_secret_access_key = stagingsecret
+aws_session_token = stagingtoken
+`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", path)
+
+	t.Setenv("AWS_PROFILE", "")
+	got, err := resolveCredentials(credentials{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AccessKeyID != "DEFAULTKEY" || got.SecretAccessKey != "defaultsecret" {
+		t.Fatalf("the default profile resolved to %+v", got)
+	}
+
+	t.Setenv("AWS_PROFILE", "staging")
+	got, err = resolveCredentials(credentials{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AccessKeyID != "STAGINGKEY" || got.SessionToken != "stagingtoken" {
+		t.Fatalf("the staging profile resolved to %+v", got)
+	}
+
+	// Explicit credentials outrank everything, which is how a caller that
+	// needs SSO or an instance role supplies what this signer will not fetch.
+	got, err = resolveCredentials(credentials{AccessKeyID: "EXPLICIT", SecretAccessKey: "s"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AccessKeyID != "EXPLICIT" {
+		t.Fatalf("explicit credentials were overridden by %+v", got)
+	}
+}
+
+// The same state machine, driven end to end against the S3 wire protocol
+// rather than a directory. This is the check that the two backends are
+// interchangeable, which is what "the object is a folder you can move between
+// clouds" rests on.
+func TestObjectLifecycleOverS3(t *testing.T) {
+	ctx := context.Background()
+	_, server := newFakeS3(t)
+
+	engine := newFakeEngine()
+	ns, err := NewNamespace("s3://my-bucket/durable?region=eu-west-1&endpoint="+server.URL,
+		NamespaceOptions{
+			EngineFactory: engine.factory(),
+			BackendFactory: func(_ context.Context, objectID string) (Backend, error) {
+				return NewS3Backend(S3Options{
+					Bucket:      "my-bucket",
+					Prefix:      "durable/" + objectID,
+					Region:      "eu-west-1",
+					Endpoint:    server.URL,
+					Credentials: credentials{AccessKeyID: "AKIDEXAMPLE", SecretAccessKey: "secret"},
+					HTTPClient:  server.Client(),
+				})
+			},
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	obj, existed, err := ns.Open(ctx, "orders", OpenOptions{Database: "mem", ScratchRoot: t.TempDir()})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if existed {
+		t.Fatal("a cold object reported as existing")
+	}
+	mustExecute(t, obj, "CREATE TABLE events (id UInt64) ENGINE = MergeTree ORDER BY id")
+	mustExecute(t, obj, "INSERT INTO events VALUES (1)")
+	if _, err := obj.Flush(ctx); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	if _, err := obj.Checkpoint(ctx); err != nil {
+		t.Fatalf("checkpoint: %v", err)
+	}
+	mustExecute(t, obj, "INSERT INTO events VALUES (2)")
+	if err := obj.Close(ctx); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	// Reopen with a fresh engine: everything has to come back through the
+	// bucket.
+	recovered := newFakeEngine()
+	ns2, err := NewNamespace("s3://my-bucket/durable?region=eu-west-1&endpoint="+server.URL,
+		NamespaceOptions{
+			EngineFactory: recovered.factory(),
+			BackendFactory: func(_ context.Context, objectID string) (Backend, error) {
+				return NewS3Backend(S3Options{
+					Bucket:      "my-bucket",
+					Prefix:      "durable/" + objectID,
+					Region:      "eu-west-1",
+					Endpoint:    server.URL,
+					Credentials: credentials{AccessKeyID: "AKIDEXAMPLE", SecretAccessKey: "secret"},
+					HTTPClient:  server.Client(),
+				})
+			},
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	reopened, existed, err := ns2.Open(ctx, "orders", OpenOptions{ScratchRoot: t.TempDir()})
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer reopened.Close(ctx)
+	if !existed {
+		t.Fatal("the object exists")
+	}
+	if got := recovered.statements(); len(got) != 3 {
+		t.Fatalf("recovery over S3 produced %v", got)
+	}
+}

--- a/chdb/durable/chdbengine.go
+++ b/chdb/durable/chdbengine.go
@@ -1,0 +1,227 @@
+package durable
+
+import (
+	"context"
+	"strings"
+	"sync"
+
+	"github.com/chdb-io/chdb-go/v2/chdb"
+	chdbpurego "github.com/chdb-io/chdb-go/v2/chdb-purego"
+)
+
+// The real engine: a chdb.Session on the object's scratch directory.
+//
+// Going through chdb.Session rather than opening a native connection directly
+// is deliberate. The session registry already models the constraint the
+// contract states in §3.6 — chDB binds one data path per process — so a second
+// durable object in the same process is refused by the registry with an error
+// naming both paths, instead of failing somewhere deeper and less legibly.
+// Nothing here maintains a second path state machine.
+
+// ChdbEngine drives one durable object through a chdb.Session.
+type ChdbEngine struct {
+	// extraArgs are appended to the connection arguments, for a caller that
+	// needs to tune the engine for its workload. They cannot be used to
+	// weaken the synchronous-write settings below: those are applied after,
+	// and the public surface cannot change them either, since SET classifies
+	// as CONTROL.
+	extraArgs []string
+
+	mu      sync.Mutex
+	session *chdb.Session
+}
+
+// NewChdbEngine returns the engine factory a namespace uses by default.
+//
+// extraArgs are extra connection-string parameters in "key=value" form, as
+// chdb.NewSession takes them.
+func NewChdbEngine(extraArgs ...string) EngineFactory {
+	return func(context.Context) (Engine, error) {
+		return &ChdbEngine{extraArgs: extraArgs}, nil
+	}
+}
+
+// Version implements Engine.
+//
+// It also settles whether this engine can serve a durable object at all. An
+// engine without the management ABI cannot back up, restore or classify, so it
+// is refused here — before the lease, before the scratch directory, before
+// anything is claimed. Version is the first thing an open asks for, which is
+// what makes it the right place: the contract requires an engine that cannot
+// read an object to cost nothing but two strings (§5.2).
+func (e *ChdbEngine) Version(context.Context) (string, error) {
+	version, err := chdb.EngineVersion()
+	if err != nil {
+		return "", wrapError(CategoryEngine, err, "durable: cannot read the engine version")
+	}
+	available, err := chdbpurego.AdminABIAvailable()
+	if err != nil {
+		return "", wrapError(CategoryEngine, err, "durable: cannot load the engine")
+	}
+	if !available {
+		return "", wrapError(CategoryEngineIncompatible, chdbpurego.ErrAdminABIUnavailable,
+			"durable: chdb %s cannot serve a durable object", version)
+	}
+	return version, nil
+}
+
+// BackupFormat implements Engine.
+//
+// The C ABI exposes no accessor for the archive-format generation, so every
+// release reports the V1 baseline. When core adds one, this is the single
+// place that changes, and the reader gate starts refusing a future generation
+// instead of assuming it can restore it.
+func (e *ChdbEngine) BackupFormat(context.Context) (int, error) {
+	return BackupFormatBaseline, nil
+}
+
+// Start implements Engine.
+func (e *ChdbEngine) Start(_ context.Context, options EngineStartOptions) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.session != nil {
+		return newError(CategoryEngine, "durable: the engine is already started")
+	}
+
+	// The settings here are the ones a durable writer cannot leave to chance.
+	// Asynchronous inserts and non-synchronous mutations both mean "the
+	// statement returned before its effect landed", which would put a
+	// statement in the WAL whose local effect is not yet in the database the
+	// next checkpoint archives.
+	params := []string{
+		"backups.allowed_path=" + options.BackupsAllowedPath,
+		"async_insert=0",
+		"wait_for_async_insert=1",
+		"mutations_sync=2",
+		"alter_sync=2",
+	}
+	params = append(params, e.extraArgs...)
+
+	session, err := chdb.NewSession(options.DataPath + "?" + strings.Join(params, "&"))
+	if err != nil {
+		// chDB binds one data path per process, so a second durable object in
+		// the same process arrives here. The session registry's message names
+		// both paths, which is more use than anything this layer could add.
+		return wrapError(CategoryEngine, err, "durable: cannot open an engine on %s", options.DataPath)
+	}
+	e.session = session
+	return nil
+}
+
+// borrow returns the live session, or the reason there is not one.
+func (e *ChdbEngine) borrow() (*chdb.Session, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.session == nil {
+		return nil, newError(CategoryEngine, "durable: the engine is not started")
+	}
+	return e.session, nil
+}
+
+// quoteIdentifier backtick-quotes a ClickHouse identifier, so a database name
+// holding a dash — or anything else needing quoting — is valid in DDL and
+// cannot break out of the statement.
+//
+// This is only for the two statements core has no argument-taking entry point
+// for, CREATE DATABASE and USE. Backup and restore take the name as an
+// argument and quote it themselves, which is why neither appears here.
+func quoteIdentifier(name string) string {
+	return "`" + strings.NewReplacer("\\", "\\\\", "`", "\\`").Replace(name) + "`"
+}
+
+// CreateDatabase implements Engine.
+func (e *ChdbEngine) CreateDatabase(ctx context.Context, database string) error {
+	return e.Run(ctx, "CREATE DATABASE IF NOT EXISTS "+quoteIdentifier(database))
+}
+
+// UseDatabase implements Engine.
+func (e *ChdbEngine) UseDatabase(ctx context.Context, database string) error {
+	return e.Run(ctx, "USE "+quoteIdentifier(database))
+}
+
+// Analyze implements Engine.
+func (e *ChdbEngine) Analyze(_ context.Context, sql, targetDatabase string) (chdbpurego.QueryAnalysis, error) {
+	session, err := e.borrow()
+	if err != nil {
+		return chdbpurego.QueryAnalysis{}, err
+	}
+	analysis, err := session.ClassifyQuery(sql, targetDatabase)
+	if err != nil {
+		// The message deliberately does not include the SQL: analysis runs on
+		// statements that may embed a credential, and that is exactly the case
+		// the caller is about to be told about.
+		return chdbpurego.QueryAnalysis{}, wrapError(CategoryEngine, err,
+			"durable: the engine could not analyse the statement")
+	}
+	return analysis, nil
+}
+
+// Query implements Engine.
+func (e *ChdbEngine) Query(_ context.Context, sql, format string) (string, error) {
+	session, err := e.borrow()
+	if err != nil {
+		return "", err
+	}
+	result, err := session.Query(sql, format)
+	if err != nil {
+		return "", wrapError(CategoryEngine, err, "durable: the engine refused a read")
+	}
+	if result == nil {
+		return "", nil
+	}
+	defer result.Free()
+	return result.String(), nil
+}
+
+// Run implements Engine.
+func (e *ChdbEngine) Run(_ context.Context, sql string) error {
+	session, err := e.borrow()
+	if err != nil {
+		return err
+	}
+	result, err := session.Query(sql, "CSV")
+	if err != nil {
+		return wrapError(CategoryEngine, err, "durable: the engine refused a statement")
+	}
+	if result != nil {
+		result.Free()
+	}
+	return nil
+}
+
+// BackupDatabase implements Engine.
+func (e *ChdbEngine) BackupDatabase(_ context.Context, database, filePath string) error {
+	session, err := e.borrow()
+	if err != nil {
+		return err
+	}
+	if err := session.BackupDatabase(database, filePath); err != nil {
+		return wrapError(CategoryEngine, err, "durable: backing up %q failed", database)
+	}
+	return nil
+}
+
+// RestoreDatabase implements Engine.
+func (e *ChdbEngine) RestoreDatabase(_ context.Context, database, filePath string) error {
+	session, err := e.borrow()
+	if err != nil {
+		return err
+	}
+	if err := session.RestoreDatabase(database, filePath); err != nil {
+		return wrapError(CategoryEngine, err, "durable: restoring %q failed", database)
+	}
+	return nil
+}
+
+// Close implements Engine. It tolerates never having started, because an open
+// that fails partway through still has to release whatever was acquired.
+func (e *ChdbEngine) Close(context.Context) error {
+	e.mu.Lock()
+	session := e.session
+	e.session = nil
+	e.mu.Unlock()
+	if session != nil {
+		session.Close()
+	}
+	return nil
+}

--- a/chdb/durable/concurrency_test.go
+++ b/chdb/durable/concurrency_test.go
@@ -1,0 +1,305 @@
+package durable
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+// The contract forbids leaning on "the runtime serializes this" as the
+// serialization argument (§5.3), and in Go it plainly does not: heartbeat runs
+// on its own goroutine and a caller may use one object from several. These
+// tests are what the race detector runs over.
+
+// Concurrent writers on one handle must not lose a statement or interleave one
+// into the wrong segment.
+func TestConcurrentExecuteAndFlushLoseNothing(t *testing.T) {
+	ctx := context.Background()
+	f := newFixture(t)
+	obj, _, _ := f.mustOpen(OpenOptions{})
+
+	const writers, perWriter = 8, 10
+	var wg sync.WaitGroup
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < perWriter; i++ {
+				ticket, err := obj.Execute(ctx, fmt.Sprintf("INSERT INTO events VALUES (%d, %d)", w, i))
+				if err != nil {
+					t.Errorf("writer %d statement %d: %v", w, i, err)
+					return
+				}
+				// Every other write asks for a durability barrier, so flushes
+				// and executes contend rather than taking turns.
+				if i%2 == 0 {
+					if err := obj.FlushThrough(ctx, ticket); err != nil {
+						t.Errorf("writer %d barrier %d: %v", w, i, err)
+						return
+					}
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	if err := obj.Close(ctx); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	// Recover and count: every statement that Execute accepted has to be
+	// there, because close flushes what was still buffered.
+	reopened, engine, _ := f.mustOpen(OpenOptions{})
+	defer reopened.Close(ctx)
+	if got := len(engine.statements()); got != writers*perWriter {
+		t.Fatalf("recovery produced %d statements, want %d", got, writers*perWriter)
+	}
+
+	// And the manifest's sequence numbers are contiguous, so no two commits
+	// claimed the same one.
+	head := f.head()
+	if head.Manifest.Seq != int64(len(head.Manifest.WAL)) {
+		t.Fatalf("seq is %d with %d segments; a commit reused a sequence number",
+			head.Manifest.Seq, len(head.Manifest.WAL))
+	}
+}
+
+// A statement racing a close must come back as either done or refused, never
+// as a write against an engine that is being shut down.
+func TestExecuteRacingCloseIsEitherDoneOrRefused(t *testing.T) {
+	ctx := context.Background()
+	f := newFixture(t)
+	obj, _, _ := f.mustOpen(OpenOptions{})
+
+	var (
+		wg      sync.WaitGroup
+		mu      sync.Mutex
+		refused int
+		done    int
+	)
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, err := obj.Execute(ctx, fmt.Sprintf("INSERT INTO events VALUES (%d)", i))
+			mu.Lock()
+			defer mu.Unlock()
+			switch {
+			case err == nil:
+				done++
+			case errors.Is(err, ErrClosed):
+				refused++
+			default:
+				t.Errorf("statement %d reported %q, want success or closed: %v",
+					i, CategoryOf(err), err)
+			}
+		}(i)
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := obj.Close(ctx); err != nil {
+			t.Errorf("close: %v", err)
+		}
+	}()
+	wg.Wait()
+
+	if done+refused != 16 {
+		t.Fatalf("%d done and %d refused out of 16", done, refused)
+	}
+	// Whatever Execute accepted, the close flushed: a close that drained the
+	// queue and then dropped the buffer would be the quiet version of this
+	// bug.
+	if got := obj.Stats().CommittedStatements; got != int64(done) {
+		t.Fatalf("close committed %d of the %d accepted statements", got, done)
+	}
+}
+
+// A writer idle for longer than its TTL is still the writer, because
+// heartbeat has been renewing in the background — and a renewal moves neither
+// the generation nor the sequence number, so it leaves no trace in the
+// manifest.
+func TestHeartbeatKeepsTheLeaseThroughAnIdleSpell(t *testing.T) {
+	ctx := context.Background()
+	f := newFixture(t)
+
+	// Heartbeat often enough to land several times during the pause below,
+	// with a TTL short enough that the pause would outlast it unaided.
+	obj, _, _ := f.mustOpen(OpenOptions{Tuning: Tuning{
+		LeaseTTL:           900 * time.Millisecond,
+		HeartbeatInterval:  100 * time.Millisecond,
+		ClockSkewAllowance: 50 * time.Millisecond,
+		CommitDeadline:     2 * time.Second,
+		MaxCommitAttempts:  3,
+	}})
+	defer obj.Close(ctx)
+
+	mustExecute(t, obj, "INSERT INTO events VALUES (1)")
+
+	before := f.head().Lease.ExpiresAt
+	time.Sleep(1200 * time.Millisecond)
+
+	if _, err := obj.Checkpoint(ctx); err != nil {
+		t.Fatalf("a checkpoint after a pause longer than the TTL should still commit: %v", err)
+	}
+	after := f.head().Lease.ExpiresAt
+	if before == nil || after == nil {
+		t.Fatal("the lease should be held throughout")
+	}
+	if *after <= *before {
+		t.Fatalf("the lease was not renewed: %v then %v", *before, *after)
+	}
+	// The generation never moved, so nothing took the object over.
+	if got := f.head().Lease.Generation; got != 1 {
+		t.Fatalf("generation is %d; a heartbeat must not increment it", got)
+	}
+	// And seq moved only for the checkpoint, not for the heartbeats.
+	if got := f.head().Manifest.Seq; got != 1 {
+		t.Fatalf("seq is %d, want 1 — heartbeat must not advance it", got)
+	}
+}
+
+// A writer that cannot confirm its lease stops writing at the moment its
+// locally believed window lapses, rather than on the next error.
+func TestAWriterThatCannotRenewFencesItself(t *testing.T) {
+	ctx := context.Background()
+	f := newFixture(t)
+
+	obj, _, _ := f.mustOpen(OpenOptions{Tuning: Tuning{
+		LeaseTTL:           300 * time.Millisecond,
+		HeartbeatInterval:  90 * time.Millisecond,
+		ClockSkewAllowance: 50 * time.Millisecond,
+		CommitDeadline:     200 * time.Millisecond,
+		MaxCommitAttempts:  2,
+	}})
+
+	// Every renewal from here on fails, the way a partitioned writer's would.
+	f.backend.mu.Lock()
+	f.backend.onReplace = func(key string, _ int) (ReplaceOutcome, error, bool) {
+		if key == HeadKey {
+			return ReplaceOutcome{}, newError(CategoryBackend, "durable: pretend the network is gone"), true
+		}
+		return ReplaceOutcome{}, nil, false
+	}
+	f.backend.mu.Unlock()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		_, err := obj.Execute(ctx, "INSERT INTO events VALUES (1)")
+		if errors.Is(err, ErrLeaseFenced) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("the writer never fenced itself; last error was %v", err)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if !obj.IsFenced() {
+		t.Fatal("a self-fenced writer should say so")
+	}
+	// It stays unusable, and close still gives back the local resources.
+	if _, err := obj.Flush(ctx); !errors.Is(err, ErrLeaseFenced) {
+		t.Fatalf("a fenced writer reported %q", CategoryOf(err))
+	}
+	f.backend.mu.Lock()
+	f.backend.onReplace = nil
+	f.backend.mu.Unlock()
+	if err := obj.Close(ctx); err != nil {
+		t.Fatalf("close after self-fencing: %v", err)
+	}
+}
+
+// Concurrent readers of the same snapshot must see a consistent one, which is
+// why Stats is taken as a whole rather than field by field.
+func TestStatsUnderConcurrentWriters(t *testing.T) {
+	ctx := context.Background()
+	f := newFixture(t)
+	obj, _, _ := f.mustOpen(OpenOptions{})
+	defer obj.Close(ctx)
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				stats := obj.Stats()
+				if stats.CommittedStatements > stats.ExecutedStatements {
+					t.Errorf("stats describe a state that never existed: committed %d of %d executed",
+						stats.CommittedStatements, stats.ExecutedStatements)
+					return
+				}
+			}
+		}
+	}()
+
+	for i := 0; i < 20; i++ {
+		mustExecute(t, obj, fmt.Sprintf("INSERT INTO events VALUES (%d)", i))
+		if i%5 == 0 {
+			if _, err := obj.Flush(ctx); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	close(stop)
+	wg.Wait()
+}
+
+// Two processes reaching a cold object at the same moment must not both come
+// away believing they created it. The conditional create decides, and the
+// loser sees an object with a live lease rather than one it may write to.
+func TestConcurrentColdCreatesLeaveOneWriter(t *testing.T) {
+	ctx := context.Background()
+	f := newFixture(t)
+
+	const racers = 6
+	var (
+		wg      sync.WaitGroup
+		mu      sync.Mutex
+		winners []*Object
+		refused int
+	)
+	for i := 0; i < racers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			obj, _, _, err := f.open(OpenOptions{Owner: fmt.Sprintf("worker-%d", i)})
+			mu.Lock()
+			defer mu.Unlock()
+			switch {
+			case err == nil:
+				winners = append(winners, obj)
+			case errors.Is(err, ErrLeaseHeld):
+				refused++
+			default:
+				t.Errorf("racer %d reported %q, want success or lease_held: %v",
+					i, CategoryOf(err), err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	if len(winners) != 1 {
+		t.Fatalf("%d racers took the object, want exactly 1", len(winners))
+	}
+	if refused != racers-1 {
+		t.Fatalf("%d racers were refused, want %d", refused, racers-1)
+	}
+	// And the object the winner holds is the one in the store.
+	winner := winners[0]
+	head := f.head()
+	if head.Lease.Owner == nil || *head.Lease.Owner != winner.Stats().Owner {
+		t.Fatalf("the head names %v, the winner is %q", head.Lease.Owner, winner.Stats().Owner)
+	}
+	if err := winner.Close(ctx); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+}

--- a/chdb/durable/digest.go
+++ b/chdb/durable/digest.go
@@ -1,0 +1,126 @@
+package durable
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"hash"
+	"io"
+	"os"
+)
+
+// Length and SHA-256 verification (contract §4.5).
+//
+// The contract requires both to be checked before a base is restored or a WAL
+// segment is parsed, and it requires checkpoint transfer not to hold the whole
+// archive in memory. So the streaming helper here does both jobs in one pass:
+// it hashes and counts while it writes, and publishes the file to its final
+// name only once both match. A caller therefore never sees a scratch path
+// holding unverified bytes.
+
+// Digest is the length and content hash of one object.
+type Digest struct {
+	Size int64
+	// SHA256 is the lowercase full hex digest.
+	SHA256 string
+}
+
+// digestOf hashes a buffer.
+func digestOf(data []byte) Digest {
+	sum := sha256.Sum256(data)
+	return Digest{Size: int64(len(data)), SHA256: hex.EncodeToString(sum[:])}
+}
+
+// digestFile streams a local file through SHA-256 without holding it in
+// memory.
+func digestFile(path string) (Digest, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return Digest{}, err
+	}
+	defer f.Close()
+	h := sha256.New()
+	size, err := io.Copy(h, f)
+	if err != nil {
+		return Digest{}, err
+	}
+	return Digest{Size: size, SHA256: hex.EncodeToString(h.Sum(nil))}, nil
+}
+
+// assertDigest refuses an object that is not the one the head describes.
+func assertDigest(ref ObjectRef, observed Digest, what string) error {
+	if ref.Size != observed.Size {
+		return newError(CategoryCorrupt, "durable: %s (%s) has size %d, head says %d",
+			what, ref.Key, observed.Size, ref.Size)
+	}
+	if ref.SHA256 != observed.SHA256 {
+		return newError(CategoryCorrupt, "durable: %s (%s) sha256 %s does not match head %s",
+			what, ref.Key, observed.SHA256, ref.SHA256)
+	}
+	return nil
+}
+
+// countingHasher accumulates length and SHA-256 as bytes flow past.
+type countingHasher struct {
+	h    hash.Hash
+	size int64
+}
+
+func newCountingHasher() *countingHasher {
+	return &countingHasher{h: sha256.New()}
+}
+
+func (c *countingHasher) Write(p []byte) (int, error) {
+	c.size += int64(len(p))
+	return c.h.Write(p)
+}
+
+func (c *countingHasher) digest() Digest {
+	return Digest{Size: c.size, SHA256: hex.EncodeToString(c.h.Sum(nil))}
+}
+
+// drainDigest reads r to the end and returns what went past, without keeping
+// it. Used to settle an upload whose response was lost: the question is
+// whether the bytes at that key are ours, and the answer is a digest.
+func drainDigest(r io.Reader) (Digest, error) {
+	c := newCountingHasher()
+	if _, err := io.Copy(c, r); err != nil {
+		return Digest{}, err
+	}
+	return c.digest(), nil
+}
+
+// streamToVerifiedFile writes src into tmpPath, verifies it against ref, then
+// renames it to finalPath.
+//
+// On any mismatch the scratch file is removed and finalPath is never created,
+// so a failed verify cannot leave behind something a later step mistakes for a
+// good archive.
+func streamToVerifiedFile(src io.Reader, ref ObjectRef, tmpPath, finalPath, what string) error {
+	f, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return wrapError(CategoryBackend, err, "durable: cannot stage %s", ref.Key)
+	}
+	counter := newCountingHasher()
+	_, copyErr := io.Copy(io.MultiWriter(f, counter), src)
+	syncErr := f.Sync()
+	closeErr := f.Close()
+	if copyErr == nil {
+		copyErr = syncErr
+	}
+	if copyErr == nil {
+		copyErr = closeErr
+	}
+	if copyErr != nil {
+		os.Remove(tmpPath)
+		return wrapError(CategoryBackend, copyErr, "durable: downloading %s failed", ref.Key)
+	}
+	if err := assertDigest(ref, counter.digest(), what); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := os.Rename(tmpPath, finalPath); err != nil {
+		os.Remove(tmpPath)
+		return wrapError(CategoryBackend, err, "durable: publishing verified %s failed", ref.Key)
+	}
+	return nil
+}

--- a/chdb/durable/doc.go
+++ b/chdb/durable/doc.go
@@ -1,0 +1,91 @@
+// Package durable implements chDB Durable V1: an addressable, single-writer
+// chDB engine whose authoritative state lives in object storage you own.
+//
+// A durable object is one chDB database whose committed state is a full
+// checkpoint plus a chain of write-ahead-log segments, published as immutable
+// objects under a prefix, with one compare-and-set `head.json` naming the
+// current manifest and holding the writer lease. Local MergeTree is the hot
+// working copy; the object itself is a folder of open-format files you can
+// move between clouds.
+//
+//	ns, err := durable.NewNamespace("s3://my-bucket/durable?region=eu-west-1",
+//		durable.NamespaceOptions{Owner: "worker-1"})
+//
+//	obj, existed, err := ns.Open(ctx, "tenant-123", durable.OpenOptions{Database: "mem"})
+//	defer obj.Close(ctx)
+//
+//	if !existed {
+//		_, err = obj.Execute(ctx, "CREATE TABLE events (id UInt64, at DateTime) ENGINE = MergeTree ORDER BY id")
+//	}
+//	ticket, err := obj.Execute(ctx, "INSERT INTO events VALUES (1, '2026-09-07 00:00:00')")
+//	err = obj.FlushThrough(ctx, ticket)   // now it survives losing this machine
+//	rows, err := obj.Query(ctx, "SELECT count() FROM events", "JSONEachRow")
+//	_, err = obj.Checkpoint(ctx)          // fold base + WAL into a fresh base
+//
+// # What Execute guarantees, and what it does not
+//
+// Execute means the statement ran locally and joined the WAL buffer. It does
+// not mean the write left the machine. Durability is Flush, or FlushThrough
+// for one statement's watermark. A service that answers a client before
+// flushing is choosing to lose that write if the process dies, and it should
+// choose that knowingly rather than by accident.
+//
+// # What the engine decides, and what this package decides
+//
+// Whether a statement may run at all is not this package's judgement. Every
+// Query and Execute is put to ClickHouse's own parser first — how many
+// executable statements is this, what class are they, does every persistent
+// write land in the database this object owns, does the text embed a
+// credential — and the answer is the gate. There is no prefix list and no
+// regular expression anywhere in this package, because neither can see through
+// `INSERT ... FORMAT` inline data or resolve an unqualified table name.
+// Likewise `BACKUP` and `RESTORE` are never assembled as text: core takes the
+// database name and the path as arguments and does its own quoting.
+//
+// That needs chdb-core v26.7.2-rc.2 or later, which is where the three
+// management entry points were added. An older engine is refused at open with
+// an engine_incompatible error rather than working partially.
+//
+// # Determinism is the caller's job
+//
+// Recovery re-executes logged SQL, so a statement must produce the same result
+// on replay as it did originally. Log literals: compute a timestamp or an id
+// in the caller and log the value, not `now()`, `rand()`,
+// `generateUUIDv4()`, or an `INSERT ... SELECT` from a volatile source. V1
+// promises ordered replay of the original statement text and nothing more.
+// Non-deterministic or bulk transformations belong in a Checkpoint, which
+// snapshots actual state.
+//
+// # One object per process
+//
+// chdb-core binds one data path per process, so one process holds one open
+// durable object at a time. Opening a second returns an error naming both
+// paths. Fan-out across many objects is sequential, or spread across worker
+// processes; this package does not pretend otherwise.
+//
+// # Version compatibility
+//
+// An object records the exact chdb_version() that wrote it, and that is not a
+// gate. Compatibility is decided by two explicit fields — the archive-format
+// generation and the minimum reader version — so an object written by
+// v26.7.2-rc.2 opens on every later chdb-core release that can still restore
+// its archive. See the comment on assertEngineCompatible in negotiate.go for
+// why the two checks are separate and why neither is a version equality test.
+//
+// # Security scope
+//
+// This package provides single-writer *coordination* — the lease plus the
+// compare-and-set fence — not security. Access control is entirely your object
+// store's IAM: anyone who can write the object's prefix can read, modify or
+// take its lock. There is no application-level auth, no client-side
+// encryption, and no tamper protection beyond the length and SHA-256 checks
+// that detect a damaged archive. For multi-tenant use, give each tenant
+// credentials scoped to its own prefix.
+//
+// # Where the specification lives
+//
+// The protocol is specified in CHDB_DURABLE_V1_CONTRACT.md in the chdb
+// repository, and that document — not this implementation — is the source of
+// truth. Semantics change there first, and the same fixtures are read by the
+// Python, Node and Go bindings.
+package durable

--- a/chdb/durable/engine.go
+++ b/chdb/durable/engine.go
@@ -1,0 +1,166 @@
+package durable
+
+import (
+	"context"
+
+	chdbpurego "github.com/chdb-io/chdb-go/v2/chdb-purego"
+)
+
+// The engine seam (contract §3).
+//
+// The durable control plane never touches a native library directly.
+// Everything it needs from the engine goes through this interface, which is
+// why the same state machine can drive a real chDB session or a fake in a unit
+// test without either knowing about the other.
+//
+// Two rules shape the interface, and both are contract requirements rather
+// than taste:
+//
+//  1. **The binding never builds management SQL.** BackupDatabase and
+//     RestoreDatabase take an identifier and a path; quoting and AST
+//     construction happen in core. A binding that concatenated
+//     "BACKUP DATABASE " + name would be one unusual database name away from
+//     injection, in four languages independently.
+//  2. **The binding never classifies SQL itself.** No prefix lists, no
+//     regular expressions. Analyze is ClickHouse's own parser answering
+//     questions only it can answer — how many executable statements are in
+//     this text, and does every persistent write land in the database we own.
+//     A regex cannot see through INSERT ... FORMAT inline data, and it cannot
+//     resolve an unqualified table name against the session's current
+//     database.
+//
+// BackupDatabase deliberately has no incremental-base parameter even though
+// the C ABI accepts one. V1 checkpoints are always full: an incremental
+// archive records the *path* of its base, and that path does not exist on the
+// machine that restores it (contract §3.2).
+
+// EngineStartOptions is where an engine puts its state for one durable object.
+type EngineStartOptions struct {
+	// DataPath is a fresh, empty, private data directory for this object.
+	DataPath string
+	// BackupsAllowedPath is an absolute, already-created directory the engine
+	// may read and write archives in.
+	BackupsAllowedPath string
+}
+
+// Engine is what a durable object needs from chDB. Implementations own their
+// native resources entirely; the control plane only calls these methods and
+// Close.
+type Engine interface {
+	// Version is the exact chdb_version() of the loaded engine.
+	//
+	// It is recorded in the head as the producer version, and it is not an
+	// exact-match gate: compatibility is checked with backup_format and
+	// min_reader, so later chdb-core releases can restore earlier V1 full
+	// backups. It must be answerable before Start — an incompatible engine is
+	// refused before the object takes a lease or creates a scratch directory.
+	Version(ctx context.Context) (string, error)
+
+	// BackupFormat is the highest archive-format generation this engine can
+	// restore. Every release so far is the V1 baseline, because the C ABI has
+	// no accessor for it; once core exposes one, this starts refusing archives
+	// from a future generation instead of assuming.
+	BackupFormat(ctx context.Context) (int, error)
+
+	// Start brings up a connection on a fresh scratch path. Called once,
+	// before anything else.
+	Start(ctx context.Context, options EngineStartOptions) error
+
+	// CreateDatabase creates the object's database, with core doing the
+	// quoting.
+	CreateDatabase(ctx context.Context, database string) error
+
+	// UseDatabase pins the connection's current database. Called once after
+	// restore; the public surface can never change it, because USE classifies
+	// as CONTROL.
+	UseDatabase(ctx context.Context, database string) error
+
+	// Analyze says what a statement would do, judged against targetDatabase,
+	// without executing it.
+	Analyze(ctx context.Context, sql, targetDatabase string) (chdbpurego.QueryAnalysis, error)
+
+	// Query runs a read query and returns its formatted result.
+	Query(ctx context.Context, sql, format string) (string, error)
+
+	// Run runs a statement for effect.
+	//
+	// This is the *internal* path: it performs no analysis and appends nothing
+	// to a WAL. Replay uses it, which is exactly why it must not be reachable
+	// from the public surface — a replayed statement that re-entered Execute
+	// would be logged a second time.
+	Run(ctx context.Context, sql string) error
+
+	// BackupDatabase writes a full archive to a new absolute path that must
+	// not already exist.
+	BackupDatabase(ctx context.Context, database, filePath string) error
+
+	// RestoreDatabase restores an archive into a database that does not
+	// already hold its tables.
+	RestoreDatabase(ctx context.Context, database, filePath string) error
+
+	// Close releases the native connection. It must be safe to call after a
+	// failed Start.
+	Close(ctx context.Context) error
+}
+
+// EngineFactory builds the engine for one durable object.
+type EngineFactory func(ctx context.Context) (Engine, error)
+
+// assertQueryAllowed applies the frozen Query gate (contract §3.4).
+//
+// Note what is *not* here: a secret check. A read-only statement never reaches
+// the WAL, so a credential inside it is not a durability problem — only a
+// logging one, which this package handles by never echoing SQL.
+func assertQueryAllowed(analysis chdbpurego.QueryAnalysis) error {
+	if analysis.StatementCount != 1 {
+		return newError(CategoryClassificationRefused,
+			"durable: Query takes exactly one statement, core counted %d", analysis.StatementCount)
+	}
+	if analysis.Class != chdbpurego.QueryReadOnly {
+		return newError(CategoryClassificationRefused,
+			"durable: Query accepts only READ_ONLY statements, core classified this as %s",
+			analysis.Class)
+	}
+	return nil
+}
+
+// assertExecuteAllowed applies the frozen Execute gate (contract §3.4).
+//
+// The checks are ordered so the message names the most actionable fact first.
+// The secret check is last and has its own category because it is the one
+// failure a caller fixes by rewriting the statement rather than by using a
+// different method — and because its message must describe the refusal without
+// quoting the statement that triggered it.
+func assertExecuteAllowed(analysis chdbpurego.QueryAnalysis, database string) error {
+	if analysis.StatementCount != 1 {
+		return newError(CategoryClassificationRefused,
+			"durable: Execute takes exactly one statement, core counted %d. A WAL record is one "+
+				"statement, so a batch has no replayable form in V1", analysis.StatementCount)
+	}
+	if analysis.Class != chdbpurego.QueryMutating {
+		message := "durable: Execute accepts only MUTATING statements, core classified this as " +
+			analysis.Class.String()
+		if analysis.Class == chdbpurego.QueryMutatingGlobal {
+			message += ". Global state lives outside every database, so a checkpoint cannot carry " +
+				"it and V1 refuses it"
+		}
+		return newError(CategoryClassificationRefused, "%s", message)
+	}
+	if analysis.ChangesDatabaseLifecycle {
+		return newError(CategoryClassificationRefused,
+			"durable: Execute cannot create, drop or rename a database; the object owns %q and its "+
+				"lifecycle is not a logged mutation", database)
+	}
+	if !analysis.WritesOnlyTargetDatabase {
+		return newError(CategoryClassificationRefused,
+			"durable: core could not prove every write lands in %q. A write to another database, "+
+				"to system, to a table function or to a file is not captured by this object's "+
+				"checkpoint", database)
+	}
+	if analysis.HasSecrets {
+		return newError(CategorySecretRefused,
+			"durable: refusing to log a mutation that embeds a credential; the WAL outlives the "+
+				"statement, so the credential would outlive it too")
+	}
+	return nil
+}

--- a/chdb/durable/engine_test.go
+++ b/chdb/durable/engine_test.go
@@ -3,6 +3,8 @@ package durable
 import (
 	"context"
 	"errors"
+	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -23,15 +25,36 @@ import (
 // limitation of the tests, and chdb.Session refuses a second path with an
 // error naming both — which is why nothing needs to guard against it here.
 
+// requireEngine skips when the loaded engine predates the management ABI, and
+// fails instead when CHDB_REQUIRE_DURABLE_ABI is set.
+//
+// The env var is what CI sets. There the engine version is pinned, so a skip
+// would not mean "this developer has an older libchdb" — it would mean the
+// installer quietly fell back to a release without the ABI, which lib.chdb.io
+// does on a failed download: it retries against releases/latest, and the
+// pinned engine is a pre-release, so "latest" is an older one. These are the
+// only tests that touch a real archive and a real parser, so a green run that
+// skipped all of them would report nothing while looking like coverage.
 func requireEngine(t *testing.T) {
 	t.Helper()
 	available, err := chdbpurego.AdminABIAvailable()
+	required := os.Getenv("CHDB_REQUIRE_DURABLE_ABI") != ""
 	if err != nil {
+		if required {
+			t.Fatalf("libchdb did not load: %v", err)
+		}
 		t.Skipf("libchdb did not load: %v", err)
 	}
-	if !available {
-		t.Skip("libchdb predates the backup/restore/classify ABI (chdb-core v26.7.2-rc.2)")
+	if available {
+		return
 	}
+	version, _ := chdbpurego.Version()
+	message := fmt.Sprintf("the loaded libchdb predates the backup/restore/classify ABI "+
+		"(added in chdb-core v26.7.2-rc.2); it reports %s", version)
+	if required {
+		t.Fatalf("CHDB_REQUIRE_DURABLE_ABI is set but %s", message)
+	}
+	t.Skip(message)
 }
 
 // realNamespace binds a namespace to a directory on disk with the real engine.

--- a/chdb/durable/engine_test.go
+++ b/chdb/durable/engine_test.go
@@ -1,0 +1,312 @@
+package durable
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	chdbpurego "github.com/chdb-io/chdb-go/v2/chdb-purego"
+)
+
+// End-to-end against the real engine.
+//
+// Everything else in this package is tested with a stand-in engine, which is
+// what makes the fault matrix reachable. These tests exist for the two things
+// a stand-in cannot establish: that the gates are fed by ClickHouse's own
+// parser rather than by string matching, and that a real chDB archive written
+// by one scratch directory restores into another.
+//
+// chDB binds one data path per process, so every object here is opened and
+// closed in turn. That is the contract's §3.6 constraint rather than a
+// limitation of the tests, and chdb.Session refuses a second path with an
+// error naming both — which is why nothing needs to guard against it here.
+
+func requireEngine(t *testing.T) {
+	t.Helper()
+	available, err := chdbpurego.AdminABIAvailable()
+	if err != nil {
+		t.Skipf("libchdb did not load: %v", err)
+	}
+	if !available {
+		t.Skip("libchdb predates the backup/restore/classify ABI (chdb-core v26.7.2-rc.2)")
+	}
+}
+
+// realNamespace binds a namespace to a directory on disk with the real engine.
+func realNamespace(t *testing.T, root string) *Namespace {
+	t.Helper()
+	ns, err := NewNamespace("file://"+root, NamespaceOptions{
+		Owner:       "engine-test",
+		ScratchRoot: t.TempDir(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ns
+}
+
+// The whole lifecycle, with nothing faked: create, write, flush, checkpoint,
+// close, and recover on a fresh scratch directory.
+func TestEngineLifecycleRecoversThroughTheObject(t *testing.T) {
+	requireEngine(t)
+	ctx := context.Background()
+	root := filepath.Join(t.TempDir(), "store")
+
+	obj, existed, err := realNamespace(t, root).Open(ctx, "orders", OpenOptions{Database: "mem"})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if existed {
+		t.Fatal("a cold object reported as existing")
+	}
+
+	mustExecute(t, obj, "CREATE TABLE events (id UInt64, note String) ENGINE = MergeTree ORDER BY id")
+	mustExecute(t, obj, "INSERT INTO events VALUES (1, 'one')")
+	if _, err := obj.Flush(ctx); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+
+	// A checkpoint is a real BACKUP DATABASE, which is the step a stand-in
+	// engine cannot stand in for.
+	if _, err := obj.Checkpoint(ctx); err != nil {
+		t.Fatalf("checkpoint: %v", err)
+	}
+
+	// Written after the checkpoint, so recovery has to restore the base *and*
+	// replay a segment on top of it.
+	mustExecute(t, obj, "INSERT INTO events VALUES (2, 'two')")
+	if err := obj.Close(ctx); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	reopened, existed, err := realNamespace(t, root).Open(ctx, "orders", OpenOptions{})
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer reopened.Close(ctx)
+	if !existed {
+		t.Fatal("the object exists")
+	}
+	if reopened.Database() != "mem" {
+		t.Fatalf("the object's database is %q; the head is authoritative", reopened.Database())
+	}
+
+	rows, err := reopened.Query(ctx, "SELECT id, note FROM events ORDER BY id", "CSV")
+	if err != nil {
+		t.Fatalf("query the recovered object: %v", err)
+	}
+	want := "1,\"one\"\n2,\"two\"\n"
+	if rows != want {
+		t.Fatalf("the recovered object holds\n%q\nwant\n%q", rows, want)
+	}
+}
+
+// A database name needing quotes is the case a binding that assembled the SQL
+// itself would get wrong — in BACKUP, in RESTORE, and in the CREATE DATABASE
+// and USE that bracket them.
+func TestEngineHandlesAQuotedDatabaseName(t *testing.T) {
+	requireEngine(t)
+	ctx := context.Background()
+	root := filepath.Join(t.TempDir(), "store")
+
+	obj, _, err := realNamespace(t, root).Open(ctx, "orders", OpenOptions{Database: "my-db"})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	mustExecute(t, obj, "CREATE TABLE events (id UInt64) ENGINE = MergeTree ORDER BY id")
+	mustExecute(t, obj, "INSERT INTO events VALUES (7)")
+	if _, err := obj.Checkpoint(ctx); err != nil {
+		t.Fatalf("checkpoint: %v", err)
+	}
+	if err := obj.Close(ctx); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	reopened, _, err := realNamespace(t, root).Open(ctx, "orders", OpenOptions{})
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer reopened.Close(ctx)
+	rows, err := reopened.Query(ctx, "SELECT id FROM events", "CSV")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if strings.TrimSpace(rows) != "7" {
+		t.Fatalf("the recovered object holds %q, want 7", rows)
+	}
+}
+
+// The gates as core decides them. A string-matching binding gets at least the
+// inline-data and unqualified-name cases wrong, which is why neither is
+// allowed to be a binding's judgement.
+func TestEngineGatesComeFromTheParser(t *testing.T) {
+	requireEngine(t)
+	ctx := context.Background()
+	root := filepath.Join(t.TempDir(), "store")
+
+	obj, _, err := realNamespace(t, root).Open(ctx, "orders", OpenOptions{Database: "mem"})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer obj.Close(ctx)
+
+	mustExecute(t, obj, "CREATE TABLE events (id UInt64) ENGINE = MergeTree ORDER BY id")
+
+	// Inline data holding a semicolon is one statement. No amount of splitting
+	// on ";" gets this right.
+	if _, err := obj.Execute(ctx, "INSERT INTO events FORMAT CSV 1\n"); err != nil {
+		t.Fatalf("a single INSERT ... FORMAT should be accepted: %v", err)
+	}
+	// An unqualified name resolves through the connection's current database,
+	// which the object pinned to its own.
+	if _, err := obj.Execute(ctx, "INSERT INTO events VALUES (2)"); err != nil {
+		t.Fatalf("an unqualified write to the object's own database should be accepted: %v", err)
+	}
+	// And a qualified one to the same database is the same write.
+	if _, err := obj.Execute(ctx, "INSERT INTO mem.events VALUES (3)"); err != nil {
+		t.Fatalf("a qualified write to the object's own database should be accepted: %v", err)
+	}
+
+	refusals := []struct {
+		name string
+		sql  string
+		want *Error
+	}{
+		{"two statements", "INSERT INTO events VALUES (4); INSERT INTO events VALUES (5)", ErrClassificationRefused},
+		{"a read through Execute", "SELECT count() FROM events", ErrClassificationRefused},
+		{"session control", "SET max_threads = 1", ErrClassificationRefused},
+		{"a global function", "CREATE FUNCTION plus_one AS (x) -> x + 1", ErrClassificationRefused},
+		{"another database", "INSERT INTO other.events VALUES (6)", ErrClassificationRefused},
+		{"database lifecycle", "DROP DATABASE mem", ErrClassificationRefused},
+		{"a table function", "INSERT INTO FUNCTION file('out.csv', 'CSV') SELECT * FROM events", ErrClassificationRefused},
+		{"a file sink", "SELECT * FROM events INTO OUTFILE '/tmp/durable-test.csv'", ErrClassificationRefused},
+		{"unparseable", "this is not sql", ErrClassificationRefused},
+	}
+	for _, tc := range refusals {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := obj.Execute(ctx, tc.sql)
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("Execute reported %q, want %q: %v", CategoryOf(err), tc.want.Category, err)
+			}
+		})
+	}
+
+	// A mutation embedding a credential cannot be logged, because the WAL
+	// outlives the statement.
+	_, err = obj.Execute(ctx,
+		"INSERT INTO events SELECT 1 FROM s3('https://example.com/x.csv', 'AKIAEXAMPLE', 'wJalrXUtnFEMIsecret', 'CSV', 'id UInt64')")
+	if !errors.Is(err, ErrSecretRefused) && !errors.Is(err, ErrClassificationRefused) {
+		t.Fatalf("a secret-bearing mutation reported %q: %v", CategoryOf(err), err)
+	}
+	if err != nil && strings.Contains(err.Error(), "wJalrXUtnFEMIsecret") {
+		t.Fatal("the refusal quoted the credential it exists to keep out")
+	}
+
+	// Query is gated from the other side.
+	if _, err := obj.Query(ctx, "INSERT INTO events VALUES (9)", "CSV"); !errors.Is(err, ErrClassificationRefused) {
+		t.Fatalf("Query accepted a write, or reported %q", CategoryOf(err))
+	}
+
+	rows, err := obj.Query(ctx, "SELECT count() FROM events", "CSV")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	// Three accepted writes, and nothing a refusal let through.
+	if strings.TrimSpace(rows) != "3" {
+		t.Fatalf("the database holds %q rows, want 3", rows)
+	}
+}
+
+// A read-only handle takes no lease and serves the manifest as it stood at
+// open. Two live objects in one process would break the engine's one-path
+// rule, so the writer is closed first.
+func TestEngineReadOnlyOpenServesASnapshot(t *testing.T) {
+	requireEngine(t)
+	ctx := context.Background()
+	root := filepath.Join(t.TempDir(), "store")
+
+	writer, _, err := realNamespace(t, root).Open(ctx, "orders", OpenOptions{Database: "mem"})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	mustExecute(t, writer, "CREATE TABLE events (id UInt64) ENGINE = MergeTree ORDER BY id")
+	mustExecute(t, writer, "INSERT INTO events VALUES (1)")
+	if err := writer.Close(ctx); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	reader, _, err := realNamespace(t, root).Open(ctx, "orders", OpenOptions{ReadOnly: true})
+	if err != nil {
+		t.Fatalf("read-only open: %v", err)
+	}
+	defer reader.Close(ctx)
+
+	rows, err := reader.Query(ctx, "SELECT count() FROM events", "CSV")
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if strings.TrimSpace(rows) != "1" {
+		t.Fatalf("the reader sees %q rows, want 1", rows)
+	}
+	if _, err := reader.Execute(ctx, "INSERT INTO events VALUES (2)"); err == nil {
+		t.Fatal("a read-only handle accepted a write")
+	}
+}
+
+// chDB binds one data path per process. The failure has to be legible rather
+// than a crash somewhere deeper, which is why durable objects go through
+// chdb.Session's registry instead of opening native connections directly.
+func TestEngineRefusesASecondObjectInOneProcess(t *testing.T) {
+	requireEngine(t)
+	ctx := context.Background()
+	root := filepath.Join(t.TempDir(), "store")
+
+	first, _, err := realNamespace(t, root).Open(ctx, "orders", OpenOptions{Database: "mem"})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer first.Close(ctx)
+
+	_, _, err = realNamespace(t, root).Open(ctx, "invoices", OpenOptions{Database: "mem"})
+	if err == nil {
+		t.Fatal("a second open on a different data path should be refused")
+	}
+	if !strings.Contains(err.Error(), "one data path per process") {
+		t.Fatalf("the error does not explain the constraint: %v", err)
+	}
+	// And the refusal did not strand a lease on the object it could not open.
+	backend, err := NewLocalBackend(filepath.Join(root, "invoices"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot, found, err := readHead(ctx, backend)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if found && snapshot.head.Lease.Owner != nil {
+		t.Fatalf("the failed open left the lease held: %+v", snapshot.head.Lease)
+	}
+}
+
+// The version an object records is the engine's own, and it is what the
+// compatibility gate is written against. If chdb_version() ever stops being
+// orderable, every later reader silently loses the ability to open the object.
+func TestEngineVersionIsOrderable(t *testing.T) {
+	requireEngine(t)
+	version, err := chdbpurego.Version()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := parseVersion(version); !ok {
+		t.Fatalf("chdb_version() reports %q, which this package cannot order by release "+
+			"precedence — so it cannot decide compatibility", version)
+	}
+	// And an object written by it is readable by itself, which is the trivial
+	// case the gate must not get wrong.
+	head := coldHead("mem", version, BackupFormatBaseline)
+	if err := assertEngineCompatible(head, runningEngine{version: version, backupFormat: BackupFormatBaseline}); err != nil {
+		t.Fatalf("an engine cannot read its own object: %v", err)
+	}
+}

--- a/chdb/durable/errors.go
+++ b/chdb/durable/errors.go
@@ -1,0 +1,172 @@
+package durable
+
+import (
+	"errors"
+	"fmt"
+)
+
+// The V1 error model.
+//
+// The contract freezes a set of error *categories* (§6) and requires them to
+// be programmatically distinguishable across bindings. It deliberately does
+// not freeze type names, so the category is a string on one error type rather
+// than a hierarchy of types — which in Go also means a caller can branch with
+// errors.Is against a sentinel:
+//
+//	if errors.Is(err, durable.ErrLeaseHeld) { ... }
+//	switch durable.CategoryOf(err) { case durable.CategoryCorrupt: ... }
+//
+// Two rules the contract states outright and this file encodes:
+//
+//  1. A provider precondition failure (HTTP 412 and friends) is a
+//     compare-and-set race first. It is resolved against lease and manifest
+//     state into lease_held, lease_fenced or a retry — never reported as a
+//     plain backend error. CategoryBackend is for failures that really are the
+//     provider's: network, auth, quota.
+//  2. Messages carry no secret-bearing SQL, no credentials and no unredacted
+//     connection parameters. secret_refused in particular says what was
+//     refused without echoing the statement that caused it.
+
+// Category is a frozen V1 error category. Cross-binding conformance asserts on
+// these exact strings, so they are wire names rather than prose.
+type Category string
+
+const (
+	// CategoryNotFound is a read-only open of an object that does not exist,
+	// or an open that required an existing object.
+	CategoryNotFound Category = "not_found"
+	// CategoryLeaseHeld is another writer holding an unexpired lease.
+	CategoryLeaseHeld Category = "lease_held"
+	// CategoryLeaseFenced is this instance no longer owning the generation it
+	// was writing under, whether through a takeover or through self-fencing
+	// after it could not confirm its lease in time.
+	CategoryLeaseFenced Category = "lease_fenced"
+	// CategoryEngineIncompatible is an object whose archive format or minimum
+	// reader this engine cannot satisfy, or one written by another engine.
+	CategoryEngineIncompatible Category = "engine_incompatible"
+	// CategoryProtocolUnsupported is a protocol version above this baseline,
+	// or a feature name this build does not know.
+	CategoryProtocolUnsupported Category = "protocol_unsupported"
+	// CategoryCorrupt is a head that fails schema validation, a referenced
+	// immutable object that is missing, or one whose length or SHA-256 does
+	// not match. Never downgraded into opening an older state.
+	CategoryCorrupt Category = "corrupt"
+	// CategoryClassificationRefused is core analysis refusing a statement at a
+	// public entry point: wrong statement count, wrong class, or a write
+	// outside the object's database.
+	CategoryClassificationRefused Category = "classification_refused"
+	// CategorySecretRefused is a mutation embedding a credential. V1 has
+	// nowhere to put it other than the WAL, which outlives the statement, so
+	// it is refused outright.
+	CategorySecretRefused Category = "secret_refused"
+	// CategoryEngine is a core query, backup or restore failure.
+	CategoryEngine Category = "engine"
+	// CategoryBackend is a provider network, auth or non-conditional failure.
+	CategoryBackend Category = "backend"
+	// CategoryTimeout is a deadline passing while the operation was provably
+	// still uncommitted.
+	CategoryTimeout Category = "timeout"
+	// CategoryCommitAmbiguous is reconcile being unable to prove whether the
+	// remote committed. The one thing it must never do is report success.
+	CategoryCommitAmbiguous Category = "commit_ambiguous"
+	// CategoryLimitExceeded is SQL, a WAL segment, a head or a provider object
+	// over a declared V1 limit.
+	CategoryLimitExceeded Category = "limit_exceeded"
+	// CategoryClosed is an operation on an object whose close has completed.
+	CategoryClosed Category = "closed"
+)
+
+// Error is every failure this package reports. Category is what callers branch
+// on; the remaining fields are populated only where they mean something, so a
+// caller can act on the specifics without parsing the message.
+type Error struct {
+	// Category is the frozen V1 category.
+	Category Category
+
+	// Message describes the failure. Never holds SQL or credentials.
+	Message string
+
+	// Err is the underlying cause, if any. Reachable with errors.Unwrap.
+	Err error
+
+	// Owner is the visible name recorded on a lease that blocked this
+	// operation. Observability only — never an authority check.
+	Owner string
+
+	// Key names the object whose commit state could not be settled, for
+	// operator triage of a commit_ambiguous.
+	Key string
+
+	// Features lists the unrecognised protocol feature names that blocked the
+	// open, so the operator learns which build they need.
+	Features []string
+
+	// Expected and Actual carry the two sides of a compatibility refusal: what
+	// the object demands and what this process offers.
+	Expected string
+	Actual   string
+
+	// Limit and Observed carry the two sides of a limit refusal, in bytes.
+	Limit    int64
+	Observed int64
+}
+
+func (e *Error) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("%s: %v", e.Message, e.Err)
+	}
+	return e.Message
+}
+
+func (e *Error) Unwrap() error { return e.Err }
+
+// Is matches by category, which is what makes the sentinels below work with
+// errors.Is: a target carrying only a category matches any error of that
+// category, while a fully populated target still compares as itself.
+func (e *Error) Is(target error) bool {
+	other, ok := target.(*Error)
+	if !ok {
+		return false
+	}
+	return other.Message == "" && other.Category == e.Category
+}
+
+// Sentinels for errors.Is. Each one carries a category and nothing else, so it
+// matches any error of that category.
+var (
+	ErrNotFound              = &Error{Category: CategoryNotFound}
+	ErrLeaseHeld             = &Error{Category: CategoryLeaseHeld}
+	ErrLeaseFenced           = &Error{Category: CategoryLeaseFenced}
+	ErrEngineIncompatible    = &Error{Category: CategoryEngineIncompatible}
+	ErrProtocolUnsupported   = &Error{Category: CategoryProtocolUnsupported}
+	ErrCorrupt               = &Error{Category: CategoryCorrupt}
+	ErrClassificationRefused = &Error{Category: CategoryClassificationRefused}
+	ErrSecretRefused         = &Error{Category: CategorySecretRefused}
+	ErrEngine                = &Error{Category: CategoryEngine}
+	ErrBackend               = &Error{Category: CategoryBackend}
+	ErrTimeout               = &Error{Category: CategoryTimeout}
+	ErrCommitAmbiguous       = &Error{Category: CategoryCommitAmbiguous}
+	ErrLimitExceeded         = &Error{Category: CategoryLimitExceeded}
+	ErrClosed                = &Error{Category: CategoryClosed}
+)
+
+// CategoryOf returns the V1 category of err, or "" if err is not one of this
+// package's errors. It unwraps, so a category survives being wrapped with
+// fmt.Errorf("%w").
+func CategoryOf(err error) Category {
+	var e *Error
+	if errors.As(err, &e) {
+		return e.Category
+	}
+	return ""
+}
+
+// newError builds an error of one category with a formatted message.
+func newError(category Category, format string, args ...any) *Error {
+	return &Error{Category: category, Message: fmt.Sprintf(format, args...)}
+}
+
+// wrapError is newError with a cause attached.
+func wrapError(category Category, cause error, format string, args ...any) *Error {
+	return &Error{Category: category, Message: fmt.Sprintf(format, args...), Err: cause}
+}

--- a/chdb/durable/fake_test.go
+++ b/chdb/durable/fake_test.go
@@ -1,0 +1,306 @@
+package durable
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	chdbpurego "github.com/chdb-io/chdb-go/v2/chdb-purego"
+)
+
+// A stand-in engine and a fault-injecting backend, so the state machine can be
+// driven through every branch the contract's fault matrix names without a
+// native library.
+//
+// The fake engine is allowed to classify SQL with string matching, which the
+// real one is not: it stands in for core's parser rather than reimplementing
+// it, and the gates it feeds are exercised against the real parser in
+// engine_test.go. What it models faithfully is the part the state machine
+// depends on — that a statement changes state, that a backup captures exactly
+// the state at the moment it runs, and that a restore reproduces it.
+
+type fakeEngine struct {
+	version      string
+	backupFormat int
+
+	mu         sync.Mutex
+	started    bool
+	dataPath   string
+	backupPath string
+	database   string
+	// applied is the database: the statements that have run, in order. It is
+	// what a backup captures and a replay has to reproduce.
+	applied []string
+
+	// analyze overrides classification for one test.
+	analyze func(sql, target string) (chdbpurego.QueryAnalysis, error)
+	// runErr fails one statement, for the "a failed statement is never
+	// logged" case.
+	runErr func(sql string) error
+	// backupErr and restoreErr fail the management calls.
+	backupErr  error
+	restoreErr error
+}
+
+func newFakeEngine() *fakeEngine {
+	return &fakeEngine{version: "26.7.2-rc.2", backupFormat: BackupFormatBaseline}
+}
+
+func (f *fakeEngine) factory() EngineFactory {
+	return func(context.Context) (Engine, error) { return f, nil }
+}
+
+func (f *fakeEngine) Version(context.Context) (string, error) { return f.version, nil }
+
+func (f *fakeEngine) BackupFormat(context.Context) (int, error) { return f.backupFormat, nil }
+
+func (f *fakeEngine) Start(_ context.Context, options EngineStartOptions) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.started = true
+	f.dataPath = options.DataPath
+	f.backupPath = options.BackupsAllowedPath
+	return nil
+}
+
+func (f *fakeEngine) CreateDatabase(_ context.Context, database string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.database = database
+	return nil
+}
+
+func (f *fakeEngine) UseDatabase(_ context.Context, database string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.database = database
+	return nil
+}
+
+func (f *fakeEngine) Analyze(_ context.Context, sql, target string) (chdbpurego.QueryAnalysis, error) {
+	if f.analyze != nil {
+		return f.analyze(sql, target)
+	}
+	return fakeClassify(sql, target), nil
+}
+
+func (f *fakeEngine) Query(_ context.Context, sql, _ string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	// The one query the tests ask: what is in the database.
+	return strings.Join(f.applied, "\n"), nil
+}
+
+func (f *fakeEngine) Run(_ context.Context, sql string) error {
+	if f.runErr != nil {
+		if err := f.runErr(sql); err != nil {
+			return err
+		}
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.applied = append(f.applied, sql)
+	return nil
+}
+
+func (f *fakeEngine) BackupDatabase(_ context.Context, database, filePath string) error {
+	if f.backupErr != nil {
+		return f.backupErr
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if _, err := os.Stat(filePath); err == nil {
+		return newError(CategoryEngine, "durable: %s already exists", filePath)
+	}
+	data, err := json.Marshal(struct {
+		Database   string   `json:"database"`
+		Statements []string `json:"statements"`
+	}{database, f.applied})
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filePath, data, 0o600)
+}
+
+func (f *fakeEngine) RestoreDatabase(_ context.Context, database, filePath string) error {
+	if f.restoreErr != nil {
+		return f.restoreErr
+	}
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return err
+	}
+	var archive struct {
+		Database   string   `json:"database"`
+		Statements []string `json:"statements"`
+	}
+	if err := json.Unmarshal(data, &archive); err != nil {
+		return err
+	}
+	if archive.Database != database {
+		// An archive names the database it came from and restores under that
+		// name and no other — the real engine reports BACKUP_ENTRY_NOT_FOUND.
+		return newError(CategoryEngine, "durable: database %s not found in backup", database)
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.applied = append(f.applied, archive.Statements...)
+	f.database = database
+	return nil
+}
+
+func (f *fakeEngine) Close(context.Context) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.started = false
+	return nil
+}
+
+func (f *fakeEngine) isStarted() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.started
+}
+
+func (f *fakeEngine) statements() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.applied...)
+}
+
+// fakeClassify stands in for core's parser. Crude on purpose: what it has to
+// get right is the shape of the answer, not the parsing.
+func fakeClassify(sql, target string) chdbpurego.QueryAnalysis {
+	trimmed := strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(sql), ";"))
+	upper := strings.ToUpper(trimmed)
+
+	count := uint32(1)
+	if trimmed == "" {
+		count = 0
+	} else if strings.Contains(trimmed, ";") || strings.Contains(upper, "PARALLEL WITH") {
+		count = 2
+	}
+
+	analysis := chdbpurego.QueryAnalysis{StatementCount: count}
+	analysis.HasSecrets = strings.Contains(upper, "SECRET_ACCESS_KEY")
+
+	switch {
+	case strings.HasPrefix(upper, "SELECT"), strings.HasPrefix(upper, "SHOW"),
+		strings.HasPrefix(upper, "DESCRIBE"), strings.HasPrefix(upper, "EXPLAIN"):
+		analysis.Class = chdbpurego.QueryReadOnly
+		analysis.WritesOnlyTargetDatabase = true
+	case strings.HasPrefix(upper, "SET"), strings.HasPrefix(upper, "USE"),
+		strings.HasPrefix(upper, "SYSTEM"), strings.HasPrefix(upper, "BACKUP"),
+		strings.HasPrefix(upper, "RESTORE"), strings.Contains(upper, "INTO OUTFILE"):
+		analysis.Class = chdbpurego.QueryControl
+	case strings.HasPrefix(upper, "CREATE FUNCTION"), strings.HasPrefix(upper, "CREATE USER"),
+		strings.Contains(upper, "SYSTEM."):
+		analysis.Class = chdbpurego.QueryMutatingGlobal
+	case strings.HasPrefix(upper, "NOT SQL"):
+		analysis.Class = chdbpurego.QueryUnknown
+		analysis.StatementCount = 0
+		analysis.HasSecrets = false
+	default:
+		analysis.Class = chdbpurego.QueryMutating
+		if strings.Contains(upper, "DATABASE") &&
+			(strings.HasPrefix(upper, "CREATE DATABASE") || strings.HasPrefix(upper, "DROP DATABASE") ||
+				strings.HasPrefix(upper, "RENAME DATABASE")) {
+			analysis.ChangesDatabaseLifecycle = true
+		}
+		// A qualified reference to anything but the target database, or a
+		// write through a table function, clears the proof.
+		other := strings.Contains(upper, "INTO FUNCTION") ||
+			(strings.Contains(trimmed, ".") && !strings.Contains(trimmed, target+"."))
+		analysis.WritesOnlyTargetDatabase = !other
+	}
+	return analysis
+}
+
+// faultBackend wraps a backend so a test can make one operation behave the way
+// a provider does on a bad day.
+type faultBackend struct {
+	Backend
+
+	mu sync.Mutex
+
+	// onPutBytes intercepts a conditional create. Returning handled=true
+	// substitutes the outcome without touching the store, which is how a
+	// write that never left the machine is modelled.
+	onPutBytes func(key string, attempt int) (outcome PutOutcome, err error, handled bool)
+
+	// afterPutBytes runs after the real create, so a test can model bytes
+	// that landed and a response that did not.
+	afterPutBytes func(key string, attempt int, outcome PutOutcome) (PutOutcome, error)
+
+	// onReplace intercepts a compare-and-swap. It runs *before* the real call;
+	// pass through by returning handled=false.
+	onReplace func(key string, attempt int) (outcome ReplaceOutcome, err error, handled bool)
+
+	// afterReplace runs after a successful compare-and-swap, so a test can
+	// model a commit whose response was lost.
+	afterReplace func(key string, attempt int, outcome ReplaceOutcome) (ReplaceOutcome, error)
+
+	putAttempts     map[string]int
+	replaceAttempts map[string]int
+}
+
+func newFaultBackend(inner Backend) *faultBackend {
+	return &faultBackend{
+		Backend:         inner,
+		putAttempts:     map[string]int{},
+		replaceAttempts: map[string]int{},
+	}
+}
+
+func (f *faultBackend) PutBytesIfAbsent(ctx context.Context, key string, data []byte) (PutOutcome, error) {
+	f.mu.Lock()
+	f.putAttempts[key]++
+	attempt := f.putAttempts[key]
+	before, after := f.onPutBytes, f.afterPutBytes
+	f.mu.Unlock()
+
+	if before != nil {
+		if outcome, err, handled := before(key, attempt); handled {
+			return outcome, err
+		}
+	}
+	outcome, err := f.Backend.PutBytesIfAbsent(ctx, key, data)
+	if err != nil || after == nil {
+		return outcome, err
+	}
+	return after(key, attempt, outcome)
+}
+
+func (f *faultBackend) ReplaceIfMatch(ctx context.Context, key string, data []byte, etag string) (ReplaceOutcome, error) {
+	f.mu.Lock()
+	f.replaceAttempts[key]++
+	attempt := f.replaceAttempts[key]
+	before, after := f.onReplace, f.afterReplace
+	f.mu.Unlock()
+
+	if before != nil {
+		if outcome, err, handled := before(key, attempt); handled {
+			return outcome, err
+		}
+	}
+	outcome, err := f.Backend.ReplaceIfMatch(ctx, key, data, etag)
+	if err != nil || after == nil {
+		return outcome, err
+	}
+	return after(key, attempt, outcome)
+}
+
+// Reaching past the backend to damage the store, for the corruption cases the
+// contract's fixture list names. A backend has no delete and no overwrite —
+// V1 gives nothing the authority to remove an object — so a test that needs
+// one goes to the filesystem directly.
+func removeFromStore(f *fixture, key string) error {
+	return os.Remove(filepath.Join(f.root, "orders", key))
+}
+
+func overwriteInStore(f *fixture, key string, data []byte) error {
+	return os.WriteFile(filepath.Join(f.root, "orders", key), data, 0o600)
+}

--- a/chdb/durable/gate.go
+++ b/chdb/durable/gate.go
@@ -1,0 +1,116 @@
+package durable
+
+import (
+	"context"
+	"sync"
+)
+
+// Operation serialization (contract §5.3).
+//
+// The contract requires an explicit queue and forbids leaning on "the runtime
+// happens to serialize this" as the argument. In Go it plainly does not:
+// heartbeat runs on its own goroutine, callers are free to use one object from
+// several goroutines, and every commit path has a window between a storage
+// call and the state update that follows it.
+//
+// A durable object uses two of these rather than one, and the split is the
+// interesting part.
+//
+//   - The **operation** gate covers a whole logical operation: execute,
+//     query, flush, checkpoint, close. Holding it for the duration of a
+//     checkpoint is what stops new writes landing in a database that is being
+//     archived.
+//   - The **head** gate covers a single compare-and-swap against head.json.
+//
+// If one gate covered both, a checkpoint of a large database would block
+// heartbeat for the whole backup and upload, and the writer would fence itself
+// out of an object it was in the middle of legitimately checkpointing. With
+// the split, heartbeat only ever contends for the head gate, which is held for
+// a single conditional write — while the checkpoint's own final commit takes
+// that same gate and therefore sees the ETag heartbeat just produced.
+//
+// A channel rather than a sync.Mutex, because waiting has to be cancellable: a
+// caller that passes a context with a deadline should not be stuck behind a
+// checkpoint until the deadline is meaningless.
+
+type gate struct {
+	slot chan struct{}
+
+	mu sync.Mutex
+	// sealed, once set, turns away new entrants with the error it returns.
+	// Close uses it: the drain has to happen before the durability barrier,
+	// and new callers have to be refused rather than silently queued behind a
+	// close they will never come back from.
+	sealed func() error
+}
+
+func newGate() *gate {
+	return &gate{slot: make(chan struct{}, 1)}
+}
+
+// acquire waits for exclusive access, honouring ctx and the seal.
+//
+// The seal is checked twice, and the second check is the one that matters. A
+// caller that arrives while the gate is still open waits behind whatever is in
+// flight — and close may be what seals it in the meantime. Checking only on
+// arrival would let that caller run one more operation against an object whose
+// close has already drained the queue and is about to shut the engine down.
+func (g *gate) acquire(ctx context.Context) error {
+	if err := g.sealedErr(); err != nil {
+		return err
+	}
+	if err := g.acquireSealed(ctx); err != nil {
+		return err
+	}
+	if err := g.sealedErr(); err != nil {
+		g.release()
+		return err
+	}
+	return nil
+}
+
+func (g *gate) sealedErr() error {
+	g.mu.Lock()
+	sealed := g.sealed
+	g.mu.Unlock()
+	if sealed == nil {
+		return nil
+	}
+	return sealed()
+}
+
+// acquireSealed waits for exclusive access without consulting the seal. Close
+// itself needs this: it seals the gate against everyone else and then still
+// has to do its own work in the same serialized position.
+func (g *gate) acquireSealed(ctx context.Context) error {
+	select {
+	case g.slot <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return wrapError(CategoryTimeout, ctx.Err(),
+			"durable: gave up waiting for the operation queue")
+	}
+}
+
+func (g *gate) release() {
+	select {
+	case <-g.slot:
+	default:
+		// Releasing a gate nobody holds is a bug in this package, not
+		// something a caller can cause; not blocking here keeps that bug from
+		// turning into a deadlock that hides where it came from.
+	}
+}
+
+// seal stops new work and waits for what is in flight to finish.
+func (g *gate) seal(ctx context.Context, reason func() error) error {
+	g.mu.Lock()
+	g.sealed = reason
+	g.mu.Unlock()
+	// Taking the slot is the drain: whoever holds it now finishes first.
+	if err := g.acquireSealed(ctx); err != nil {
+		return err
+	}
+	g.release()
+	return nil
+}

--- a/chdb/durable/head.go
+++ b/chdb/durable/head.go
@@ -1,0 +1,564 @@
+package durable
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"math"
+	"regexp"
+	"strings"
+	"unicode/utf8"
+)
+
+// head.json parsing, strict validation and unknown-field-preserving
+// write-back (contract §4.2, §4.3, §4.5).
+//
+// The single most important thing this file does is *not* rebuild the head
+// from scratch on every write. A writer that constructs a fresh document each
+// time silently deletes every field it does not know about, which turns the
+// whole named-feature mechanism into a lie: a future revision's state would
+// survive exactly until an older writer touched the object. So the parsed raw
+// JSON travels alongside the typed view, and serializeHead patches the known
+// fields onto a copy of it.
+//
+// The second thing is that "preserve unknown fields" is not "be lenient".
+// Known fields are validated strictly — a wrong type is corrupt, not a
+// best-effort coercion — because a head that does not mean what it says is
+// more dangerous than one that fails to load.
+//
+// Numbers are decoded as json.Number rather than float64 throughout. An
+// unknown field holding a large integer or a long decimal would otherwise come
+// back as a float and be written out in a different, lossy spelling — silently
+// corrupting the one thing round-tripping exists to protect.
+
+var sha256Pattern = regexp.MustCompile(`^[0-9a-f]{64}$`)
+
+// maxSafeInteger is the largest integer every JSON implementation can hold
+// exactly. The contract requires all integers in a head to stay inside it, so
+// a value beyond it is refused here rather than read differently by the next
+// binding to open the object.
+const maxSafeInteger = int64(1)<<53 - 1
+
+func corrupt(format string, args ...any) *Error {
+	return newError(CategoryCorrupt, "durable: head.json "+fmt.Sprintf(format, args...))
+}
+
+func asObject(v any) (map[string]any, bool) {
+	obj, ok := v.(map[string]any)
+	return obj, ok
+}
+
+// required reads a field that must be present.
+//
+// A plain lookup cannot tell an absent property from an explicit null, and for
+// this document that distinction carries meaning: a released lease is
+// *explicitly* three nulls, while a lease missing those keys is a truncated
+// write. Treating the second as the first hands the object to a new writer on
+// the strength of a corrupt head.
+func required(obj map[string]any, key, where string) (any, error) {
+	v, ok := obj[key]
+	if !ok {
+		return nil, corrupt("%s is required", where)
+	}
+	return v, nil
+}
+
+func safeInt(v any, where string) (int64, error) {
+	num, ok := v.(json.Number)
+	if !ok {
+		return 0, corrupt("%s must be a non-negative safe integer", where)
+	}
+	n, err := num.Int64()
+	if err != nil || n < 0 || n > maxSafeInteger {
+		return 0, corrupt("%s must be a non-negative safe integer", where)
+	}
+	return n, nil
+}
+
+func nonEmptyString(v any, where string) (string, error) {
+	s, ok := v.(string)
+	if !ok || s == "" {
+		return "", corrupt("%s must be a non-empty string", where)
+	}
+	return s, nil
+}
+
+func stringArray(v any, where string) ([]string, error) {
+	items, ok := v.([]any)
+	if !ok {
+		return nil, corrupt("%s must be an array of strings", where)
+	}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		s, ok := item.(string)
+		if !ok {
+			return nil, corrupt("%s must be an array of strings", where)
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}
+
+func parseRef(v any, where string) (ObjectRef, error) {
+	obj, ok := asObject(v)
+	if !ok {
+		return ObjectRef{}, corrupt("%s must be an object", where)
+	}
+	rawKey, err := required(obj, "key", where+".key")
+	if err != nil {
+		return ObjectRef{}, err
+	}
+	key, ok := rawKey.(string)
+	if !ok || !IsValidObjectKey(key) {
+		return ObjectRef{}, corrupt("%s.key is not a valid relative object key: %v", where, rawKey)
+	}
+	rawSize, err := required(obj, "size", where+".size")
+	if err != nil {
+		return ObjectRef{}, err
+	}
+	size, err := safeInt(rawSize, where+".size")
+	if err != nil {
+		return ObjectRef{}, err
+	}
+	rawSum, err := required(obj, "sha256", where+".sha256")
+	if err != nil {
+		return ObjectRef{}, err
+	}
+	sum, ok := rawSum.(string)
+	if !ok || !sha256Pattern.MatchString(sum) {
+		return ObjectRef{}, corrupt("%s.sha256 must be 64 lowercase hex characters", where)
+	}
+	return ObjectRef{Key: key, Size: size, SHA256: sum}, nil
+}
+
+// parseProtocol reads the negotiation block.
+//
+// A missing block reads as the V1 baseline with no features. That is the
+// documented default rather than a rejection so that objects written before
+// the block existed stay readable; every other shape is validated strictly.
+// An absent key takes its default, while a key that is *present* takes its
+// value — including an explicit null, which then fails validation. The
+// defaults exist for older documents, not as a way to launder bad data.
+func parseProtocol(v any, present bool) (Protocol, error) {
+	if !present {
+		return Protocol{Version: ProtocolVersion, ReaderFeatures: []string{}, WriterFeatures: []string{}}, nil
+	}
+	obj, ok := asObject(v)
+	if !ok {
+		return Protocol{}, corrupt("protocol must be an object")
+	}
+	out := Protocol{Version: ProtocolVersion, ReaderFeatures: []string{}, WriterFeatures: []string{}}
+	if raw, ok := obj["version"]; ok {
+		n, err := safeInt(raw, "protocol.version")
+		if err != nil {
+			return Protocol{}, err
+		}
+		out.Version = int(n)
+	}
+	if raw, ok := obj["reader_features"]; ok {
+		features, err := stringArray(raw, "protocol.reader_features")
+		if err != nil {
+			return Protocol{}, err
+		}
+		out.ReaderFeatures = features
+	}
+	if raw, ok := obj["writer_features"]; ok {
+		features, err := stringArray(raw, "protocol.writer_features")
+		if err != nil {
+			return Protocol{}, err
+		}
+		out.WriterFeatures = features
+	}
+	return out, nil
+}
+
+// parseEngine reads the engine identity.
+//
+// The block itself has no default — a head that records no engine cannot
+// establish compatibility at all, so an absent one is a refusal rather than a
+// wildcard. The two compatibility fields do have defaults, and both are the
+// conservative reading of an object written before they existed:
+//
+//   - backup_format defaults to the V1 baseline, which is what such an object
+//     necessarily used.
+//   - min_reader defaults to version. That reproduces the old exact-match
+//     behaviour's lower bound: only a reader at or above the producer may open
+//     it. Defaulting it to something older would retroactively widen an
+//     object's audience on the strength of a field its writer never wrote.
+func parseEngine(v any) (EngineIdentity, error) {
+	obj, ok := asObject(v)
+	if !ok {
+		return EngineIdentity{}, corrupt("engine must be an object")
+	}
+	rawVersion, err := required(obj, "version", "engine.version")
+	if err != nil {
+		return EngineIdentity{}, err
+	}
+	version, err := nonEmptyString(rawVersion, "engine.version")
+	if err != nil {
+		return EngineIdentity{}, err
+	}
+	rawName, err := required(obj, "name", "engine.name")
+	if err != nil {
+		return EngineIdentity{}, err
+	}
+	name, err := nonEmptyString(rawName, "engine.name")
+	if err != nil {
+		return EngineIdentity{}, err
+	}
+	out := EngineIdentity{Name: name, Version: version, BackupFormat: BackupFormatBaseline, MinReader: version}
+	if raw, ok := obj["backup_format"]; ok {
+		n, err := safeInt(raw, "engine.backup_format")
+		if err != nil {
+			return EngineIdentity{}, err
+		}
+		out.BackupFormat = int(n)
+	}
+	if raw, ok := obj["min_reader"]; ok {
+		s, err := nonEmptyString(raw, "engine.min_reader")
+		if err != nil {
+			return EngineIdentity{}, err
+		}
+		out.MinReader = s
+	}
+	return out, nil
+}
+
+// parseLease reads the writer lease.
+//
+// The lease is either fully held or fully released. A partial form — an owner
+// with no expiry, an expiry with no instance — is rejected rather than
+// normalised, because each half implies a different answer to "may I take this
+// over", and guessing is how two writers end up believing they are the one
+// writer.
+func parseLease(v any) (Lease, error) {
+	obj, ok := asObject(v)
+	if !ok {
+		return Lease{}, corrupt("lease must be an object")
+	}
+	rawGeneration, err := required(obj, "generation", "lease.generation")
+	if err != nil {
+		return Lease{}, err
+	}
+	generation, err := safeInt(rawGeneration, "lease.generation")
+	if err != nil {
+		return Lease{}, err
+	}
+	owner, err := required(obj, "owner", "lease.owner")
+	if err != nil {
+		return Lease{}, err
+	}
+	instance, err := required(obj, "instance", "lease.instance")
+	if err != nil {
+		return Lease{}, err
+	}
+	expiresAt, err := required(obj, "expires_at", "lease.expires_at")
+	if err != nil {
+		return Lease{}, err
+	}
+
+	if owner == nil && instance == nil && expiresAt == nil {
+		return Lease{Generation: generation}, nil
+	}
+
+	ownerStr, ownerOK := owner.(string)
+	instanceStr, instanceOK := instance.(string)
+	expiresNum, expiresOK := expiresAt.(json.Number)
+	if !ownerOK || !instanceOK || !expiresOK {
+		return Lease{}, corrupt("lease must be either fully released (owner, instance and " +
+			"expires_at all null) or fully held (owner and instance strings, expires_at a number)")
+	}
+	expires, err := expiresNum.Float64()
+	if err != nil || math.IsInf(expires, 0) || math.IsNaN(expires) {
+		return Lease{}, corrupt("lease.expires_at must be finite")
+	}
+	return Lease{
+		Generation: generation,
+		Owner:      &ownerStr,
+		Instance:   &instanceStr,
+		ExpiresAt:  &expires,
+	}, nil
+}
+
+func parseManifest(v any) (Manifest, error) {
+	obj, ok := asObject(v)
+	if !ok {
+		return Manifest{}, corrupt("manifest must be an object")
+	}
+	rawDB, err := required(obj, "db", "manifest.db")
+	if err != nil {
+		return Manifest{}, err
+	}
+	db, err := nonEmptyString(rawDB, "manifest.db")
+	if err != nil {
+		return Manifest{}, err
+	}
+	// base is the only field the protocol allows to be null; the rest are
+	// required and may not be, so an absent or nulled wal is corrupt rather
+	// than an empty replay list.
+	rawBase, err := required(obj, "base", "manifest.base")
+	if err != nil {
+		return Manifest{}, err
+	}
+	var base *ObjectRef
+	if rawBase != nil {
+		ref, err := parseRef(rawBase, "manifest.base")
+		if err != nil {
+			return Manifest{}, err
+		}
+		base = &ref
+	}
+	rawWAL, err := required(obj, "wal", "manifest.wal")
+	if err != nil {
+		return Manifest{}, err
+	}
+	items, ok := rawWAL.([]any)
+	if !ok {
+		return Manifest{}, corrupt("manifest.wal must be an array")
+	}
+	wal := make([]ObjectRef, 0, len(items))
+	for i, item := range items {
+		ref, err := parseRef(item, fmt.Sprintf("manifest.wal[%d]", i))
+		if err != nil {
+			return Manifest{}, err
+		}
+		wal = append(wal, ref)
+	}
+	rawSeq, err := required(obj, "seq", "manifest.seq")
+	if err != nil {
+		return Manifest{}, err
+	}
+	seq, err := safeInt(rawSeq, "manifest.seq")
+	if err != nil {
+		return Manifest{}, err
+	}
+	return Manifest{DB: db, Base: base, WAL: wal, Seq: seq}, nil
+}
+
+// parseHead validates head bytes strictly and keeps the raw JSON for
+// round-trip.
+func parseHead(data []byte) (Head, map[string]any, error) {
+	if int64(len(data)) > MaxHeadBytes {
+		return Head{}, nil, &Error{
+			Category: CategoryLimitExceeded,
+			Message: fmt.Sprintf("durable: head.json is %d bytes, over the V1 limit of %d",
+				len(data), MaxHeadBytes),
+			Limit:    MaxHeadBytes,
+			Observed: int64(len(data)),
+		}
+	}
+	// The protocol says UTF-8. Bytes that are not UTF-8 are corrupt rather
+	// than silently repaired: replacing a malformed byte with U+FFFD would let
+	// invalid data inside an *unknown* field parse cleanly and then be written
+	// back mangled.
+	if !utf8.Valid(data) {
+		return Head{}, nil, corrupt("is not valid UTF-8")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	var raw any
+	if err := decoder.Decode(&raw); err != nil {
+		return Head{}, nil, wrapError(CategoryCorrupt, err, "durable: head.json is not valid JSON")
+	}
+	// Trailing content would mean two documents, and the second would be
+	// dropped on write-back.
+	if decoder.More() {
+		return Head{}, nil, corrupt("holds more than one JSON document")
+	}
+	obj, ok := asObject(raw)
+	if !ok {
+		return Head{}, nil, corrupt("must be a JSON object")
+	}
+
+	rawProtocol, hasProtocol := obj["protocol"]
+	protocol, err := parseProtocol(rawProtocol, hasProtocol)
+	if err != nil {
+		return Head{}, nil, err
+	}
+	rawEngine, err := required(obj, "engine", "engine")
+	if err != nil {
+		return Head{}, nil, err
+	}
+	engine, err := parseEngine(rawEngine)
+	if err != nil {
+		return Head{}, nil, err
+	}
+	rawLease, err := required(obj, "lease", "lease")
+	if err != nil {
+		return Head{}, nil, err
+	}
+	lease, err := parseLease(rawLease)
+	if err != nil {
+		return Head{}, nil, err
+	}
+	rawManifest, err := required(obj, "manifest", "manifest")
+	if err != nil {
+		return Head{}, nil, err
+	}
+	manifest, err := parseManifest(rawManifest)
+	if err != nil {
+		return Head{}, nil, err
+	}
+	return Head{Protocol: protocol, Engine: engine, Lease: lease, Manifest: manifest}, obj, nil
+}
+
+// mergeInto patches known fields onto whatever is stored under key, so an
+// unrecognised sibling inside protocol, engine, lease or manifest survives.
+func mergeInto(base map[string]any, key string, known map[string]any) {
+	existing, ok := asObject(base[key])
+	if !ok {
+		base[key] = known
+		return
+	}
+	merged := make(map[string]any, len(existing)+len(known))
+	for k, v := range existing {
+		merged[k] = v
+	}
+	for k, v := range known {
+		merged[k] = v
+	}
+	base[key] = merged
+}
+
+// cloneJSON deep-copies a decoded document, so patching a candidate head
+// cannot mutate the raw map the committed head still refers to.
+func cloneJSON(v any) any {
+	switch typed := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(typed))
+		for k, item := range typed {
+			out[k] = cloneJSON(item)
+		}
+		return out
+	case []any:
+		out := make([]any, len(typed))
+		for i, item := range typed {
+			out[i] = cloneJSON(item)
+		}
+		return out
+	default:
+		return v
+	}
+}
+
+func refToJSON(ref ObjectRef) map[string]any {
+	return map[string]any{
+		"key":    ref.Key,
+		"size":   json.Number(fmt.Sprint(ref.Size)),
+		"sha256": ref.SHA256,
+	}
+}
+
+// serializeHead renders head, preserving every unrecognised field of raw.
+//
+// manifest.base and manifest.wal are replaced wholesale rather than merged:
+// they are this build's own state, and a stale unknown key inside a reference
+// being rewritten would describe bytes that are no longer there.
+func serializeHead(head Head, raw map[string]any) ([]byte, error) {
+	// Refuse to emit a document this parser would reject. Writing one is
+	// worse than failing here: head.json is created with a conditional create
+	// and V1 has no destroy, so an object published with, say, an empty
+	// manifest.db is corrupt on every subsequent open and cannot be removed.
+	switch {
+	case head.Manifest.DB == "":
+		return nil, corrupt("manifest.db must be a non-empty string")
+	case head.Engine.Name == "":
+		return nil, corrupt("engine.name must be a non-empty string")
+	case head.Engine.Version == "":
+		return nil, corrupt("engine.version must be a non-empty string")
+	case head.Engine.MinReader == "":
+		return nil, corrupt("engine.min_reader must be a non-empty string")
+	}
+
+	base := map[string]any{}
+	if raw != nil {
+		base = cloneJSON(raw).(map[string]any)
+	}
+
+	readerFeatures := make([]any, len(head.Protocol.ReaderFeatures))
+	for i, f := range head.Protocol.ReaderFeatures {
+		readerFeatures[i] = f
+	}
+	writerFeatures := make([]any, len(head.Protocol.WriterFeatures))
+	for i, f := range head.Protocol.WriterFeatures {
+		writerFeatures[i] = f
+	}
+	mergeInto(base, "protocol", map[string]any{
+		"version":         json.Number(fmt.Sprint(head.Protocol.Version)),
+		"reader_features": readerFeatures,
+		"writer_features": writerFeatures,
+	})
+	mergeInto(base, "engine", map[string]any{
+		"name":          head.Engine.Name,
+		"version":       head.Engine.Version,
+		"backup_format": json.Number(fmt.Sprint(head.Engine.BackupFormat)),
+		"min_reader":    head.Engine.MinReader,
+	})
+	lease := map[string]any{
+		"generation": json.Number(fmt.Sprint(head.Lease.Generation)),
+		"owner":      nil,
+		"instance":   nil,
+		"expires_at": nil,
+	}
+	if head.Lease.Owner != nil {
+		lease["owner"] = *head.Lease.Owner
+	}
+	if head.Lease.Instance != nil {
+		lease["instance"] = *head.Lease.Instance
+	}
+	if head.Lease.ExpiresAt != nil {
+		lease["expires_at"] = json.Number(formatSeconds(*head.Lease.ExpiresAt))
+	}
+	mergeInto(base, "lease", lease)
+
+	wal := make([]any, len(head.Manifest.WAL))
+	for i, ref := range head.Manifest.WAL {
+		wal[i] = refToJSON(ref)
+	}
+	manifest := map[string]any{
+		"db":   head.Manifest.DB,
+		"base": nil,
+		"wal":  wal,
+		"seq":  json.Number(fmt.Sprint(head.Manifest.Seq)),
+	}
+	if head.Manifest.Base != nil {
+		manifest["base"] = refToJSON(*head.Manifest.Base)
+	}
+	mergeInto(base, "manifest", manifest)
+
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	// Leave <, > and & alone. The escaped form is valid JSON and every parser
+	// reads it the same way, but an unknown field's value would come back out
+	// spelled differently from how another binding wrote it, which makes a
+	// round-trip harder to verify than it needs to be.
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(base); err != nil {
+		return nil, wrapError(CategoryCorrupt, err, "durable: head.json cannot be encoded")
+	}
+	// Encode appends a newline; the document itself is what gets stored.
+	out := bytes.TrimRight(buf.Bytes(), "\n")
+	if int64(len(out)) > MaxHeadBytes {
+		return nil, &Error{
+			Category: CategoryLimitExceeded,
+			Message: fmt.Sprintf("durable: head.json would be %d bytes, over the V1 limit of %d; "+
+				"checkpoint to truncate the WAL list", len(out), MaxHeadBytes),
+			Limit:    MaxHeadBytes,
+			Observed: int64(len(out)),
+		}
+	}
+	return out, nil
+}
+
+// formatSeconds renders an epoch-seconds timestamp without an exponent.
+//
+// strconv's shortest form would write 1.7882304e+09, which is the same number
+// but reads as a different kind of value in a document meant for humans and
+// four languages. Trailing zeros are trimmed so a whole second stays whole.
+func formatSeconds(v float64) string {
+	s := strings.TrimRight(strings.TrimRight(fmt.Sprintf("%.6f", v), "0"), ".")
+	if s == "" || s == "-" {
+		return "0"
+	}
+	return s
+}

--- a/chdb/durable/head_test.go
+++ b/chdb/durable/head_test.go
@@ -1,0 +1,309 @@
+package durable
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// A head as another binding would write it: different key order, extra
+// whitespace, and two fields this build has never heard of.
+const foreignHead = `{
+  "manifest": {
+    "seq": 9,
+    "db": "mem",
+    "wal": [
+      {"sha256": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+       "size": 127, "key": "wal/3-9-acde5678.jsonl"}
+    ],
+    "base": {"key": "checkpoints/3-8-acde1234.tar.gz", "size": 1048576,
+             "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"},
+    "future_manifest_field": {"nested": [1, 2, 3]}
+  },
+  "lease": {"expires_at": 1788230400.5, "owner": "worker-visible-name",
+            "instance": "unique-live-instance-id", "generation": 3},
+  "engine": {"name": "chdb", "version": "26.7.2-rc.2", "backup_format": 1,
+             "min_reader": "26.7.2-rc.2"},
+  "protocol": {"version": 1, "reader_features": [], "writer_features": []},
+  "top_level_future_field": "keep me"
+}`
+
+func mustParse(t *testing.T, text string) (Head, map[string]any) {
+	t.Helper()
+	head, raw, err := parseHead([]byte(text))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return head, raw
+}
+
+func TestParseHeadReadsAnotherBindingsSpelling(t *testing.T) {
+	head, _ := mustParse(t, foreignHead)
+
+	if head.Manifest.DB != "mem" || head.Manifest.Seq != 9 {
+		t.Fatalf("manifest is %+v", head.Manifest)
+	}
+	if head.Manifest.Base == nil || head.Manifest.Base.Size != 1048576 {
+		t.Fatalf("base is %+v", head.Manifest.Base)
+	}
+	if len(head.Manifest.WAL) != 1 || head.Manifest.WAL[0].Key != "wal/3-9-acde5678.jsonl" {
+		t.Fatalf("wal is %+v", head.Manifest.WAL)
+	}
+	if head.Lease.Generation != 3 || head.Lease.Owner == nil || *head.Lease.Owner != "worker-visible-name" {
+		t.Fatalf("lease is %+v", head.Lease)
+	}
+	if head.Engine.MinReader != "26.7.2-rc.2" || head.Engine.BackupFormat != 1 {
+		t.Fatalf("engine is %+v", head.Engine)
+	}
+}
+
+// The whole named-feature mechanism rests on this: a writer that dropped
+// fields it does not recognise would delete a future revision's state the
+// first time an older build touched the object.
+func TestSerializeHeadKeepsUnknownFields(t *testing.T) {
+	head, raw := mustParse(t, foreignHead)
+
+	// Move the object on the way a flush would, then write it back.
+	head.Manifest.Seq = 10
+	head.Lease.ExpiresAt = floatPtr(1788230500)
+
+	data, err := serializeHead(head, raw)
+	if err != nil {
+		t.Fatalf("serialize: %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("the written head is not JSON: %v", err)
+	}
+
+	if out["top_level_future_field"] != "keep me" {
+		t.Errorf("a top-level unknown field was dropped: %v", out)
+	}
+	manifest, ok := out["manifest"].(map[string]any)
+	if !ok {
+		t.Fatalf("manifest is %T", out["manifest"])
+	}
+	if _, ok := manifest["future_manifest_field"]; !ok {
+		t.Errorf("an unknown field inside manifest was dropped: %v", manifest)
+	}
+	if manifest["seq"].(float64) != 10 {
+		t.Errorf("seq was not updated: %v", manifest["seq"])
+	}
+
+	// And it round-trips through the parser again, so the write is not merely
+	// JSON but a valid head.
+	if _, _, err := parseHead(data); err != nil {
+		t.Fatalf("the written head does not parse: %v", err)
+	}
+}
+
+// A large integer inside an unknown field must survive. Decoding numbers as
+// float64 would rewrite it, which is the failure round-tripping exists to
+// prevent and the least visible one.
+func TestSerializeHeadKeepsUnknownNumbersExactly(t *testing.T) {
+	text := strings.Replace(foreignHead, `"top_level_future_field": "keep me"`,
+		`"future_counter": 9007199254740993, "future_precise": 0.10000000000000000555`, 1)
+	head, raw := mustParse(t, text)
+	data, err := serializeHead(head, raw)
+	if err != nil {
+		t.Fatalf("serialize: %v", err)
+	}
+	for _, want := range []string{"9007199254740993", "0.10000000000000000555"} {
+		if !strings.Contains(string(data), want) {
+			t.Errorf("%s was not written back verbatim:\n%s", want, data)
+		}
+	}
+}
+
+// A missing protocol block is the documented default so that an object written
+// before the block existed stays readable.
+func TestParseHeadDefaultsAMissingProtocol(t *testing.T) {
+	text := strings.Replace(foreignHead,
+		`"protocol": {"version": 1, "reader_features": [], "writer_features": []},`, "", 1)
+	head, _ := mustParse(t, text)
+	if head.Protocol.Version != ProtocolVersion {
+		t.Fatalf("version is %d, want the baseline %d", head.Protocol.Version, ProtocolVersion)
+	}
+	if len(head.Protocol.ReaderFeatures) != 0 || len(head.Protocol.WriterFeatures) != 0 {
+		t.Fatalf("features are %+v, want empty", head.Protocol)
+	}
+}
+
+// min_reader defaults to the producer version, which reproduces the old
+// exact-match behaviour's lower bound. Defaulting it lower would retroactively
+// widen an object's audience on the strength of a field its writer never
+// wrote.
+func TestParseHeadDefaultsMinReaderToTheProducer(t *testing.T) {
+	text := strings.Replace(foreignHead, `, "min_reader": "26.7.2-rc.2"`, "", 1)
+	text = strings.Replace(text, `, "backup_format": 1`, "", 1)
+	head, _ := mustParse(t, text)
+	if head.Engine.MinReader != "26.7.2-rc.2" {
+		t.Errorf("min_reader is %q, want the producer version", head.Engine.MinReader)
+	}
+	if head.Engine.BackupFormat != BackupFormatBaseline {
+		t.Errorf("backup_format is %d, want the baseline", head.Engine.BackupFormat)
+	}
+}
+
+func TestParseHeadRefusesCorruptDocuments(t *testing.T) {
+	cases := []struct {
+		name string
+		edit func(string) string
+	}{
+		{"not an object", func(string) string { return `[]` }},
+		{"not JSON", func(string) string { return `{oops` }},
+		{"two documents", func(s string) string { return s + s }},
+		{"no engine", func(s string) string {
+			return strings.Replace(s, `"engine": {"name": "chdb", "version": "26.7.2-rc.2", "backup_format": 1,
+             "min_reader": "26.7.2-rc.2"},`, "", 1)
+		}},
+		{"no lease", func(s string) string {
+			return strings.Replace(s, `"lease": {"expires_at": 1788230400.5, "owner": "worker-visible-name",
+            "instance": "unique-live-instance-id", "generation": 3},`, "", 1)
+		}},
+		// Half a lease implies a different answer to "may I take this over"
+		// than either whole one, and guessing is how two writers end up
+		// believing they are the one writer.
+		{"half-released lease", func(s string) string {
+			return strings.Replace(s, `"instance": "unique-live-instance-id"`, `"instance": null`, 1)
+		}},
+		{"lease missing expires_at", func(s string) string {
+			return strings.Replace(s, `"expires_at": 1788230400.5,`, "", 1)
+		}},
+		{"nulled wal", func(s string) string {
+			return strings.Replace(s, `"wal": [`, `"wal": null, "ignored": [`, 1)
+		}},
+		{"empty db", func(s string) string {
+			return strings.Replace(s, `"db": "mem"`, `"db": ""`, 1)
+		}},
+		{"negative seq", func(s string) string {
+			return strings.Replace(s, `"seq": 9`, `"seq": -1`, 1)
+		}},
+		{"seq beyond the safe integer range", func(s string) string {
+			return strings.Replace(s, `"seq": 9`, `"seq": 9007199254740993`, 1)
+		}},
+		{"uppercase sha256", func(s string) string {
+			return strings.Replace(s, "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+				"ABCDEF0123456789abcdef0123456789abcdef0123456789abcdef0123456789", 1)
+		}},
+		{"short sha256", func(s string) string {
+			return strings.Replace(s, "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+				"abcdef", 1)
+		}},
+		// A key steering a read outside the object is refused where it is
+		// read, not where it is used.
+		{"traversing wal key", func(s string) string {
+			return strings.Replace(s, `"key": "wal/3-9-acde5678.jsonl"`,
+				`"key": "../../etc/passwd"`, 1)
+		}},
+		{"absolute wal key", func(s string) string {
+			return strings.Replace(s, `"key": "wal/3-9-acde5678.jsonl"`, `"key": "/etc/passwd"`, 1)
+		}},
+		{"size as a string", func(s string) string {
+			return strings.Replace(s, `"size": 127`, `"size": "127"`, 1)
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := parseHead([]byte(tc.edit(foreignHead)))
+			if err == nil {
+				t.Fatal("a corrupt head must not parse")
+			}
+			if !errors.Is(err, ErrCorrupt) {
+				t.Fatalf("category is %q, want corrupt: %v", CategoryOf(err), err)
+			}
+		})
+	}
+}
+
+func TestParseHeadRefusesNonUTF8(t *testing.T) {
+	data := append([]byte(nil), foreignHead...)
+	data = append(data, 0xff)
+	if _, _, err := parseHead(data); !errors.Is(err, ErrCorrupt) {
+		t.Fatalf("category is %q, want corrupt", CategoryOf(err))
+	}
+}
+
+func TestHeadLimits(t *testing.T) {
+	oversized := append([]byte(`{"padding":"`), make([]byte, MaxHeadBytes)...)
+	if _, _, err := parseHead(oversized); !errors.Is(err, ErrLimitExceeded) {
+		t.Fatalf("reading an oversized head gave %q, want limit_exceeded", CategoryOf(err))
+	}
+
+	// A writer must be stopped before it publishes a head nobody can read
+	// back, because V1 has no way to remove one.
+	head, _ := mustParse(t, foreignHead)
+	ref := head.Manifest.WAL[0]
+	// One reference encodes to a bit over 100 bytes, so this many is safely
+	// past a 1 MiB head without depending on the exact figure.
+	for i := 0; i < 20000; i++ {
+		head.Manifest.WAL = append(head.Manifest.WAL, ref)
+	}
+	if _, err := serializeHead(head, nil); !errors.Is(err, ErrLimitExceeded) {
+		t.Fatalf("writing an oversized head gave %q, want limit_exceeded", CategoryOf(err))
+	}
+}
+
+// A released lease is exactly three nulls, and that is what the next acquirer
+// looks for.
+func TestSerializeHeadWritesAReleasedLeaseAsNulls(t *testing.T) {
+	head, raw := mustParse(t, foreignHead)
+	head.Lease = Lease{Generation: head.Lease.Generation}
+	data, err := serializeHead(head, raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reparsed, _, err := parseHead(data)
+	if err != nil {
+		t.Fatalf("a released lease does not parse: %v", err)
+	}
+	if reparsed.Lease.Owner != nil || reparsed.Lease.Instance != nil || reparsed.Lease.ExpiresAt != nil {
+		t.Fatalf("lease is %+v, want fully released", reparsed.Lease)
+	}
+	if reparsed.Lease.Generation != 3 {
+		t.Fatalf("generation is %d, want 3 — a release does not reset it", reparsed.Lease.Generation)
+	}
+}
+
+// An expiry is a timestamp an operator reads. Written in exponent form it is
+// the same number and a worse document, and json.Number is what keeps
+// encoding/json from choosing the exponent for us.
+func TestSerializeHeadWritesExpiryWithoutAnExponent(t *testing.T) {
+	head, raw := mustParse(t, foreignHead)
+	head.Lease.ExpiresAt = floatPtr(1788230400)
+	data, err := serializeHead(head, raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "1788230400") || strings.Contains(string(data), "e+") {
+		t.Fatalf("expiry was written oddly:\n%s", data)
+	}
+}
+
+func TestSerializeHeadRefusesADocumentItWouldReject(t *testing.T) {
+	head, _ := mustParse(t, foreignHead)
+	head.Manifest.DB = ""
+	if _, err := serializeHead(head, nil); !errors.Is(err, ErrCorrupt) {
+		t.Fatalf("category is %q, want corrupt", CategoryOf(err))
+	}
+}
+
+func TestColdHeadIsReadableByItself(t *testing.T) {
+	head := coldHead("mem", "26.7.2-rc.2", BackupFormatBaseline)
+	data, err := serializeHead(head, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, _, err := parseHead(data)
+	if err != nil {
+		t.Fatalf("a cold head does not parse: %v", err)
+	}
+	if parsed.Manifest.Base != nil || len(parsed.Manifest.WAL) != 0 || parsed.Manifest.Seq != 0 {
+		t.Fatalf("a cold manifest is %+v", parsed.Manifest)
+	}
+	if parsed.Lease.Generation != 1 {
+		t.Fatalf("a cold lease starts at generation %d, want 1", parsed.Lease.Generation)
+	}
+}

--- a/chdb/durable/keys.go
+++ b/chdb/durable/keys.go
@@ -1,0 +1,83 @@
+package durable
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+// Object key construction and validation (contract §4.1).
+//
+// Two separate jobs live here, and they are separate on purpose:
+//
+//   - *Minting* a key for something this writer is about to publish. Every
+//     attempt gets a fresh key, including a retry of an attempt that may
+//     already have landed. That is what makes an ambiguous upload resolvable
+//     rather than destructive: a retry can never overwrite the bytes the
+//     first try published (contract §5.8).
+//   - *Validating* a key read out of someone else's head. A reference is a
+//     relative key inside the object prefix and nothing else. Rejecting "..",
+//     absolute paths and empty segments here is what stops a hostile or
+//     broken head from steering a download outside the object — the local
+//     backend resolves keys against a directory, so a traversal would be a
+//     real escape.
+
+// HeadKey is the one mutable key in an object.
+const HeadKey = "head.json"
+
+// uuid8 returns the first 8 hex digits of a random UUID4, per the frozen key
+// shape. It reads from crypto/rand because two writers minting the same
+// suffix in the same generation and sequence would collide on a key that must
+// be unique per attempt.
+func uuid8() string {
+	var b [4]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// crypto/rand does not fail on any platform this package builds for;
+		// if it ever did, a predictable key is worse than a stopped process.
+		panic("durable: crypto/rand is unavailable: " + err.Error())
+	}
+	return hex.EncodeToString(b[:])
+}
+
+// checkpointKey mints checkpoints/<generation>-<seq>-<uuid8>.tar.gz.
+func checkpointKey(generation, seq int64) string {
+	return fmt.Sprintf("checkpoints/%d-%d-%s.tar.gz", generation, seq, uuid8())
+}
+
+// walKey mints wal/<generation>-<seq>-<uuid8>.jsonl.
+func walKey(generation, seq int64) string {
+	return fmt.Sprintf("wal/%d-%d-%s.jsonl", generation, seq, uuid8())
+}
+
+// IsValidObjectKey accepts only a relative, "/"-separated key with no empty,
+// "." or ".." segments.
+//
+// Backslashes are rejected too: on a POSIX filesystem a backslash is an
+// ordinary character, so a key holding one would name a different file here
+// than it does on a provider that normalises it — and an object is supposed to
+// mean the same thing wherever it is opened.
+func IsValidObjectKey(key string) bool {
+	if key == "" || strings.HasPrefix(key, "/") {
+		return false
+	}
+	if strings.ContainsAny(key, "\\\x00") {
+		return false
+	}
+	for _, segment := range strings.Split(key, "/") {
+		if segment == "" || segment == "." || segment == ".." {
+			return false
+		}
+	}
+	return true
+}
+
+// validateObjectID accepts an object id that is a single path segment, so an
+// id cannot climb out of its namespace or contain another id's prefix.
+func validateObjectID(id string) error {
+	if id == "" || strings.ContainsAny(id, "/\\\x00") || id == "." || id == ".." {
+		return newError(CategoryBackend,
+			"durable: object id must be a single non-empty path segment, got %q", id)
+	}
+	return nil
+}

--- a/chdb/durable/lease.go
+++ b/chdb/durable/lease.go
@@ -1,0 +1,220 @@
+package durable
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"time"
+)
+
+// Lease acquisition, cold creation and release (contract §5.2, §5.7).
+//
+// These run before an Object exists, which is why they are functions rather
+// than methods: an open that fails while taking the lease has nothing to hang
+// state on, and the unwind has to work anyway.
+
+// newInstanceID identifies one live instance of a writer.
+//
+// The owner name is for humans and may repeat — two replicas of the same
+// deployment, a restarted process with the same name. The instance is what the
+// fence compares, so it has to be unique per live handle, and it comes from
+// crypto/rand for the same reason a key suffix does.
+func newInstanceID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		panic("durable: crypto/rand is unavailable: " + err.Error())
+	}
+	return hex.EncodeToString(b[:])
+}
+
+// nowSeconds is the current time as epoch seconds, the form a lease records.
+func nowSeconds() float64 {
+	return float64(time.Now().UnixMicro()) / 1e6
+}
+
+type leaseParams struct {
+	instance string
+	owner    string
+	tuning   Tuning
+	force    bool
+}
+
+type coldParams struct {
+	id       string
+	database string
+	running  runningEngine
+	instance string
+	owner    string
+	tuning   Tuning
+}
+
+// createCold atomically creates a cold object and takes generation 1 in the
+// same write.
+func createCold(ctx context.Context, backend Backend, params coldParams) (*headSnapshot, error) {
+	head := coldHead(params.database, params.running.version, params.running.backupFormat)
+	head.Lease = Lease{
+		Generation: 1,
+		Owner:      stringPtr(params.owner),
+		Instance:   stringPtr(params.instance),
+		ExpiresAt:  floatPtr(nowSeconds() + params.tuning.LeaseTTL.Seconds()),
+	}
+	data, err := serializeHead(head, nil)
+	if err != nil {
+		return nil, err
+	}
+	outcome, err := backend.PutBytesIfAbsent(ctx, HeadKey, data)
+	if err != nil {
+		return nil, err
+	}
+
+	// Read back on every path, including success. The ETag of what was created
+	// is what the next commit has to present, and a conditional create does
+	// not always report one.
+	fresh, found, readErr := readHead(ctx, backend)
+
+	if outcome == PutCreated {
+		if readErr != nil {
+			return nil, readErr
+		}
+		if !found {
+			return nil, newError(CategoryCorrupt,
+				"durable: created %s at %s but it cannot be read back", HeadKey, backend.Describe())
+		}
+		return &fresh, nil
+	}
+
+	// Lost the race, or the response was lost. Either way the answer is in the
+	// object: if the head that is there names this instance, the create
+	// landed.
+	if readErr != nil {
+		return nil, readErr
+	}
+	if !found {
+		return nil, &Error{
+			Category: CategoryCommitAmbiguous,
+			Message: fmt.Sprintf("durable: could not determine whether object %s was created at %s",
+				params.id, backend.Describe()),
+			Key: HeadKey,
+		}
+	}
+	if fresh.head.Lease.instanceIs(params.instance) {
+		return &fresh, nil
+	}
+
+	// Someone else created it. It is now an existing object, so it goes
+	// through the same gates any existing object would.
+	if err := assertReadable(fresh.head); err != nil {
+		return nil, err
+	}
+	if err := assertEngineCompatible(fresh.head, params.running); err != nil {
+		return nil, err
+	}
+	if err := assertWritable(fresh.head); err != nil {
+		return nil, err
+	}
+	return acquireLease(ctx, backend, fresh, leaseParams{
+		instance: params.instance, owner: params.owner, tuning: params.tuning, force: false,
+	})
+}
+
+// acquireLease takes the writer lease by compare-and-swap.
+//
+// An unheld lease is free. A held one is only takeable once its recorded expiry
+// is behind us by more than the clock-skew allowance — the allowance is there
+// because the two writers' clocks are not the same clock, and a lease that
+// looks expired by a second might not be. Taking a lease that has not expired
+// is possible, but only as an explicit force, never as a retry.
+func acquireLease(ctx context.Context, backend Backend, start headSnapshot, params leaseParams) (*headSnapshot, error) {
+	current := start
+	deadline := time.Now().Add(params.tuning.CommitDeadline)
+
+	for attempt := 1; ; attempt++ {
+		lease := current.head.Lease
+		if lease.held() && !params.force {
+			var expiresAt float64
+			if lease.ExpiresAt != nil {
+				expiresAt = *lease.ExpiresAt
+			}
+			takeableAt := expiresAt + params.tuning.ClockSkewAllowance.Seconds()
+			if nowSeconds() < takeableAt {
+				return nil, &Error{
+					Category: CategoryLeaseHeld,
+					Message: fmt.Sprintf("durable: %q holds the writer lease (generation %d)",
+						*lease.Owner, lease.Generation),
+					Owner: *lease.Owner,
+				}
+			}
+		}
+
+		candidate := current.head.clone()
+		candidate.Lease = Lease{
+			Generation: lease.Generation + 1,
+			Owner:      stringPtr(params.owner),
+			Instance:   stringPtr(params.instance),
+			ExpiresAt:  floatPtr(nowSeconds() + params.tuning.LeaseTTL.Seconds()),
+		}
+		data, err := serializeHead(candidate, current.raw)
+		if err != nil {
+			return nil, err
+		}
+		outcome, err := backend.ReplaceIfMatch(ctx, HeadKey, data, current.etag)
+		if err != nil {
+			return nil, err
+		}
+		if outcome.Status == ReplaceDone {
+			return &headSnapshot{head: candidate, etag: outcome.ETag, raw: current.raw}, nil
+		}
+
+		fresh, found, err := readHead(ctx, backend)
+		if err != nil {
+			return nil, err
+		}
+		if !found {
+			return nil, newError(CategoryCorrupt,
+				"durable: %s disappeared from %s while taking the lease", HeadKey, backend.Describe())
+		}
+		if fresh.head.Lease.instanceIs(params.instance) {
+			// The write landed and its response was lost.
+			return &fresh, nil
+		}
+
+		if attempt >= params.tuning.MaxCommitAttempts || !time.Now().Before(deadline) {
+			held := &Error{
+				Category: CategoryLeaseHeld,
+				Message: fmt.Sprintf("durable: could not take the writer lease after %d attempts; "+
+					"generation is now %d", attempt, fresh.head.Lease.Generation),
+			}
+			if fresh.head.Lease.Owner != nil {
+				held.Owner = *fresh.head.Lease.Owner
+			}
+			return nil, held
+		}
+		current = fresh
+	}
+}
+
+// releaseLease gives the lease back, best effort, when an open failed
+// part-way through.
+//
+// A failure after the lease was taken must not strand it until the TTL
+// expires, but the release has to be conditional on still owning it: a head
+// that has moved on belongs to someone else, and writing over it would undo
+// their acquisition.
+func releaseLease(ctx context.Context, backend Backend, instance string) error {
+	fresh, found, err := readHead(ctx, backend)
+	if err != nil {
+		return err
+	}
+	if !found || !fresh.head.Lease.instanceIs(instance) {
+		return nil
+	}
+	candidate := fresh.head.clone()
+	candidate.Lease = Lease{Generation: fresh.head.Lease.Generation}
+	data, err := serializeHead(candidate, fresh.raw)
+	if err != nil {
+		return err
+	}
+	_, err = backend.ReplaceIfMatch(ctx, HeadKey, data, fresh.etag)
+	return err
+}

--- a/chdb/durable/namespace.go
+++ b/chdb/durable/namespace.go
@@ -1,0 +1,181 @@
+package durable
+
+import (
+	"context"
+	"net/url"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// Namespaces: the entry point to the durable control plane.
+//
+// A namespace is a URL plus an engine factory. The URL says where objects live
+// and, through its scheme, which backend implements the conditional
+// operations; the factory says how to bring up an engine for whichever object
+// is being opened.
+//
+// One constraint is not the namespace's to hide: chdb-core binds one data path
+// per process, so one process holds one open durable object at a time. Fan-out
+// across objects is therefore sequential, or spread across worker processes. A
+// registry here that pretended otherwise would only move the failure somewhere
+// less obvious (contract §3.6).
+
+// SchemeFactory builds a backend for one object, given the namespace URL and
+// the object id.
+type SchemeFactory func(ctx context.Context, u *url.URL, objectID string) (Backend, error)
+
+var (
+	schemesMu sync.RWMutex
+	schemes   = map[string]SchemeFactory{}
+)
+
+// RegisterBackendScheme registers a backend for a URL scheme.
+//
+// The local filesystem and S3-compatible schemes are registered by this
+// package. A provider that is not — a bespoke store, a fault-injecting wrapper
+// — registers itself here, which is also how it can live in its own module
+// without this one depending on it.
+func RegisterBackendScheme(scheme string, factory SchemeFactory) {
+	schemesMu.Lock()
+	defer schemesMu.Unlock()
+	schemes[strings.TrimSuffix(scheme, ":")] = factory
+}
+
+func lookupScheme(scheme string) (SchemeFactory, bool) {
+	schemesMu.RLock()
+	defer schemesMu.RUnlock()
+	factory, ok := schemes[scheme]
+	return factory, ok
+}
+
+func registeredSchemes() []string {
+	schemesMu.RLock()
+	defer schemesMu.RUnlock()
+	names := make([]string, 0, len(schemes))
+	for name := range schemes {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// NamespaceOptions configures a namespace.
+type NamespaceOptions struct {
+	// EngineFactory says how to build the engine for an object being opened.
+	// Defaults to NewChdbEngine(), which runs the engine this process loaded.
+	EngineFactory EngineFactory
+
+	// BackendFactory bypasses scheme lookup and supplies the backend
+	// directly. Tests use it to wrap a real backend in fault injection.
+	BackendFactory BackendFactory
+
+	// Owner is the default writer name for objects opened from this
+	// namespace.
+	Owner string
+
+	// ScratchRoot is the default parent directory for scratch trees.
+	ScratchRoot string
+
+	// Tuning holds the default lease and commit parameters, field by field.
+	Tuning Tuning
+}
+
+// Namespace addresses durable objects on one backend.
+type Namespace struct {
+	u       *url.URL
+	options NamespaceOptions
+}
+
+// NewNamespace binds a namespace to a URL.
+//
+//	file:///var/lib/chdb-durable
+//	s3://bucket/prefix?region=eu-west-1
+//
+// The scheme decides the backend. An unregistered scheme is refused here
+// rather than at the first open, so a typo in a configuration file fails at
+// startup.
+func NewNamespace(rawURL string, options NamespaceOptions) (*Namespace, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, wrapError(CategoryBackend, err, "durable: %q is not a URL", rawURL)
+	}
+	if options.EngineFactory == nil {
+		options.EngineFactory = NewChdbEngine()
+	}
+	if options.BackendFactory == nil {
+		if _, ok := lookupScheme(u.Scheme); !ok {
+			return nil, newError(CategoryBackend,
+				"durable: no backend registered for scheme %q; registered: %s",
+				u.Scheme, strings.Join(registeredSchemes(), ", "))
+		}
+	}
+	return &Namespace{u: u, options: options}, nil
+}
+
+// URL is the namespace's location.
+func (n *Namespace) URL() string { return n.u.String() }
+
+// Open opens one object.
+//
+// It returns the object and whether it already existed — a caller creating a
+// tenant on first use needs to tell "restored" from "created" without a
+// separate probe. A writer lease is taken unless OpenOptions.ReadOnly is set.
+//
+// An open that fails leaves nothing behind: any lease it took is released, the
+// engine is closed and the scratch directory is removed.
+func (n *Namespace) Open(ctx context.Context, objectID string, options OpenOptions) (*Object, bool, error) {
+	if err := validateObjectID(objectID); err != nil {
+		return nil, false, err
+	}
+
+	var (
+		backend Backend
+		err     error
+	)
+	if n.options.BackendFactory != nil {
+		backend, err = n.options.BackendFactory(ctx, objectID)
+	} else {
+		factory, ok := lookupScheme(n.u.Scheme)
+		if !ok {
+			return nil, false, newError(CategoryBackend,
+				"durable: no backend registered for scheme %q", n.u.Scheme)
+		}
+		backend, err = factory(ctx, n.u, objectID)
+	}
+	if err != nil {
+		return nil, false, err
+	}
+
+	if options.Owner == "" {
+		options.Owner = n.options.Owner
+	}
+	if options.ScratchRoot == "" {
+		options.ScratchRoot = n.options.ScratchRoot
+	}
+	options.Tuning = mergeTuning(n.options.Tuning, options.Tuning)
+
+	return openObject(ctx, objectID, backend, n.options.EngineFactory, options)
+}
+
+// mergeTuning lets a per-open override win field by field over the
+// namespace's default, and leaves the rest to take theirs.
+func mergeTuning(base, override Tuning) Tuning {
+	out := base
+	if override.LeaseTTL != 0 {
+		out.LeaseTTL = override.LeaseTTL
+	}
+	if override.HeartbeatInterval != 0 {
+		out.HeartbeatInterval = override.HeartbeatInterval
+	}
+	if override.ClockSkewAllowance != 0 {
+		out.ClockSkewAllowance = override.ClockSkewAllowance
+	}
+	if override.CommitDeadline != 0 {
+		out.CommitDeadline = override.CommitDeadline
+	}
+	if override.MaxCommitAttempts != 0 {
+		out.MaxCommitAttempts = override.MaxCommitAttempts
+	}
+	return out
+}

--- a/chdb/durable/negotiate.go
+++ b/chdb/durable/negotiate.go
@@ -1,0 +1,162 @@
+package durable
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Version and feature negotiation (contract §4.3) and engine identity (§4.2).
+//
+// V1 uses named features rather than a monotonic minimum-version number. A
+// monotonic number requires features to be linearly ordered, and with several
+// bindings developed in parallel they are not: a client can implement B
+// without A, and under a version floor it would be locked out of an object
+// that only ever used B. Delta Lake moved off version numbers onto table
+// features for exactly this reason.
+//
+// The asymmetry between the two feature lists is the whole point. An unknown
+// *reader* feature means bytes in this object cannot be interpreted, so the
+// object does not open at all. An unknown *writer* feature means only that
+// writing correctly needs something this build cannot do — reading is still
+// sound, so a read-only open is allowed and only the lease is refused.
+
+func unknownFeatures(features, known []string) []string {
+	var missing []string
+	for _, f := range features {
+		found := false
+		for _, k := range known {
+			if f == k {
+				found = true
+				break
+			}
+		}
+		if !found {
+			missing = append(missing, f)
+		}
+	}
+	return missing
+}
+
+// assertReadable gates a read: it refuses a protocol version above this
+// baseline, or any unrecognised reader feature, naming the offenders so the
+// operator knows which build they need.
+func assertReadable(head Head) error {
+	if head.Protocol.Version > ProtocolVersion {
+		return &Error{
+			Category: CategoryProtocolUnsupported,
+			Message: fmt.Sprintf("durable: object uses protocol version %d, this build implements %d",
+				head.Protocol.Version, ProtocolVersion),
+		}
+	}
+	if missing := unknownFeatures(head.Protocol.ReaderFeatures, KnownReaderFeatures); len(missing) > 0 {
+		return &Error{
+			Category: CategoryProtocolUnsupported,
+			Message: fmt.Sprintf("durable: object requires reader features this build does not implement: %s",
+				strings.Join(missing, ", ")),
+			Features: missing,
+		}
+	}
+	return nil
+}
+
+// assertWritable gates taking the writer lease. It assumes assertReadable has
+// already passed, and only adds the writer-side feature check.
+func assertWritable(head Head) error {
+	if missing := unknownFeatures(head.Protocol.WriterFeatures, KnownWriterFeatures); len(missing) > 0 {
+		return &Error{
+			Category: CategoryProtocolUnsupported,
+			Message: fmt.Sprintf("durable: object requires writer features this build does not implement: %s; "+
+				"it can still be opened read-only", strings.Join(missing, ", ")),
+			Features: missing,
+		}
+	}
+	return nil
+}
+
+// runningEngine is what the engine in this process can offer, for the
+// compatibility gate.
+type runningEngine struct {
+	// version is chdb_version() of the loaded library.
+	version string
+	// backupFormat is the highest archive-format generation it can restore.
+	backupFormat int
+}
+
+// assertEngineCompatible applies the frozen engine gate:
+//
+//	backup_format > reader baseline   -> engine_incompatible
+//	running_version < min_reader      -> engine_incompatible
+//	otherwise                         -> open
+//
+// Note what is deliberately absent: a comparison against engine.version. That
+// field records which build produced the object, for diagnosis, and is
+// explicitly not a gate. An exact match would refuse every later release,
+// which is the opposite of what the compatibility promise says — a newer
+// chdb-core restores full backups made by an earlier one, so an object written
+// by 26.7.2-rc.2 opens on 26.7.3 and everything after it.
+//
+// The two checks guard different failures and neither subsumes the other.
+// min_reader catches a reader that is simply too old. backup_format is the
+// escape hatch for the day the promise itself is withdrawn: version numbers
+// keep increasing whether or not the format still works, so a broken format
+// needs its own signal, or a reader would compare a larger version, conclude
+// it is fine, and discover otherwise partway through RESTORE.
+func assertEngineCompatible(head Head, running runningEngine) error {
+	if head.Engine.Name != EngineName {
+		return &Error{
+			Category: CategoryEngineIncompatible,
+			Message: fmt.Sprintf("durable: object was written by engine %q, not %q",
+				head.Engine.Name, EngineName),
+			Expected: head.Engine.Name,
+			Actual:   EngineName,
+		}
+	}
+	if head.Engine.BackupFormat > running.backupFormat {
+		return &Error{
+			Category: CategoryEngineIncompatible,
+			Message: fmt.Sprintf("durable: object uses archive format generation %d, and this engine "+
+				"restores up to %d; a newer chdb-core is required, since the format generation only "+
+				"moves when older archives can no longer be restored",
+				head.Engine.BackupFormat, running.backupFormat),
+			Expected: fmt.Sprintf("%d", head.Engine.BackupFormat),
+			Actual:   fmt.Sprintf("%d", running.backupFormat),
+		}
+	}
+	cmp, err := CompareEngineVersions(running.version, head.Engine.MinReader)
+	if err != nil {
+		return err
+	}
+	if cmp < 0 {
+		return &Error{
+			Category: CategoryEngineIncompatible,
+			Message: fmt.Sprintf("durable: object requires chdb %s or later to read, and this process "+
+				"runs %s (written by %s)",
+				head.Engine.MinReader, running.version, head.Engine.Version),
+			Expected: head.Engine.MinReader,
+			Actual:   running.version,
+		}
+	}
+	return nil
+}
+
+// raiseCompatibilityFloor records this engine's requirements on a head being
+// written, without ever relaxing what is already stored.
+//
+// The protocol says a writer must not lower either requirement. Taking the
+// maximum rather than overwriting is what enforces that: an object whose base
+// was produced by a newer engine keeps demanding that engine even if an older
+// one somehow reaches a write, instead of quietly advertising itself as
+// readable by a build that cannot restore it.
+func raiseCompatibilityFloor(head Head, running runningEngine) (Head, error) {
+	out := head
+	out.Engine.Version = running.version
+	if running.backupFormat > out.Engine.BackupFormat {
+		out.Engine.BackupFormat = running.backupFormat
+	}
+	minReader, err := maxEngineVersion(out.Engine.MinReader, running.version)
+	if err != nil {
+		return Head{}, err
+	}
+	out.Engine.MinReader = minReader
+	return out, nil
+}

--- a/chdb/durable/negotiate_test.go
+++ b/chdb/durable/negotiate_test.go
@@ -1,0 +1,147 @@
+package durable
+
+import (
+	"errors"
+	"testing"
+)
+
+func headWith(engine EngineIdentity, protocol Protocol) Head {
+	head := coldHead("mem", engine.Version, engine.BackupFormat)
+	head.Engine = engine
+	head.Protocol = protocol
+	return head
+}
+
+func v1Protocol() Protocol {
+	return Protocol{Version: 1, ReaderFeatures: []string{}, WriterFeatures: []string{}}
+}
+
+// The case the whole engine gate exists for: an object written by one release
+// and opened by a later one. An exact-match check would refuse this, which is
+// the opposite of what the compatibility promise says.
+func TestEngineGateOpensAnObjectFromAnEarlierRelease(t *testing.T) {
+	head := headWith(EngineIdentity{
+		Name: EngineName, Version: "26.7.2-rc.2", BackupFormat: 1, MinReader: "26.7.2-rc.2",
+	}, v1Protocol())
+
+	for _, reader := range []string{"26.7.2-rc.2", "26.7.2", "26.7.3", "26.8.0", "27.0.0"} {
+		if err := assertEngineCompatible(head, runningEngine{version: reader, backupFormat: 1}); err != nil {
+			t.Errorf("chdb %s should be able to read an object written by 26.7.2-rc.2: %v", reader, err)
+		}
+	}
+}
+
+func TestEngineGateRefusesAReaderBelowMinReader(t *testing.T) {
+	head := headWith(EngineIdentity{
+		Name: EngineName, Version: "26.8.0", BackupFormat: 1, MinReader: "26.8.0",
+	}, v1Protocol())
+
+	err := assertEngineCompatible(head, runningEngine{version: "26.7.2-rc.2", backupFormat: 1})
+	if !errors.Is(err, ErrEngineIncompatible) {
+		t.Fatalf("category is %q, want engine_incompatible", CategoryOf(err))
+	}
+	var e *Error
+	errors.As(err, &e)
+	if e.Expected != "26.8.0" || e.Actual != "26.7.2-rc.2" {
+		t.Errorf("the error should name both sides, got expected=%q actual=%q", e.Expected, e.Actual)
+	}
+}
+
+// A newer archive format is the one signal that the compatibility promise has
+// been withdrawn. Without it a reader compares a larger version, concludes it
+// is fine, and discovers otherwise partway through RESTORE.
+func TestEngineGateRefusesANewerArchiveFormat(t *testing.T) {
+	head := headWith(EngineIdentity{
+		Name: EngineName, Version: "27.0.0", BackupFormat: 2, MinReader: "26.7.2-rc.2",
+	}, v1Protocol())
+
+	err := assertEngineCompatible(head, runningEngine{version: "26.7.2-rc.2", backupFormat: 1})
+	if !errors.Is(err, ErrEngineIncompatible) {
+		t.Fatalf("category is %q, want engine_incompatible", CategoryOf(err))
+	}
+}
+
+func TestEngineGateRefusesAnotherEngine(t *testing.T) {
+	head := headWith(EngineIdentity{
+		Name: "duckdb", Version: "1.0.0", BackupFormat: 1, MinReader: "1.0.0",
+	}, v1Protocol())
+
+	if err := assertEngineCompatible(head, runningEngine{version: "26.7.2-rc.2", backupFormat: 1}); !errors.Is(err, ErrEngineIncompatible) {
+		t.Fatalf("category is %q, want engine_incompatible", CategoryOf(err))
+	}
+}
+
+func TestProtocolGateRefusesAFutureVersion(t *testing.T) {
+	head := headWith(EngineIdentity{
+		Name: EngineName, Version: "26.7.2-rc.2", BackupFormat: 1, MinReader: "26.7.2-rc.2",
+	}, Protocol{Version: 2, ReaderFeatures: []string{}, WriterFeatures: []string{}})
+
+	if err := assertReadable(head); !errors.Is(err, ErrProtocolUnsupported) {
+		t.Fatalf("category is %q, want protocol_unsupported", CategoryOf(err))
+	}
+}
+
+// The asymmetry is the point: an unknown reader feature means bytes in the
+// object cannot be interpreted at all, while an unknown writer feature only
+// means writing correctly needs something this build cannot do.
+func TestFeatureGatesAreAsymmetric(t *testing.T) {
+	readerSide := headWith(EngineIdentity{
+		Name: EngineName, Version: "26.7.2-rc.2", BackupFormat: 1, MinReader: "26.7.2-rc.2",
+	}, Protocol{Version: 1, ReaderFeatures: []string{"preamble"}, WriterFeatures: []string{}})
+
+	err := assertReadable(readerSide)
+	if !errors.Is(err, ErrProtocolUnsupported) {
+		t.Fatalf("an unknown reader feature must refuse the open, got %q", CategoryOf(err))
+	}
+	var e *Error
+	errors.As(err, &e)
+	if len(e.Features) != 1 || e.Features[0] != "preamble" {
+		t.Errorf("the error should name the feature, got %v", e.Features)
+	}
+
+	writerSide := headWith(EngineIdentity{
+		Name: EngineName, Version: "26.7.2-rc.2", BackupFormat: 1, MinReader: "26.7.2-rc.2",
+	}, Protocol{Version: 1, ReaderFeatures: []string{}, WriterFeatures: []string{"data-wal"}})
+
+	if err := assertReadable(writerSide); err != nil {
+		t.Fatalf("an unknown writer feature must still read: %v", err)
+	}
+	if err := assertWritable(writerSide); !errors.Is(err, ErrProtocolUnsupported) {
+		t.Fatalf("an unknown writer feature must refuse the lease, got %q", CategoryOf(err))
+	}
+}
+
+// A writer records its own requirements on every head write and never lowers
+// what is already stored. Overwriting rather than taking the maximum would let
+// an older writer advertise an object as readable by a build that cannot
+// restore its base.
+func TestCompatibilityFloorOnlyRises(t *testing.T) {
+	head := headWith(EngineIdentity{
+		Name: EngineName, Version: "26.8.0", BackupFormat: 2, MinReader: "26.8.0",
+	}, v1Protocol())
+
+	raised, err := raiseCompatibilityFloor(head, runningEngine{version: "26.7.2-rc.2", backupFormat: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if raised.Engine.MinReader != "26.8.0" {
+		t.Errorf("min_reader dropped to %q; an older writer must not lower it", raised.Engine.MinReader)
+	}
+	if raised.Engine.BackupFormat != 2 {
+		t.Errorf("backup_format dropped to %d; an older writer must not lower it", raised.Engine.BackupFormat)
+	}
+	// engine.version is a record of who wrote last, not a floor, so it does
+	// move.
+	if raised.Engine.Version != "26.7.2-rc.2" {
+		t.Errorf("engine.version is %q, want the writer that just wrote", raised.Engine.Version)
+	}
+
+	// And a newer writer does raise it.
+	raised, err = raiseCompatibilityFloor(head, runningEngine{version: "27.0.0", backupFormat: 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if raised.Engine.MinReader != "27.0.0" || raised.Engine.BackupFormat != 3 {
+		t.Errorf("a newer writer should raise the floor, got %+v", raised.Engine)
+	}
+}

--- a/chdb/durable/object.go
+++ b/chdb/durable/object.go
@@ -1,0 +1,1457 @@
+package durable
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// The Durable V1 object state machine (contract §5).
+//
+// Everything the protocol calls hard lives here: lease acquisition and
+// fencing, the operation queue, WAL publication, checkpoint, and the reconcile
+// that decides whether a request whose response vanished actually committed.
+// None of it touches a native library — the engine arrives as an Engine, the
+// object store as a Backend.
+//
+// A few invariants are worth stating up front, because most of the code below
+// exists to hold one of them:
+//
+//   - **Execute succeeding does not mean the write is durable.** It means the
+//     statement ran locally and joined the buffer. Durability is Flush. A
+//     product that answers a client before flushing is choosing to lose that
+//     write on a crash, and it should choose that knowingly.
+//   - **Nothing is ever reported as committed without proof.** Every commit
+//     path can end in commit_ambiguous, which is an honest answer. Reporting a
+//     lost response as success would be the one failure mode a caller cannot
+//     defend against.
+//   - **A writer that cannot confirm its lease stops writing.** Not on the
+//     next error — at the moment its locally believed validity window lapses.
+//     The alternative is two processes each convinced they are the only
+//     writer.
+//   - **Local resources are always released.** A close that fails to flush
+//     still closes the connection and removes the scratch directory, and still
+//     reports the failure.
+
+// Tuning holds the lease and commit parameters. The contract lets a binding
+// choose these but requires the defaults, their units and their rules to be
+// documented — so they are, here, and the same values drive the tests.
+//
+// A zero field takes its default, so a caller overriding one leaves the rest
+// alone.
+type Tuning struct {
+	// LeaseTTL is how long a lease stays valid after a successful head write.
+	// Default 30s.
+	LeaseTTL time.Duration
+
+	// HeartbeatInterval is how often the writer renews. It must be at most a
+	// third of the TTL, so two consecutive heartbeat failures still leave a
+	// window to notice and fence. Default 10s.
+	HeartbeatInterval time.Duration
+
+	// ClockSkewAllowance is how far past a recorded expiry another writer
+	// waits before treating a lease as abandoned. This is a bound on
+	// disagreement between two machines' clocks, not a grace period for a slow
+	// writer. Default 5s.
+	ClockSkewAllowance time.Duration
+
+	// CommitDeadline is how long a single commit may spend retrying and
+	// reconciling. Default 30s.
+	CommitDeadline time.Duration
+
+	// MaxCommitAttempts is how many attempts a commit makes inside that
+	// deadline before giving up. Default 5.
+	MaxCommitAttempts int
+}
+
+// DefaultTuning is what an object uses when a caller says nothing.
+var DefaultTuning = Tuning{
+	LeaseTTL:           30 * time.Second,
+	HeartbeatInterval:  10 * time.Second,
+	ClockSkewAllowance: 5 * time.Second,
+	CommitDeadline:     30 * time.Second,
+	MaxCommitAttempts:  5,
+}
+
+func (t Tuning) withDefaults() Tuning {
+	out := t
+	if out.LeaseTTL == 0 {
+		out.LeaseTTL = DefaultTuning.LeaseTTL
+	}
+	if out.HeartbeatInterval == 0 {
+		out.HeartbeatInterval = DefaultTuning.HeartbeatInterval
+	}
+	if out.ClockSkewAllowance == 0 {
+		out.ClockSkewAllowance = DefaultTuning.ClockSkewAllowance
+	}
+	if out.CommitDeadline == 0 {
+		out.CommitDeadline = DefaultTuning.CommitDeadline
+	}
+	if out.MaxCommitAttempts == 0 {
+		out.MaxCommitAttempts = DefaultTuning.MaxCommitAttempts
+	}
+	return out
+}
+
+func (t Tuning) validate() error {
+	// Every one of these ends up in arithmetic that decides whether this
+	// process still owns the object, so a nonsensical value is refused rather
+	// than propagated into an expiry nobody can take over.
+	fields := []struct {
+		name  string
+		value time.Duration
+	}{
+		{"LeaseTTL", t.LeaseTTL},
+		{"HeartbeatInterval", t.HeartbeatInterval},
+		{"ClockSkewAllowance", t.ClockSkewAllowance},
+		{"CommitDeadline", t.CommitDeadline},
+	}
+	for _, f := range fields {
+		if f.value <= 0 {
+			return newError(CategoryBackend, "durable: Tuning.%s must be positive, got %s",
+				f.name, f.value)
+		}
+	}
+	if t.MaxCommitAttempts <= 0 {
+		return newError(CategoryBackend, "durable: Tuning.MaxCommitAttempts must be positive, got %d",
+			t.MaxCommitAttempts)
+	}
+	if t.HeartbeatInterval*3 > t.LeaseTTL {
+		return newError(CategoryBackend,
+			"durable: Tuning.HeartbeatInterval (%s) must be at most a third of LeaseTTL (%s); "+
+				"the contract requires room for a retry before expiry",
+			t.HeartbeatInterval, t.LeaseTTL)
+	}
+	return nil
+}
+
+// OpenOptions configures one open.
+type OpenOptions struct {
+	// ReadOnly opens without a writer lease. A read-only handle serves the
+	// manifest as it stood at open.
+	ReadOnly bool
+
+	// Force takes an unexpired lease from its current holder. This is an
+	// administrator action: the previous writer's unflushed local work is
+	// lost, and it learns this only when its next commit is fenced.
+	Force bool
+
+	// ExistingOnly refuses to create the object if it does not exist.
+	ExistingOnly bool
+
+	// Owner is the visible writer name recorded in the lease. Observability
+	// only. Defaults to a name derived from the process id.
+	Owner string
+
+	// Database is the database this object holds. Only used when creating a
+	// cold object; an existing object's head is authoritative. Defaults to
+	// "default".
+	Database string
+
+	// ScratchRoot is the parent directory for the scratch tree. Defaults to
+	// the system temporary directory.
+	ScratchRoot string
+
+	// OnRestoreProgress is called as the open restores base and replays WAL.
+	// It is called synchronously and best-effort: a panic from it is not
+	// caught, but it is never given a chance to fail the recovery, because it
+	// returns nothing.
+	OnRestoreProgress func(RestoreProgress)
+
+	// Tuning overrides the lease and commit defaults, field by field.
+	Tuning Tuning
+}
+
+// RestorePhase names a stage of the restore an open performs.
+type RestorePhase string
+
+const (
+	PhaseCreatingDatabase RestorePhase = "creating-database"
+	PhaseRestoringBase    RestorePhase = "restoring-base"
+	PhaseReplayingWAL     RestorePhase = "replaying-wal"
+	PhaseReady            RestorePhase = "ready"
+)
+
+// RestoreProgress reports progress through an open's restore, for a caller
+// that has to show one. Recovering a large object is not instantaneous, and
+// "starting" with no further detail is indistinguishable from "stuck" — which
+// is the state an operator most needs to tell apart.
+type RestoreProgress struct {
+	Phase RestorePhase
+
+	// Database is set during PhaseCreatingDatabase.
+	Database string
+
+	// Key and Size describe the object being fetched, during
+	// PhaseRestoringBase and PhaseReplayingWAL.
+	Key  string
+	Size int64
+
+	// Segment is the 1-based index of the WAL segment being replayed, and
+	// Segments how many there are.
+	Segment  int
+	Segments int
+
+	// Statements is how many statements have been replayed so far, across all
+	// segments.
+	Statements int64
+}
+
+// Stats is a consistent snapshot of an object's runtime state.
+//
+// It is taken as a whole rather than field by field, so what it reports is
+// internally consistent: reading a generation and a sequence number through
+// separate accessors can straddle a commit and describe a state that never
+// existed.
+//
+// It carries no credentials and no SQL, so it is safe to log verbatim. Object
+// ids and keys are safe; the statements that produced them are not, and are
+// deliberately absent.
+type Stats struct {
+	ObjectID string
+	Database string
+	ReadOnly bool
+
+	// State is "open", "closing" or "closed".
+	State string
+
+	// Fenced is true once this writer has lost, or given up on, its lease.
+	Fenced bool
+
+	Generation int64
+	Owner      string
+	Instance   string
+
+	// LeaseExpiresAt is when this writer stops believing its lease. Zero for a
+	// read-only open.
+	LeaseExpiresAt time.Time
+
+	// CommittedSeq is manifest.seq as last committed.
+	CommittedSeq int64
+
+	BaseKey     string
+	WALSegments int
+
+	// ExecutedStatements is how many statements this handle has run since it
+	// opened, and CommittedStatements how many of those are in a committed WAL
+	// segment.
+	ExecutedStatements  int64
+	CommittedStatements int64
+
+	PendingStatements int
+	PendingBytes      int64
+
+	LastFlushAt      time.Time
+	LastCheckpointAt time.Time
+}
+
+// WriteTicket is a watermark for one executed statement.
+//
+// FlushThrough turns it into a durability barrier, which is what lets a caller
+// that expands one request into several statements answer the request as a
+// whole without the protocol having to know about requests.
+type WriteTicket struct {
+	// Statement is the ordinal of the statement within this open session,
+	// starting at 1.
+	Statement int64
+}
+
+type scratch struct {
+	root    string
+	data    string
+	backups string
+	staging string
+}
+
+// Object is one open durable object.
+type Object struct {
+	id       string
+	readOnly bool
+	backend  Backend
+	engine   Engine
+	scratch  scratch
+	tuning   Tuning
+	instance string
+	owner    string
+	running  runningEngine
+	progress func(RestoreProgress)
+
+	// ops serializes whole logical operations; headGate serializes single head
+	// compare-and-swaps, including heartbeat. See gate.go for why there are
+	// two.
+	ops      *gate
+	headGate *gate
+
+	// st guards every mutable field below. It is taken for short reads and
+	// writes only, never held across storage or engine I/O — the two gates
+	// provide that ordering.
+	st                  sync.Mutex
+	head                Head
+	etag                string
+	raw                 map[string]any
+	walBuffer           []string
+	walBufferBytes      int64
+	statementCounter    int64
+	committedStatements int64
+	lastFlushAt         time.Time
+	lastCheckpointAt    time.Time
+	state               string
+	fenced              bool
+	leaseDeadline       time.Time
+
+	heartbeatStop     chan struct{}
+	heartbeatDone     chan struct{}
+	heartbeatStopOnce sync.Once
+
+	closeOnce sync.Once
+	closeErr  error
+}
+
+// ---------------------------------------------------------------- accessors
+
+// ID is the object's id within its namespace.
+func (o *Object) ID() string { return o.id }
+
+// ReadOnly reports whether this handle holds a lease.
+func (o *Object) ReadOnly() bool { return o.readOnly }
+
+// Database is the database this object holds, fixed for its lifetime.
+func (o *Object) Database() string {
+	o.st.Lock()
+	defer o.st.Unlock()
+	return o.head.Manifest.DB
+}
+
+// Generation is the lease generation currently recorded in the head.
+func (o *Object) Generation() int64 {
+	o.st.Lock()
+	defer o.st.Unlock()
+	return o.head.Lease.Generation
+}
+
+// Manifest returns a copy of the committed manifest. Observability; never
+// authority.
+func (o *Object) Manifest() Manifest {
+	o.st.Lock()
+	defer o.st.Unlock()
+	return o.head.clone().Manifest
+}
+
+// ScratchPath is the absolute path of this object's private scratch tree.
+func (o *Object) ScratchPath() string { return o.scratch.root }
+
+// IsFenced reports whether this writer has lost, or given up on, its lease.
+func (o *Object) IsFenced() bool {
+	o.st.Lock()
+	defer o.st.Unlock()
+	return o.fenced
+}
+
+// PendingStatements is how many statements have run locally but are not yet in
+// a published WAL segment.
+func (o *Object) PendingStatements() int {
+	o.st.Lock()
+	defer o.st.Unlock()
+	return len(o.walBuffer)
+}
+
+// PendingBytes is the encoded size of those statements.
+//
+// It is exposed so a caller can apply its own backpressure — flush on a size
+// threshold rather than discovering the segment ceiling by hitting it.
+func (o *Object) PendingBytes() int64 {
+	o.st.Lock()
+	defer o.st.Unlock()
+	return o.walBufferBytes
+}
+
+// Stats returns a point-in-time snapshot for a status endpoint or a log line.
+func (o *Object) Stats() Stats {
+	o.st.Lock()
+	defer o.st.Unlock()
+	stats := Stats{
+		ObjectID:            o.id,
+		Database:            o.head.Manifest.DB,
+		ReadOnly:            o.readOnly,
+		State:               o.state,
+		Fenced:              o.fenced,
+		Generation:          o.head.Lease.Generation,
+		Owner:               o.owner,
+		Instance:            o.instance,
+		CommittedSeq:        o.head.Manifest.Seq,
+		WALSegments:         len(o.head.Manifest.WAL),
+		ExecutedStatements:  o.statementCounter,
+		CommittedStatements: o.committedStatements,
+		PendingStatements:   len(o.walBuffer),
+		PendingBytes:        o.walBufferBytes,
+		LastFlushAt:         o.lastFlushAt,
+		LastCheckpointAt:    o.lastCheckpointAt,
+	}
+	if !o.readOnly {
+		stats.LeaseExpiresAt = o.leaseDeadline
+	}
+	if o.head.Manifest.Base != nil {
+		stats.BaseKey = o.head.Manifest.Base.Key
+	}
+	return stats
+}
+
+// --------------------------------------------------------------- public API
+
+// Query runs a read-only statement and returns its formatted result.
+//
+// It is refused unless core proves the text is exactly one READ_ONLY
+// statement: the method name is not the gate, the analysis is. format is a
+// ClickHouse output format; "" means JSONEachRow.
+func (o *Object) Query(ctx context.Context, sql, format string) (string, error) {
+	if err := o.ops.acquire(ctx); err != nil {
+		return "", err
+	}
+	defer o.ops.release()
+
+	if err := o.assertUsable(); err != nil {
+		return "", err
+	}
+	analysis, err := o.engine.Analyze(ctx, sql, o.Database())
+	if err != nil {
+		return "", err
+	}
+	if err := assertQueryAllowed(analysis); err != nil {
+		return "", err
+	}
+	if format == "" {
+		format = "JSONEachRow"
+	}
+	return o.engine.Query(ctx, sql, format)
+}
+
+// Execute runs one mutating statement and buffers it for the WAL.
+//
+// The statement is executed first and buffered only on success, so a statement
+// that failed is never replayed. The returned ticket is the watermark to pass
+// to FlushThrough when the caller needs the write to be durable before it
+// answers someone.
+func (o *Object) Execute(ctx context.Context, sql string) (WriteTicket, error) {
+	if err := o.ops.acquire(ctx); err != nil {
+		return WriteTicket{}, err
+	}
+	defer o.ops.release()
+
+	if err := o.assertWriter(); err != nil {
+		return WriteTicket{}, err
+	}
+	database := o.Database()
+	analysis, err := o.engine.Analyze(ctx, sql, database)
+	if err != nil {
+		return WriteTicket{}, err
+	}
+	if err := assertExecuteAllowed(analysis, database); err != nil {
+		return WriteTicket{}, err
+	}
+
+	// Both limits are checked here rather than at flush, and before the
+	// statement runs rather than after.
+	//
+	// The ordering is the point. A statement that has executed cannot be
+	// un-executed, so a buffer that has grown past what a segment can hold can
+	// no longer be flushed at all — every flush would fail encoding while the
+	// local database has already moved on. Checkpoint can still rescue it,
+	// since it archives the database rather than the buffer, but a caller has
+	// to know that, and nothing would have warned it. Worse, that state is
+	// reachable from a single transient failure: a flush that fails leaves the
+	// buffer intact by design, and a caller that keeps writing walks straight
+	// into it.
+	//
+	// Refusing here instead turns an unrecoverable flush into a recoverable
+	// execute. Nothing has run, so the refusal costs only the statement.
+	if err := assertStatementWithinLimit(sql); err != nil {
+		return WriteTicket{}, err
+	}
+	lineBytes, err := walLineBytes(sql)
+	if err != nil {
+		return WriteTicket{}, err
+	}
+	o.st.Lock()
+	projected := o.walBufferBytes + lineBytes
+	o.st.Unlock()
+	if projected > MaxWALSegmentBytes {
+		return WriteTicket{}, &Error{
+			Category: CategoryLimitExceeded,
+			Message: fmt.Sprintf("durable: this statement would take the unflushed buffer to %d "+
+				"bytes, over the %d-byte WAL segment limit; Flush or Checkpoint first",
+				projected, MaxWALSegmentBytes),
+			Limit:    MaxWALSegmentBytes,
+			Observed: projected,
+		}
+	}
+
+	if err := o.engine.Run(ctx, sql); err != nil {
+		return WriteTicket{}, err
+	}
+
+	o.st.Lock()
+	o.walBuffer = append(o.walBuffer, sql)
+	o.walBufferBytes += lineBytes
+	o.statementCounter++
+	ticket := WriteTicket{Statement: o.statementCounter}
+	o.st.Unlock()
+	return ticket, nil
+}
+
+// Flush publishes the buffered statements as one immutable WAL segment and
+// commits the reference.
+//
+// It returns the published reference, or a nil reference when there was
+// nothing buffered.
+func (o *Object) Flush(ctx context.Context) (*ObjectRef, error) {
+	if err := o.ops.acquire(ctx); err != nil {
+		return nil, err
+	}
+	defer o.ops.release()
+	return o.flushLocked(ctx)
+}
+
+// FlushThrough is a durability barrier for one ticket.
+//
+// It returns immediately if that statement is already committed, which is what
+// makes concurrent callers coalesce onto a single head write: the first
+// through the queue publishes the segment covering all of them, and the rest
+// find their watermark already met.
+func (o *Object) FlushThrough(ctx context.Context, ticket WriteTicket) error {
+	o.st.Lock()
+	done := ticket.Statement <= o.committedStatements
+	o.st.Unlock()
+	if done {
+		return nil
+	}
+	if err := o.ops.acquire(ctx); err != nil {
+		return err
+	}
+	defer o.ops.release()
+
+	o.st.Lock()
+	done = ticket.Statement <= o.committedStatements
+	o.st.Unlock()
+	if done {
+		return nil
+	}
+	_, err := o.flushLocked(ctx)
+	return err
+}
+
+// Checkpoint replaces the base with a full backup of the current local
+// database and clears the WAL list.
+//
+// It holds the operation queue for its whole duration, so nothing new is
+// executed into a database that is being archived. Heartbeat is unaffected: it
+// contends only for the head gate, which this takes just for the final commit.
+func (o *Object) Checkpoint(ctx context.Context) (*ObjectRef, error) {
+	if err := o.ops.acquire(ctx); err != nil {
+		return nil, err
+	}
+	defer o.ops.release()
+	return o.checkpointLocked(ctx)
+}
+
+// Close drains, flushes, releases the lease, then releases local resources.
+//
+// Local cleanup happens whether or not the remote steps worked, and a remote
+// failure is still returned. A close that swallowed a failed flush would be
+// reporting a durability barrier it did not reach.
+//
+// Close is idempotent: a second call returns the first one's error.
+func (o *Object) Close(ctx context.Context) error {
+	o.closeOnce.Do(func() { o.closeErr = o.closeInner(ctx) })
+	return o.closeErr
+}
+
+// ------------------------------------------------------------ open sequence
+
+// openObject runs the writer and read-only open sequences of contract §5.2.
+func openObject(ctx context.Context, id string, backend Backend, factory EngineFactory, options OpenOptions) (*Object, bool, error) {
+	tuning := options.Tuning.withDefaults()
+	if err := tuning.validate(); err != nil {
+		return nil, false, err
+	}
+
+	owner := options.Owner
+	if owner == "" {
+		owner = fmt.Sprintf("chdb-go-%d", os.Getpid())
+	}
+	instance := newInstanceID()
+
+	engine, err := factory(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+
+	var (
+		created     scratch
+		haveScratch bool
+		leaseTaken  *headSnapshot
+	)
+	// Unwind in the reverse order of acquisition, and never let a cleanup
+	// failure mask the error that caused it.
+	fail := func(cause error) (*Object, bool, error) {
+		_ = engine.Close(ctx)
+		if leaseTaken != nil {
+			_ = releaseLease(ctx, backend, instance)
+		}
+		if haveScratch {
+			_ = os.RemoveAll(created.root)
+		}
+		return nil, false, cause
+	}
+
+	// Compatibility is settled before anything is created or claimed: an
+	// object this engine cannot read should cost nothing but two strings.
+	version, err := engine.Version(ctx)
+	if err != nil {
+		return fail(err)
+	}
+	backupFormat, err := engine.BackupFormat(ctx)
+	if err != nil {
+		return fail(err)
+	}
+	running := runningEngine{version: version, backupFormat: backupFormat}
+
+	existing, found, err := readHead(ctx, backend)
+	if err != nil {
+		return fail(err)
+	}
+	if found {
+		if err := assertReadable(existing.head); err != nil {
+			return fail(err)
+		}
+		if err := assertEngineCompatible(existing.head, running); err != nil {
+			return fail(err)
+		}
+		if !options.ReadOnly {
+			if err := assertWritable(existing.head); err != nil {
+				return fail(err)
+			}
+		}
+	} else if options.ReadOnly || options.ExistingOnly {
+		return fail(newError(CategoryNotFound, "durable: object %s does not exist at %s",
+			id, backend.Describe()))
+	}
+
+	if !options.ReadOnly {
+		// Checked before anything is published: an empty name would produce a
+		// head that fails to parse, created with a conditional create that V1
+		// gives no way to undo. A bad argument should be a bad argument, not a
+		// permanently corrupt object.
+		database := options.Database
+		if database == "" {
+			database = "default"
+		}
+		if found {
+			leaseTaken, err = acquireLease(ctx, backend, existing, leaseParams{
+				instance: instance, owner: owner, tuning: tuning, force: options.Force,
+			})
+		} else {
+			leaseTaken, err = createCold(ctx, backend, coldParams{
+				id: id, database: database, running: running,
+				instance: instance, owner: owner, tuning: tuning,
+			})
+		}
+		if err != nil {
+			return fail(err)
+		}
+	}
+
+	snapshot := existing
+	if leaseTaken != nil {
+		snapshot = *leaseTaken
+	}
+
+	created, err = makeScratch(options.ScratchRoot)
+	if err != nil {
+		return fail(wrapError(CategoryBackend, err, "durable: cannot create a scratch directory"))
+	}
+	haveScratch = true
+
+	if err := engine.Start(ctx, EngineStartOptions{
+		DataPath:           created.data,
+		BackupsAllowedPath: created.backups,
+	}); err != nil {
+		return fail(err)
+	}
+
+	object := &Object{
+		id:       id,
+		readOnly: options.ReadOnly,
+		backend:  backend,
+		engine:   engine,
+		scratch:  created,
+		tuning:   tuning,
+		instance: instance,
+		owner:    owner,
+		running:  running,
+		progress: options.OnRestoreProgress,
+		ops:      newGate(),
+		headGate: newGate(),
+		head:     snapshot.head,
+		etag:     snapshot.etag,
+		raw:      snapshot.raw,
+		state:    "open",
+	}
+
+	if err := object.restore(ctx); err != nil {
+		return fail(err)
+	}
+
+	if options.ReadOnly {
+		// No lease, no heartbeat: the manifest read above is the snapshot this
+		// handle serves for its whole life. Immutable references make that
+		// safe even while a writer keeps committing.
+		return object, found, nil
+	}
+
+	object.st.Lock()
+	object.leaseDeadline = leaseDeadlineFrom(snapshot.head.Lease, tuning.LeaseTTL)
+	object.st.Unlock()
+
+	// Restore can outlast a lease. Confirming ownership before the handle
+	// escapes is what stops a writer from starting work on a database someone
+	// else has already taken over (contract §5.2 step 7).
+	if err := object.renewLease(ctx); err != nil {
+		return fail(err)
+	}
+	object.startHeartbeat()
+	leaseTaken = nil
+	return object, found, nil
+}
+
+// leaseDeadlineFrom is when this writer stops believing a lease it just wrote.
+//
+// It is the earlier of what is stored and what the local clock allows. Trusting
+// only the stored value would extend the deadline past the TTL if a remote
+// clock runs fast; trusting only the local clock would extend it past what
+// another writer will honour.
+func leaseDeadlineFrom(lease Lease, ttl time.Duration) time.Time {
+	local := time.Now().Add(ttl)
+	if lease.ExpiresAt == nil {
+		return time.Time{}
+	}
+	stored := time.UnixMicro(int64(*lease.ExpiresAt * 1e6))
+	if stored.Before(local) {
+		return stored
+	}
+	return local
+}
+
+func makeScratch(root string) (scratch, error) {
+	if root == "" {
+		root = os.TempDir()
+	}
+	base, err := os.MkdirTemp(root, "chdb-durable-")
+	if err != nil {
+		return scratch{}, err
+	}
+	out := scratch{
+		root:    base,
+		data:    filepath.Join(base, "data"),
+		backups: filepath.Join(base, "backups"),
+		staging: filepath.Join(base, "staging"),
+	}
+	// The engine validates that a backup target's parent directory exists, and
+	// its allowed-path guard resolves a relative value somewhere nobody wants,
+	// so all three are created up front and always absolute.
+	for _, dir := range []string{out.data, out.backups, out.staging} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			os.RemoveAll(base)
+			return scratch{}, err
+		}
+	}
+	return out, nil
+}
+
+func readHead(ctx context.Context, backend Backend) (headSnapshot, bool, error) {
+	data, etag, found, err := backend.GetBytesWithETag(ctx, HeadKey)
+	if err != nil {
+		return headSnapshot{}, false, err
+	}
+	if !found {
+		return headSnapshot{}, false, nil
+	}
+	head, raw, err := parseHead(data)
+	if err != nil {
+		return headSnapshot{}, false, err
+	}
+	return headSnapshot{head: head, etag: etag, raw: raw}, true, nil
+}
+
+// ------------------------------------------------------------ internal work
+
+func (o *Object) report(progress RestoreProgress) {
+	if o.progress != nil {
+		o.progress(progress)
+	}
+}
+
+// restore brings the manifest's state into the scratch engine: base, then WAL
+// in order.
+//
+// Both are verified against length and SHA-256 before use, and a missing or
+// mismatched object stops the open rather than yielding a partially recovered
+// database (contract §4.5).
+func (o *Object) restore(ctx context.Context) error {
+	head := o.head
+	db := head.Manifest.DB
+
+	if head.Manifest.Base == nil {
+		o.report(RestoreProgress{Phase: PhaseCreatingDatabase, Database: db})
+		if err := o.engine.CreateDatabase(ctx, db); err != nil {
+			return err
+		}
+	} else {
+		base := *head.Manifest.Base
+		o.report(RestoreProgress{Phase: PhaseRestoringBase, Key: base.Key, Size: base.Size})
+		reader, found, err := o.backend.OpenReader(ctx, base.Key)
+		if err != nil {
+			return err
+		}
+		if !found {
+			return newError(CategoryCorrupt,
+				"durable: manifest names base %s, which is not present at %s",
+				base.Key, o.backend.Describe())
+		}
+		staged := filepath.Join(o.scratch.staging, "base-"+uuid8()+".part")
+		archive := filepath.Join(o.scratch.backups, "base-"+uuid8()+".tar.gz")
+		err = streamToVerifiedFile(reader, base, staged, archive, "base checkpoint")
+		reader.Close()
+		if err != nil {
+			return err
+		}
+		// A restore is where an incompatible archive actually surfaces. The
+		// gate already established that this engine is allowed to read the
+		// object, so a RESTORE that fails anyway means the compatibility
+		// promise was violated rather than that the engine hit an ordinary
+		// error. The distinction is the caller's next move: upgrade the
+		// engine, or report a core defect. Reporting it as a plain engine
+		// error hides both.
+		if err := o.engine.RestoreDatabase(ctx, db, archive); err != nil {
+			return &Error{
+				Category: CategoryEngineIncompatible,
+				Message: fmt.Sprintf("durable: restoring base %s into %q failed on chdb %s. The "+
+					"archive was produced by %s and the object declares min_reader %s at archive "+
+					"format %d, so this restore was expected to be supported",
+					base.Key, db, o.running.version, head.Engine.Version,
+					head.Engine.MinReader, head.Engine.BackupFormat),
+				Err:      err,
+				Expected: head.Engine.Version,
+				Actual:   o.running.version,
+			}
+		}
+		os.Remove(archive)
+	}
+
+	if err := o.engine.UseDatabase(ctx, db); err != nil {
+		return err
+	}
+
+	var replayed int64
+	for i, ref := range head.Manifest.WAL {
+		o.report(RestoreProgress{
+			Phase: PhaseReplayingWAL, Key: ref.Key, Size: ref.Size,
+			Segment: i + 1, Segments: len(head.Manifest.WAL), Statements: replayed,
+		})
+		data, found, err := o.backend.GetBytes(ctx, ref.Key)
+		if err != nil {
+			return err
+		}
+		if !found {
+			return newError(CategoryCorrupt,
+				"durable: manifest names WAL segment %s, which is not present at %s",
+				ref.Key, o.backend.Describe())
+		}
+		if err := assertDigest(ref, digestOf(data), "WAL segment"); err != nil {
+			return err
+		}
+		statements, err := decodeWALSegment(data, ref.Key)
+		if err != nil {
+			return err
+		}
+		for _, sql := range statements {
+			// Replay goes straight to the engine. Routing it back through the
+			// public Execute would re-analyse statements core already accepted
+			// and, worse, append every one of them to the WAL a second time.
+			if err := o.engine.Run(ctx, sql); err != nil {
+				return err
+			}
+			replayed++
+		}
+	}
+	o.report(RestoreProgress{Phase: PhaseReady, Statements: replayed})
+	return nil
+}
+
+// assertUsable refuses an operation on a closed or fenced object.
+func (o *Object) assertUsable() error {
+	o.st.Lock()
+	defer o.st.Unlock()
+	if o.state == "closed" {
+		return newError(CategoryClosed, "durable: object %s is closed", o.id)
+	}
+	if o.fenced {
+		return newError(CategoryLeaseFenced,
+			"durable: object %s lost its lease (generation %d); this handle cannot be used again",
+			o.id, o.head.Lease.Generation)
+	}
+	return nil
+}
+
+// assertWriter additionally refuses a read-only handle and self-fences a
+// writer whose lease has lapsed.
+func (o *Object) assertWriter() error {
+	if err := o.assertUsable(); err != nil {
+		return err
+	}
+	if o.readOnly {
+		return newError(CategoryClassificationRefused,
+			"durable: object %s is open read-only; only READ_ONLY statements are accepted", o.id)
+	}
+	o.st.Lock()
+	lapsed := !time.Now().Before(o.leaseDeadline)
+	o.st.Unlock()
+	if lapsed {
+		// Self-fence. The lease may in fact still be ours, but we cannot show
+		// that it is, and "probably still the writer" is not a state to write
+		// from.
+		o.fence()
+		return newError(CategoryLeaseFenced,
+			"durable: object %s could not confirm its lease before it lapsed; the writer has "+
+				"fenced itself", o.id)
+	}
+	return nil
+}
+
+// fence marks this writer as no longer the writer and stops renewing.
+//
+// It signals the heartbeat rather than waiting for it, because a failed
+// renewal is one of the ways an object gets fenced — and that runs *on* the
+// heartbeat goroutine, which cannot wait for itself to finish.
+func (o *Object) fence() {
+	o.st.Lock()
+	o.fenced = true
+	o.st.Unlock()
+	o.signalHeartbeatStop()
+}
+
+func (o *Object) flushLocked(ctx context.Context) (*ObjectRef, error) {
+	if err := o.assertWriter(); err != nil {
+		return nil, err
+	}
+
+	o.st.Lock()
+	statements := append([]string(nil), o.walBuffer...)
+	generation := o.head.Lease.Generation
+	nextSeq := o.head.Manifest.Seq + 1
+	o.st.Unlock()
+
+	if len(statements) == 0 {
+		return nil, nil
+	}
+
+	data, err := encodeWALSegment(statements)
+	if err != nil {
+		return nil, err
+	}
+	digest := digestOf(data)
+	ref := ObjectRef{Key: walKey(generation, nextSeq), Size: digest.Size, SHA256: digest.SHA256}
+
+	if err := o.publishBytes(ctx, ref, data); err != nil {
+		return nil, err
+	}
+	// The upload is network I/O and can outlast the lease. Checking only at
+	// entry would let a writer that was required to self-fence mid-upload go on
+	// to commit the manifest anyway.
+	if err := o.assertWriter(); err != nil {
+		return nil, err
+	}
+	err = o.commitHead(ctx, commitParams{
+		key: ref.Key,
+		build: func(current Head) Head {
+			next := current.clone()
+			next.Manifest.WAL = append(next.Manifest.WAL, ref)
+			next.Manifest.Seq = current.Manifest.Seq + 1
+			return next
+		},
+		committed: func(observed Head) bool {
+			for _, w := range observed.Manifest.WAL {
+				if w.Key == ref.Key {
+					return true
+				}
+			}
+			return false
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	o.st.Lock()
+	o.walBuffer = o.walBuffer[len(statements):]
+	o.walBufferBytes = 0
+	for _, sql := range o.walBuffer {
+		n, _ := walLineBytes(sql)
+		o.walBufferBytes += n
+	}
+	o.committedStatements += int64(len(statements))
+	o.lastFlushAt = time.Now()
+	o.st.Unlock()
+	return &ref, nil
+}
+
+func (o *Object) checkpointLocked(ctx context.Context) (*ObjectRef, error) {
+	if err := o.assertWriter(); err != nil {
+		return nil, err
+	}
+
+	o.st.Lock()
+	database := o.head.Manifest.DB
+	generation := o.head.Lease.Generation
+	nextSeq := o.head.Manifest.Seq + 1
+	o.st.Unlock()
+
+	archive := filepath.Join(o.scratch.backups, "checkpoint-"+uuid8()+".tar.gz")
+	if err := o.engine.BackupDatabase(ctx, database, archive); err != nil {
+		os.Remove(archive)
+		return nil, err
+	}
+	defer os.Remove(archive)
+
+	digest, err := digestFile(archive)
+	if err != nil {
+		return nil, wrapError(CategoryEngine, err, "durable: cannot read the archive just written")
+	}
+	ref := ObjectRef{Key: checkpointKey(generation, nextSeq), Size: digest.Size, SHA256: digest.SHA256}
+
+	if err := o.publishFile(ctx, ref, archive, digest); err != nil {
+		return nil, err
+	}
+	// A full backup plus its upload is the longest thing this object does,
+	// easily longer than a lease TTL. Ownership was checked before it started;
+	// it has to hold now, when the commit actually happens.
+	if err := o.assertWriter(); err != nil {
+		return nil, err
+	}
+
+	o.st.Lock()
+	covered := len(o.walBuffer)
+	o.st.Unlock()
+
+	err = o.commitHead(ctx, commitParams{
+		key: ref.Key,
+		build: func(current Head) Head {
+			next := current.clone()
+			base := ref
+			next.Manifest.Base = &base
+			next.Manifest.WAL = []ObjectRef{}
+			next.Manifest.Seq = current.Manifest.Seq + 1
+			return next
+		},
+		committed: func(observed Head) bool {
+			return observed.Manifest.Base != nil && observed.Manifest.Base.Key == ref.Key
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Only now. Until the head names this base, the old base plus the old WAL
+	// is still the authoritative state, and these statements are only
+	// recoverable from the buffer.
+	o.st.Lock()
+	o.walBuffer = o.walBuffer[covered:]
+	o.walBufferBytes = 0
+	for _, sql := range o.walBuffer {
+		n, _ := walLineBytes(sql)
+		o.walBufferBytes += n
+	}
+	o.committedStatements += int64(covered)
+	o.lastCheckpointAt = time.Now()
+	o.st.Unlock()
+	return &ref, nil
+}
+
+func (o *Object) closeInner(ctx context.Context) error {
+	o.st.Lock()
+	o.state = "closing"
+	o.st.Unlock()
+	o.stopHeartbeat()
+
+	var failure error
+	if err := o.ops.seal(ctx, func() error {
+		return newError(CategoryClosed, "durable: object %s is closing", o.id)
+	}); err != nil {
+		failure = err
+	}
+
+	o.st.Lock()
+	readOnly, fenced, pending := o.readOnly, o.fenced, len(o.walBuffer)
+	o.st.Unlock()
+
+	if failure == nil && !readOnly && !fenced {
+		if err := o.ops.acquireSealed(ctx); err != nil {
+			failure = err
+		} else {
+			if pending > 0 {
+				if _, err := o.flushLocked(ctx); err != nil {
+					failure = err
+				}
+			}
+			if failure == nil {
+				failure = o.releaseLeaseLocked(ctx)
+			}
+			o.ops.release()
+		}
+	}
+
+	// Native connection and scratch go back whatever happened above: a remote
+	// failure is a durability problem, not a reason to leak a connection or a
+	// temp tree.
+	if err := o.engine.Close(ctx); err != nil && failure == nil {
+		failure = err
+	}
+	if err := os.RemoveAll(o.scratch.root); err != nil && failure == nil {
+		failure = wrapError(CategoryBackend, err, "durable: cannot remove the scratch directory")
+	}
+
+	o.st.Lock()
+	o.state = "closed"
+	o.st.Unlock()
+	return failure
+}
+
+func (o *Object) releaseLeaseLocked(ctx context.Context) error {
+	err := o.commitHead(ctx, commitParams{
+		key: HeadKey,
+		build: func(current Head) Head {
+			next := current.clone()
+			next.Lease = Lease{Generation: current.Lease.Generation}
+			return next
+		},
+		committed: func(observed Head) bool { return observed.Lease.Instance == nil },
+		// Releasing is the last thing this instance does; after it succeeds
+		// the ownership check would fail by construction.
+		skipOwnershipAfter: true,
+	})
+	if err != nil {
+		return err
+	}
+	o.st.Lock()
+	o.fenced = false
+	o.leaseDeadline = time.Time{}
+	o.st.Unlock()
+	return nil
+}
+
+// ------------------------------------------------------------------- lease
+
+func (o *Object) startHeartbeat() {
+	if o.readOnly {
+		return
+	}
+	o.st.Lock()
+	o.heartbeatStop = make(chan struct{})
+	o.heartbeatDone = make(chan struct{})
+	stop, done := o.heartbeatStop, o.heartbeatDone
+	o.st.Unlock()
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(o.tuning.HeartbeatInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				// A renewal that fails is not fatal on its own — the next
+				// attempt may succeed. What is fatal is reaching the locally
+				// believed expiry without a confirmation, and assertWriter
+				// checks exactly that.
+				ctx, cancel := context.WithTimeout(context.Background(), o.tuning.CommitDeadline)
+				_ = o.renewLease(ctx)
+				cancel()
+			}
+		}
+	}()
+}
+
+// signalHeartbeatStop tells the heartbeat goroutine to finish, without
+// waiting for it.
+func (o *Object) signalHeartbeatStop() {
+	o.st.Lock()
+	stop := o.heartbeatStop
+	o.st.Unlock()
+	if stop == nil {
+		return
+	}
+	o.heartbeatStopOnce.Do(func() { close(stop) })
+}
+
+// stopHeartbeat signals the heartbeat goroutine and waits for it to return, so
+// that no renewal is in flight once close starts its own head writes.
+//
+// Only close calls it. Calling it from the heartbeat goroutine would be a wait
+// for itself.
+func (o *Object) stopHeartbeat() {
+	o.signalHeartbeatStop()
+	o.st.Lock()
+	done := o.heartbeatDone
+	o.st.Unlock()
+	if done != nil {
+		<-done
+	}
+}
+
+// renewLease extends the expiry, leaving generation and seq untouched.
+func (o *Object) renewLease(ctx context.Context) error {
+	o.st.Lock()
+	skip := o.readOnly || o.fenced || o.state == "closed"
+	o.st.Unlock()
+	if skip {
+		return nil
+	}
+
+	var written float64
+	err := o.commitHead(ctx, commitParams{
+		key: HeadKey,
+		build: func(current Head) Head {
+			// The expiry has to be computed inside the commit, not before
+			// waiting for the head gate. Computed early and then delayed
+			// behind a long checkpoint commit, the value written could already
+			// be in the past — while the local deadline below was refreshed
+			// from the current clock. The object would then keep writing under
+			// a lease other writers are entitled to take.
+			written = float64(time.Now().Add(o.tuning.LeaseTTL).UnixMicro()) / 1e6
+			next := current.clone()
+			next.Lease.Owner = stringPtr(o.owner)
+			next.Lease.Instance = stringPtr(o.instance)
+			next.Lease.ExpiresAt = floatPtr(written)
+			return next
+		},
+		committed: func(observed Head) bool {
+			return observed.Lease.instanceIs(o.instance) &&
+				observed.Lease.ExpiresAt != nil && *observed.Lease.ExpiresAt >= written
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	// Believe what is actually stored, not what a fresh clock would allow.
+	// Reconciliation can settle on a head written by an earlier attempt whose
+	// expiry is older than this one's.
+	o.st.Lock()
+	o.leaseDeadline = leaseDeadlineFrom(o.head.Lease, o.tuning.LeaseTTL)
+	o.st.Unlock()
+	return nil
+}
+
+// -------------------------------------------------------- immutable publish
+
+func (o *Object) publishBytes(ctx context.Context, ref ObjectRef, data []byte) error {
+	outcome, err := o.backend.PutBytesIfAbsent(ctx, ref.Key, data)
+	if err != nil {
+		return err
+	}
+	if outcome == PutCreated {
+		return nil
+	}
+	return o.reconcileUpload(ctx, ref, outcome)
+}
+
+func (o *Object) publishFile(ctx context.Context, ref ObjectRef, localPath string, digest Digest) error {
+	outcome, err := o.backend.PutFileIfAbsent(ctx, ref.Key, localPath, digest)
+	if err != nil {
+		return err
+	}
+	if outcome == PutCreated {
+		return nil
+	}
+	return o.reconcileUpload(ctx, ref, outcome)
+}
+
+// reconcileUpload settles an upload that did not cleanly create
+// (contract §5.8).
+//
+// The key is unique to this attempt, so "already exists" can only mean an
+// earlier try by this same writer landed. Re-reading and comparing the digest
+// is what turns a lost response into a fact: matching bytes are the bytes we
+// meant to publish, different bytes are corruption, and an absent object means
+// the write genuinely did not happen.
+func (o *Object) reconcileUpload(ctx context.Context, ref ObjectRef, outcome PutOutcome) error {
+	reader, found, err := o.backend.OpenReader(ctx, ref.Key)
+	if err != nil {
+		return err
+	}
+	if !found {
+		if outcome == PutAlreadyExists {
+			return newError(CategoryCorrupt,
+				"durable: %s was reported as existing but cannot be read from %s",
+				ref.Key, o.backend.Describe())
+		}
+		return &Error{
+			Category: CategoryCommitAmbiguous,
+			Message: fmt.Sprintf("durable: could not determine whether %s was uploaded to %s",
+				ref.Key, o.backend.Describe()),
+			Key: ref.Key,
+		}
+	}
+	defer reader.Close()
+	observed, err := drainDigest(reader)
+	if err != nil {
+		return wrapError(CategoryBackend, err, "durable: cannot re-read %s", ref.Key)
+	}
+	return assertDigest(ref, observed, "published object")
+}
+
+// --------------------------------------------------------------- head commit
+
+type commitParams struct {
+	// key names what is being committed, for the message an unresolved commit
+	// reports.
+	key string
+	// build produces the next head from whatever the current one turns out to
+	// be.
+	build func(current Head) Head
+	// committed recognises this writer's own intent in a head it did not
+	// write. This is what makes a lost response recoverable.
+	committed func(observed Head) bool
+	// skipOwnershipAfter allows a commit to be recognised as landed even
+	// though this instance no longer owns the lease. Only lease release sets
+	// it, because success there *is* the loss of ownership.
+	skipOwnershipAfter bool
+}
+
+// commitHead is the single path through which this object writes head.json.
+//
+// Every caller supplies two things: how to build the next head, and how to
+// recognise its own intent in a head it did not write. The second is what
+// makes a lost response recoverable — after re-reading, either the intent is
+// visible and this committed, or ownership is gone and this is fenced, or
+// neither is true and it can try again inside the deadline.
+func (o *Object) commitHead(ctx context.Context, params commitParams) error {
+	if err := o.headGate.acquire(ctx); err != nil {
+		return err
+	}
+	defer o.headGate.release()
+
+	deadline := time.Now().Add(o.tuning.CommitDeadline)
+	attempts := 0
+	sawAmbiguous := false
+
+	for {
+		attempts++
+
+		o.st.Lock()
+		current := o.head.clone()
+		etag := o.etag
+		raw := o.raw
+		generation := o.head.Lease.Generation
+		o.st.Unlock()
+
+		candidate, err := raiseCompatibilityFloor(params.build(current), o.running)
+		if err != nil {
+			return err
+		}
+		data, err := serializeHead(candidate, raw)
+		if err != nil {
+			return err
+		}
+		outcome, err := o.backend.ReplaceIfMatch(ctx, HeadKey, data, etag)
+		if err != nil {
+			return err
+		}
+		if outcome.Status == ReplaceDone {
+			o.adopt(candidate, outcome.ETag, nil)
+			return nil
+		}
+		if outcome.Status == ReplaceAmbiguous {
+			sawAmbiguous = true
+		}
+
+		// Either someone else wrote (not-replaced) or the answer was lost
+		// (ambiguous). Both are settled the same way: look at what is actually
+		// there.
+		fresh, found, err := readHead(ctx, o.backend)
+		if err != nil {
+			return err
+		}
+		if !found {
+			return newError(CategoryCorrupt,
+				"durable: %s disappeared from %s while committing", HeadKey, o.backend.Describe())
+		}
+
+		stillOurs := fresh.head.Lease.instanceIs(o.instance) &&
+			fresh.head.Lease.Generation == generation
+
+		if params.committed(fresh.head) && (stillOurs || params.skipOwnershipAfter) {
+			o.adopt(fresh.head, fresh.etag, fresh.raw)
+			return nil
+		}
+
+		if !stillOurs {
+			o.fence()
+			return newError(CategoryLeaseFenced,
+				"durable: object %s was taken over (generation %d); this writer can no longer commit",
+				o.id, fresh.head.Lease.Generation)
+		}
+
+		// Ownership intact and the intent is not there: our ETag was stale.
+		// Adopt the current one and retry within the deadline.
+		o.adopt(fresh.head, fresh.etag, fresh.raw)
+
+		if attempts >= o.tuning.MaxCommitAttempts || !time.Now().Before(deadline) {
+			// Two different answers, and the caller acts on them differently.
+			// If every attempt came back as a definite refusal, the commit
+			// provably did not happen and retrying later is safe. If any
+			// attempt was ambiguous, it may have landed, and a blind retry
+			// could publish twice.
+			if sawAmbiguous {
+				return &Error{
+					Category: CategoryCommitAmbiguous,
+					Message: fmt.Sprintf("durable: gave up committing %s after %d attempts without "+
+						"proving the outcome", params.key, attempts),
+					Key: params.key,
+				}
+			}
+			return newError(CategoryTimeout,
+				"durable: could not commit %s within %s (%d attempts, each definitively refused); "+
+					"nothing was committed", params.key, o.tuning.CommitDeadline, attempts)
+		}
+	}
+}
+
+// adopt records a head as the committed one.
+//
+// When raw is nil the candidate was this build's own construction, so the raw
+// document is re-derived from it — the same merge that produced the bytes just
+// written, which keeps the unknown fields that went out with them.
+//
+// Neither step can fail here: these are the inputs serializeHead accepted a
+// moment ago, and its output is what parseHead validates. If one somehow did,
+// keeping the previous raw is harmless rather than lossy — every known field is
+// patched from o.head on the next write, and the unknown fields in the older
+// document are the same ones.
+func (o *Object) adopt(head Head, etag string, raw map[string]any) {
+	o.st.Lock()
+	defer o.st.Unlock()
+	o.head = head
+	o.etag = etag
+	if raw != nil {
+		o.raw = raw
+		return
+	}
+	if data, err := serializeHead(head, o.raw); err == nil {
+		if _, parsed, err := parseHead(data); err == nil {
+			o.raw = parsed
+		}
+	}
+}

--- a/chdb/durable/object_test.go
+++ b/chdb/durable/object_test.go
@@ -1,0 +1,1234 @@
+package durable
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fixture holds one object store and the knobs to open writers against it.
+type fixture struct {
+	t       *testing.T
+	root    string
+	backend *faultBackend
+}
+
+func newFixture(t *testing.T) *fixture {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), "store")
+	local, err := NewLocalBackend(filepath.Join(root, "orders"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &fixture{t: t, root: root, backend: newFaultBackend(local)}
+}
+
+// open brings up an object against the shared store with a fresh engine, so a
+// reopen recovers through the object rather than through leftover local state.
+func (f *fixture) open(options OpenOptions) (*Object, *fakeEngine, bool, error) {
+	f.t.Helper()
+	engine := newFakeEngine()
+	if options.Database == "" {
+		options.Database = "mem"
+	}
+	options.ScratchRoot = f.t.TempDir()
+	ns, err := NewNamespace("file:///unused", NamespaceOptions{
+		EngineFactory: engine.factory(),
+		BackendFactory: func(context.Context, string) (Backend, error) {
+			return f.backend, nil
+		},
+	})
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	obj, existed, err := ns.Open(context.Background(), "orders", options)
+	return obj, engine, existed, err
+}
+
+func (f *fixture) mustOpen(options OpenOptions) (*Object, *fakeEngine, bool) {
+	f.t.Helper()
+	obj, engine, existed, err := f.open(options)
+	if err != nil {
+		f.t.Fatalf("open: %v", err)
+	}
+	return obj, engine, existed
+}
+
+func (f *fixture) head() Head {
+	f.t.Helper()
+	snapshot, found, err := readHead(context.Background(), f.backend)
+	if err != nil {
+		f.t.Fatalf("read head: %v", err)
+	}
+	if !found {
+		f.t.Fatal("no head was published")
+	}
+	return snapshot.head
+}
+
+func mustExecute(t *testing.T, obj *Object, sql string) WriteTicket {
+	t.Helper()
+	ticket, err := obj.Execute(context.Background(), sql)
+	if err != nil {
+		t.Fatalf("execute %q: %v", sql, err)
+	}
+	return ticket
+}
+
+// ------------------------------------------------------------- cold and warm
+
+func TestOpenCreatesAColdObject(t *testing.T) {
+	ctx := context.Background()
+	f := newFixture(t)
+
+	obj, _, existed := f.mustOpen(OpenOptions{Database: "mem", Owner: "worker-1"})
+	if existed {
+		t.Fatal("a cold open reported the object as existing")
+	}
+	defer obj.Close(ctx)
+
+	head := f.head()
+	if head.Protocol.Version != ProtocolVersion {
+		t.Errorf("protocol version is %d", head.Protocol.Version)
+	}
+	if head.Engine.Name != EngineName || head.Engine.Version != "26.7.2-rc.2" {
+		t.Errorf("engine is %+v", head.Engine)
+	}
+	if head.Engine.MinReader != "26.7.2-rc.2" || head.Engine.BackupFormat != BackupFormatBaseline {
+		t.Errorf("a fresh object should demand exactly the engine that made it, got %+v", head.Engine)
+	}
+	if head.Manifest.DB != "mem" || head.Manifest.Base != nil || len(head.Manifest.WAL) != 0 {
+		t.Errorf("a cold manifest is %+v", head.Manifest)
+	}
+	// Cold create and lease acquisition are one conditional write, so the
+	// published head is already held.
+	if head.Lease.Generation != 1 || head.Lease.Owner == nil || *head.Lease.Owner != "worker-1" {
+		t.Errorf("a cold lease is %+v", head.Lease)
+	}
+}
+
+func TestExecuteAndFlushPublishASegment(t *testing.T) {
+	ctx := context.Background()
+	f := newFixture(t)
+	obj, _, _ := f.mustOpen(OpenOptions{})
+
+	mustExecute(t, obj, "CREATE TABLE events (id UInt64) ENGINE = MergeTree ORDER BY id")
+	mustExecute(t, obj, "INSERT INTO events VALUES (1)")
+
+	// Execute means "ran locally and joined the buffer", nothing more.
+	if obj.PendingStatements() != 2 {
+		t.Fatalf("%d statements pending, want 2", obj.PendingStatements())
+	}
+	if len(f.head().Manifest.WAL) != 0 {
+		t.Fatal("Execute must not publish anything by itself")
+	}
+
+	ref, err := obj.Flush(ctx)
+	if err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	if ref == nil {
+		t.Fatal("flush published nothing")
+	}
+	head := f.head()
+	if len(head.Manifest.WAL) != 1 || head.Manifest.WAL[0].Key != ref.Key {
+		t.Fatalf("the manifest does not name the segment: %+v", head.Manifest)
+	}
+	if head.Manifest.Seq != 1 {
+		t.Errorf("seq is %d, want 1", head.Manifest.Seq)
+	}
+	if obj.PendingStatements() != 0 {
+		t.Errorf("%d statements still pending after a flush", obj.PendingStatements())
+	}
+
+	// The reference carries the length and digest a reader verifies against.
+	data, found, err := f.backend.GetBytes(ctx, ref.Key)
+	if err != nil || !found {
+		t.Fatalf("found=%v err=%v", found, err)
+	}
+	if err := assertDigest(*ref, digestOf(data), "WAL segment"); err != nil {
+		t.Fatalf("the published segment does not match its reference: %v", err)
+	}
+
+	// Flushing nothing is not an error and publishes nothing.
+	again, err := obj.Flush(ctx)
+	if err != nil {
+		t.Fatalf("an empty flush should succeed: %v", err)
+	}
+	if again != nil {
+		t.Fatalf("an empty flush published %s", again.Key)
+	}
+	if err := obj.Close(ctx); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+}
+
+func TestReopenReplaysTheWAL(t *testing.T) {
+	ctx := context.Background()
+	f := newFixture(t)
+
+	obj, _, _ := f.mustOpen(OpenOptions{})
+	mustExecute(t, obj, "CREATE TABLE events (id UInt64) ENGINE = MergeTree ORDER BY id")
+	mustExecute(t, obj, "INSERT INTO events VALUES (1)")
+	if _, err := obj.Flush(ctx); err != nil {
+		t.Fatal(err)
+	}
+	mustExecute(t, obj, "INSERT INTO events VALUES (2)")
+	if _, err := obj.Flush(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := obj.Close(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	var phases []RestorePhase
+	reopened, engine, existed := f.mustOpen(OpenOptions{
+		OnRestoreProgress: func(p RestoreProgress) { phases = append(phases, p.Phase) },
+	})
+	defer reopened.Close(ctx)
+	if !existed {
+		t.Fatal("a reopen reported the object as cold")
+	}
+
+	want := []string{
+		"CREATE TABLE events (id UInt64) ENGINE = MergeTree ORDER BY id",
+		"INSERT INTO events VALUES (1)",
+		"INSERT INTO events VALUES (2)",
+	}
+	got := engine.statements()
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Fatalf("replay produced\n%v\nwant\n%v", got, want)
+	}
+	// Replay goes straight to the engine: it must not re-enter the WAL.
+	if reopened.PendingStatements() != 0 {
+		t.Fatalf("replay buffered %d statements", reopened.PendingStatements())
+	}
+	if len(phases) < 3 || phases[0] != PhaseCreatingDatabase || phases[len(phases)-1] != PhaseReady {
+		t.Fatalf("restore reported phases %v", phases)
+	}
+}
+
+func TestCheckpointFoldsTheWALIntoANewBase(t *testing.T) {
+	ctx := context.Background()
+	f := newFixture(t)
+
+	obj, _, _ := f.mustOpen(OpenOptions{})
+	mustExecute(t, obj, "CREATE TABLE events (id UInt64) ENGINE = MergeTree ORDER BY id")
+	mustExecute(t, obj, "INSERT INTO events VALUES (1)")
+	if _, err := obj.Flush(ctx); err != nil {
+		t.Fatal(err)
+	}
+	// A statement executed but not flushed is still in the database the
+	// checkpoint archives, so the checkpoint covers it.
+	mustExecute(t, obj, "INSERT INTO events VALUES (2)")
+
+	ref, err := obj.Checkpoint(ctx)
+	if err != nil {
+		t.Fatalf("checkpoint: %v", err)
+	}
+	head := f.head()
+	if head.Manifest.Base == nil || head.Manifest.Base.Key != ref.Key {
+		t.Fatalf("the manifest does not name the new base: %+v", head.Manifest)
+	}
+	if len(head.Manifest.WAL) != 0 {
+		t.Fatalf("the WAL list was not truncated: %+v", head.Manifest.WAL)
+	}
+	if head.Manifest.Seq != 2 {
+		t.Errorf("seq is %d, want 2", head.Manifest.Seq)
+	}
+	if obj.PendingStatements() != 0 {
+		t.Errorf("%d statements still pending; the checkpoint covered them", obj.PendingStatements())
+	}
+	if err := obj.Close(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, engine, _ := f.mustOpen(OpenOptions{})
+	defer reopened.Close(ctx)
+	if len(engine.statements()) != 3 {
+		t.Fatalf("restoring from the base produced %v", engine.statements())
+	}
+}
+
+// ------------------------------------------------------------ read-only open
+
+func TestReadOnlyOpenOfAMissingObjectIsNotFound(t *testing.T) {
+	f := newFixture(t)
+	_, _, _, err := f.open(OpenOptions{ReadOnly: true})
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("category is %q, want not_found: %v", CategoryOf(err), err)
+	}
+	// And it must not have created anything on the way.
+	if _, found, err := f.backend.GetBytes(context.Background(), HeadKey); err != nil || found {
+		t.Fatalf("a read-only open created a head: found=%v err=%v", found, err)
+	}
+}
+
+func TestExistingOnlyRefusesToCreate(t *testing.T) {
+	f := newFixture(t)
+	if _, _, _, err := f.open(OpenOptions{ExistingOnly: true}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("category is %q, want not_found", CategoryOf(err))
+	}
+}
+
+func TestReadOnlyOpenTakesNoLeaseAndRefusesWrites(t *testing.T) {
+	ctx := context.Background()
+	f := newFixture(t)
+
+	writer, _, _ := f.mustOpen(OpenOptions{})
+	mustExecute(t, writer, "INSERT INTO events VALUES (1)")
+	if _, err := writer.Flush(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	generationBefore := f.head().Lease.Generation
+	reader, engine, existed := f.mustOpen(OpenOptions{ReadOnly: true})
+	defer reader.Close(ctx)
+	if !existed {
+		t.Fatal("the object exists")
+	}
+	if got := f.head().Lease.Generation; got != generationBefore {
+		t.Fatalf("a read-only open moved the generation from %d to %d", generationBefore, got)
+	}
+	if len(engine.statements()) != 1 {
+		t.Fatalf("the reader restored %v", engine.statements())
+	}
+	if _, err := reader.Execute(ctx, "INSERT INTO events VALUES (2)"); !errors.Is(err, ErrClassificationRefused) {
+		t.Fatalf("a read-only handle accepted a write, or reported %q", CategoryOf(err))
+	}
+	if _, err := reader.Query(ctx, "SELECT count() FROM events", ""); err != nil {
+		t.Fatalf("a read-only handle should still read: %v", err)
+	}
+}
+
+// ------------------------------------------------------------------- leasing
+
+func TestASecondWriterIsRefusedWhileTheLeaseIsLive(t *testing.T) {
+	ctx := context.Background()
+	f := newFixture(t)
+
+	first, _, _ := f.mustOpen(OpenOptions{Owner: "worker-1"})
+	defer first.Close(ctx)
+
+	_, _, _, err := f.open(OpenOptions{Owner: "worker-2"})
+	if !errors.Is(err, ErrLeaseHeld) {
+		t.Fatalf("category is %q, want lease_held: %v", CategoryOf(err), err)
+	}
+	var e *Error
+	errors.As(err, &e)
+	if e.Owner != "worker-1" {
+		t.Errorf("the error names owner %q, want worker-1", e.Owner)
+	}
+}
+
+func TestAnExpiredLeaseCanBeTakenOver(t *testing.T) {
+	ctx := context.Background()
+	f := newFixture(t)
+
+	// A TTL short enough to lapse during the test, with heartbeat and skew
+	// scaled to match — the validate() rules still apply.
+	brief := Tuning{
+		LeaseTTL:           300 * time.Millisecond,
+		HeartbeatInterval:  90 * time.Millisecond,
+		ClockSkewAllowance: 50 * time.Millisecond,
+		CommitDeadline:     2 * time.Second,
+		MaxCommitAttempts:  3,
+	}
+	first, _, _ := f.mustOpen(OpenOptions{Owner: "worker-1", Tuning: brief})
+	// Stop renewing without releasing, the way a crashed writer would.
+	first.signalHeartbeatStop()
+	generation := f.head().Lease.Generation
+
+	// Past the expiry and past the skew allowance.
+	time.Sleep(brief.LeaseTTL + brief.ClockSkewAllowance + 100*time.Millisecond)
+
+	second, _, _, err := f.open(OpenOptions{Owner: "worker-2", Tuning: brief})
+	if err != nil {
+		t.Fatalf("an expired lease should be takeable: %v", err)
+	}
+	defer second.Close(ctx)
+	if got := f.head().Lease.Generation; got != generation+1 {
+		t.Fatalf("generation went from %d to %d, want one more", generation, got)
+	}
+
+	// The old writer is fenced the moment it tries to commit again.
+	if _, err := first.Execute(ctx, "INSERT INTO events VALUES (1)"); !errors.Is(err, ErrLeaseFenced) {
+		t.Fatalf("the superseded writer reported %q, want lease_fenced: %v", CategoryOf(err), err)
+	}
+}
+
+func TestForceTakesAnUnexpiredLeaseAndFencesTheHolder(t *testing.T) {
+	ctx := context.Background()
+	f := newFixture(t)
+
+	first, _, _ := f.mustOpen(OpenOptions{Owner: "worker-1"})
+	mustExecute(t, first, "INSERT INTO events VALUES (1)")
+	generation := f.head().Lease.Generation
+
+	second, _, _, err := f.open(OpenOptions{Owner: "worker-2", Force: true})
+	if err != nil {
+		t.Fatalf("force should take an unexpired lease: %v", err)
+	}
+	defer second.Close(ctx)
+	if got := f.head().Lease.Generation; got != generation+1 {
+		t.Fatalf("generation went from %d to %d", generation, got)
+	}
+
+	// The dispossessed writer learns at its next commit, and its unflushed
+	// work is what the force warning is about.
+	_, err = first.Flush(ctx)
+	if !errors.Is(err, ErrLeaseFenced) {
+		t.Fatalf("the dispossessed writer reported %q, want lease_fenced: %v", CategoryOf(err), err)
+	}
+	if !first.IsFenced() {
+		t.Fatal("a fenced writer should say so")
+	}
+	// And it stays unusable rather than recovering on the next call.
+	if _, err := first.Execute(ctx, "INSERT INTO events VALUES (2)"); !errors.Is(err, ErrLeaseFenced) {
+		t.Fatalf("a fenced handle accepted work, or reported %q", CategoryOf(err))
+	}
+}
+
+func TestCloseReleasesTheLeaseForTheNextWriter(t *testing.T) {
+	ctx := context.Background()
+	f := newFixture(t)
+
+	first, _, _ := f.mustOpen(OpenOptions{Owner: "worker-1"})
+	if err := first.Close(ctx); err != nil {
+		t.Fatal(err)
+	}
+	head := f.head()
+	if head.Lease.Owner != nil || head.Lease.Instance != nil || head.Lease.ExpiresAt != nil {
+		t.Fatalf("close left the lease as %+v, want fully released", head.Lease)
+	}
+	if head.Lease.Generation != 1 {
+		t.Fatalf("a release moved the generation to %d", head.Lease.Generation)
+	}
+
+	second, _, _, err := f.open(OpenOptions{Owner: "worker-2"})
+	if err != nil {
+		t.Fatalf("a released lease should be free: %v", err)
+	}
+	defer second.Close(ctx)
+	if got := f.head().Lease.Generation; got != 2 {
+		t.Fatalf("taking a released lease produced generation %d, want 2", got)
+	}
+}
+
+func TestOperationsAfterCloseAreRefused(t *testing.T) {
+	ctx := context.Background()
+	f := newFixture(t)
+	obj, _, _ := f.mustOpen(OpenOptions{})
+	if err := obj.Close(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := obj.Execute(ctx, "INSERT INTO events VALUES (1)"); !errors.Is(err, ErrClosed) {
+		t.Fatalf("category is %q, want closed", CategoryOf(err))
+	}
+	if _, err := obj.Query(ctx, "SELECT 1", ""); !errors.Is(err, ErrClosed) {
+		t.Fatalf("category is %q, want closed", CategoryOf(err))
+	}
+	// Idempotent, and it does not report the first close's success twice as
+	// something new.
+	if err := obj.Close(ctx); err != nil {
+		t.Fatalf("a second close reported %v", err)
+	}
+}
+
+// A failed open must not strand the lease until the TTL expires.
+func TestAFailedOpenReleasesWhatItTook(t *testing.T) {
+	ctx := context.Background()
+	f := newFixture(t)
+
+	first, _, _ := f.mustOpen(OpenOptions{})
+	mustExecute(t, first, "INSERT INTO events VALUES (1)")
+	if _, err := first.Flush(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := first.Close(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Break the replay the next open has to perform.
+	engine := newFakeEngine()
+	engine.runErr = func(string) error { return newError(CategoryEngine, "durable: engine says no") }
+	ns, err := NewNamespace("file:///unused", NamespaceOptions{
+		EngineFactory:  engine.factory(),
+		BackendFactory: func(context.Context, string) (Backend, error) { return f.backend, nil },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := ns.Open(ctx, "orders", OpenOptions{ScratchRoot: t.TempDir()}); err == nil {
+		t.Fatal("an open whose replay fails must fail")
+	}
+
+	head := f.head()
+	if head.Lease.Owner != nil {
+		t.Fatalf("the failed open left the lease held: %+v", head.Lease)
+	}
+	// So the next writer gets in without waiting out a TTL.
+	next, _, _, err := f.open(OpenOptions{})
+	if err != nil {
+		t.Fatalf("the lease was not released: %v", err)
+	}
+	next.Close(ctx)
+}
+
+// ------------------------------------------------------------- fault matrix
+
+// A published segment whose head commit fails leaves the old manifest
+// authoritative and the local buffer intact, so nothing is lost and a retry
+// publishes a fresh unique segment.
+func TestAFailedHeadCommitKeepsTheBufferAndTheOldManifest(t *testing.T) {
+	ctx := context.Background()
+	f := newFixture(t)
+	obj, _, _ := f.mustOpen(OpenOptions{})
+	defer obj.Close(ctx)
+
+	mustExecute(t, obj, "INSERT INTO events VALUES (1)")
+
+	// Refuse every head commit definitively.
+	f.backend.mu.Lock()
+	f.backend.onReplace = func(key string, _ int) (ReplaceOutcome, error, bool) {
+		if key == HeadKey {
+			return ReplaceOutcome{Status: ReplaceNotMatched}, nil, true
+		}
+		return ReplaceOutcome{}, nil, false
+	}
+	f.backend.mu.Unlock()
+
+	_, err := obj.Flush(ctx)
+	if err == nil {
+		t.Fatal("a flush whose head commit never lands must fail")
+	}
+	// Every attempt was a definite refusal, so the commit provably did not
+	// happen and a later retry is safe.
+	if !errors.Is(err, ErrTimeout) {
+		t.Fatalf("category is %q, want timeout: %v", CategoryOf(err), err)
+	}
+	if obj.PendingStatements() != 1 {
+		t.Fatalf("the buffer holds %d statements; a failed flush must keep them",
+			obj.PendingStatements())
+	}
+	if len(f.head().Manifest.WAL) != 0 || f.head().Manifest.Seq != 0 {
+		t.Fatalf("the manifest moved anyway: %+v", f.head().Manifest)
+	}
+
+	// With the fault removed, the retry lands.
+	f.backend.mu.Lock()
+	f.backend.onReplace = nil
+	f.backend.mu.Unlock()
+	ref, err := obj.Flush(ctx)
+	if err != nil {
+		t.Fatalf("the retry failed: %v", err)
+	}
+	head := f.head()
+	if len(head.Manifest.WAL) != 1 || head.Manifest.WAL[0].Key != ref.Key {
+		t.Fatalf("the retry did not commit: %+v", head.Manifest)
+	}
+}
+
+// The response to a head commit can be lost after it landed. Re-reading and
+// finding our own intent, with our own lease still on it, is what turns that
+// into a success rather than a double publish.
+func TestACommitWhoseResponseWasLostReconcilesToSuccess(t *testing.T) {
+	ctx := context.Background()
+	f := newFixture(t)
+	obj, _, _ := f.mustOpen(OpenOptions{})
+	defer obj.Close(ctx)
+
+	mustExecute(t, obj, "INSERT INTO events VALUES (1)")
+
+	// The write goes through; the answer does not come back.
+	f.backend.mu.Lock()
+	f.backend.afterReplace = func(key string, _ int, outcome ReplaceOutcome) (ReplaceOutcome, error) {
+		if key == HeadKey && outcome.Status == ReplaceDone {
+			return ReplaceOutcome{Status: ReplaceAmbiguous}, nil
+		}
+		return outcome, nil
+	}
+	f.backend.mu.Unlock()
+
+	ref, err := obj.Flush(ctx)
+	if err != nil {
+		t.Fatalf("a committed write reported as ambiguous should reconcile to success: %v", err)
+	}
+	head := f.head()
+	if len(head.Manifest.WAL) != 1 || head.Manifest.WAL[0].Key != ref.Key {
+		t.Fatalf("the manifest is %+v", head.Manifest)
+	}
+	if obj.PendingStatements() != 0 {
+		t.Fatalf("%d statements still pending after a reconciled commit", obj.PendingStatements())
+	}
+	// And the object is still usable, with a token that matches the store.
+	f.backend.mu.Lock()
+	f.backend.afterReplace = nil
+	f.backend.mu.Unlock()
+	mustExecute(t, obj, "INSERT INTO events VALUES (2)")
+	if _, err := obj.Flush(ctx); err != nil {
+		t.Fatalf("the adopted token does not work: %v", err)
+	}
+}
+
+// When ambiguity cannot be resolved, the answer is commit_ambiguous. A caller
+// told "committed" would be undefended; one told "ambiguous" can check.
+func TestAnUnresolvableCommitIsReportedAsAmbiguous(t *testing.T) {
+	ctx := context.Background()
+	f := newFixture(t)
+	obj, _, _ := f.mustOpen(OpenOptions{Tuning: Tuning{
+		CommitDeadline: 2 * time.Second, MaxCommitAttempts: 2,
+	}})
+	defer obj.Close(ctx)
+
+	mustExecute(t, obj, "INSERT INTO events VALUES (1)")
+
+	f.backend.mu.Lock()
+	f.backend.onReplace = func(key string, _ int) (ReplaceOutcome, error, bool) {
+		if key == HeadKey {
+			return ReplaceOutcome{Status: ReplaceAmbiguous}, nil, true
+		}
+		return ReplaceOutcome{}, nil, false
+	}
+	f.backend.mu.Unlock()
+
+	_, err := obj.Flush(ctx)
+	if !errors.Is(err, ErrCommitAmbiguous) {
+		t.Fatalf("category is %q, want commit_ambiguous: %v", CategoryOf(err), err)
+	}
+	var e *Error
+	errors.As(err, &e)
+	if e.Key == "" {
+		t.Error("an ambiguous commit should name the key, for triage")
+	}
+	if obj.PendingStatements() != 1 {
+		t.Fatalf("the buffer holds %d statements; nothing was proven, so nothing is dropped",
+			obj.PendingStatements())
+	}
+}
+
+// An upload whose response was lost is settled by re-reading the unique key
+// and comparing the digest — matching bytes are ours.
+func TestAnAmbiguousUploadIsSettledByItsDigest(t *testing.T) {
+	ctx := context.Background()
+	f := newFixture(t)
+	obj, _, _ := f.mustOpen(OpenOptions{})
+	defer obj.Close(ctx)
+
+	mustExecute(t, obj, "INSERT INTO events VALUES (1)")
+
+	// The bytes land; the caller is told nothing useful. Reconcile has to read
+	// the segment back and compare its digest to find out.
+	f.backend.mu.Lock()
+	f.backend.afterPutBytes = func(key string, _ int, outcome PutOutcome) (PutOutcome, error) {
+		if strings.HasPrefix(key, "wal/") && outcome == PutCreated {
+			return PutAmbiguous, nil
+		}
+		return outcome, nil
+	}
+	f.backend.mu.Unlock()
+
+	if _, err := obj.Flush(ctx); err != nil {
+		t.Fatalf("an upload that landed should reconcile to success: %v", err)
+	}
+}
+
+func TestAnUploadThatNeverLandedIsAmbiguous(t *testing.T) {
+	ctx := context.Background()
+	f := newFixture(t)
+	obj, _, _ := f.mustOpen(OpenOptions{})
+	defer obj.Close(ctx)
+
+	mustExecute(t, obj, "INSERT INTO events VALUES (1)")
+
+	f.backend.mu.Lock()
+	f.backend.onPutBytes = func(key string, _ int) (PutOutcome, error, bool) {
+		if strings.HasPrefix(key, "wal/") {
+			// Reported uncertain, and nothing was written.
+			return PutAmbiguous, nil, true
+		}
+		return 0, nil, false
+	}
+	f.backend.mu.Unlock()
+
+	_, err := obj.Flush(ctx)
+	if !errors.Is(err, ErrCommitAmbiguous) {
+		t.Fatalf("category is %q, want commit_ambiguous: %v", CategoryOf(err), err)
+	}
+}
+
+// A checkpoint whose head commit fails leaves the old base and WAL restorable,
+// and keeps the local buffer.
+func TestAFailedCheckpointCommitLeavesTheOldStateAuthoritative(t *testing.T) {
+	ctx := context.Background()
+	f := newFixture(t)
+	obj, _, _ := f.mustOpen(OpenOptions{})
+
+	mustExecute(t, obj, "INSERT INTO events VALUES (1)")
+	if _, err := obj.Flush(ctx); err != nil {
+		t.Fatal(err)
+	}
+	mustExecute(t, obj, "INSERT INTO events VALUES (2)")
+	before := f.head().Manifest
+
+	f.backend.mu.Lock()
+	f.backend.onReplace = func(key string, _ int) (ReplaceOutcome, error, bool) {
+		if key == HeadKey {
+			return ReplaceOutcome{Status: ReplaceNotMatched}, nil, true
+		}
+		return ReplaceOutcome{}, nil, false
+	}
+	f.backend.mu.Unlock()
+
+	if _, err := obj.Checkpoint(ctx); err == nil {
+		t.Fatal("a checkpoint whose commit never lands must fail")
+	}
+	after := f.head().Manifest
+	if after.Base != nil || len(after.WAL) != len(before.WAL) || after.Seq != before.Seq {
+		t.Fatalf("the manifest moved anyway: was %+v, now %+v", before, after)
+	}
+	if obj.PendingStatements() != 1 {
+		t.Fatalf("the buffer holds %d statements; the checkpoint was never committed",
+			obj.PendingStatements())
+	}
+
+	// The old base plus the old WAL still restores, which is the property that
+	// makes the failure survivable. A read-only open is the way to check it
+	// without the writer's close flushing the pending statement first.
+	f.backend.mu.Lock()
+	f.backend.onReplace = nil
+	f.backend.mu.Unlock()
+
+	reader, engine, _ := f.mustOpen(OpenOptions{ReadOnly: true})
+	if len(engine.statements()) != 1 {
+		t.Fatalf("recovery produced %v, want only the committed statement", engine.statements())
+	}
+	reader.Close(ctx)
+
+	// And the writer was never fenced by the failure, so its close still
+	// commits what it was holding.
+	if err := obj.Close(ctx); err != nil {
+		t.Fatalf("close after a failed checkpoint: %v", err)
+	}
+	if len(f.head().Manifest.WAL) != 2 {
+		t.Fatalf("close published %d segments, want the original plus the pending one",
+			len(f.head().Manifest.WAL))
+	}
+}
+
+// ------------------------------------------------------------------ corrupt
+
+func TestAMissingBaseIsCorruptNotAnEmptyObject(t *testing.T) {
+	ctx := context.Background()
+	f := newFixture(t)
+
+	obj, _, _ := f.mustOpen(OpenOptions{})
+	mustExecute(t, obj, "INSERT INTO events VALUES (1)")
+	ref, err := obj.Checkpoint(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := obj.Close(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Take the base away, the way a lifecycle rule or a bad clean-up would.
+	if err := removeFromStore(f, ref.Key); err != nil {
+		t.Fatal(err)
+	}
+	_, _, _, err = f.open(OpenOptions{})
+	if !errors.Is(err, ErrCorrupt) {
+		t.Fatalf("category is %q, want corrupt: %v", CategoryOf(err), err)
+	}
+}
+
+func TestAMissingWALSegmentIsCorrupt(t *testing.T) {
+	ctx := context.Background()
+	f := newFixture(t)
+
+	obj, _, _ := f.mustOpen(OpenOptions{})
+	mustExecute(t, obj, "INSERT INTO events VALUES (1)")
+	ref, err := obj.Flush(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := obj.Close(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := removeFromStore(f, ref.Key); err != nil {
+		t.Fatal(err)
+	}
+	_, _, _, err = f.open(OpenOptions{})
+	if !errors.Is(err, ErrCorrupt) {
+		t.Fatalf("category is %q, want corrupt: %v", CategoryOf(err), err)
+	}
+}
+
+func TestATamperedWALSegmentIsCorrupt(t *testing.T) {
+	ctx := context.Background()
+	f := newFixture(t)
+
+	obj, _, _ := f.mustOpen(OpenOptions{})
+	mustExecute(t, obj, "INSERT INTO events VALUES (1)")
+	ref, err := obj.Flush(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := obj.Close(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Same length, different bytes: only the digest catches this, which is why
+	// the manifest records one.
+	if err := overwriteInStore(f, ref.Key, []byte(`{"sql":"INSERT INTO events VALUES (9)"}`+"\n")); err != nil {
+		t.Fatal(err)
+	}
+	_, _, _, err = f.open(OpenOptions{})
+	if !errors.Is(err, ErrCorrupt) {
+		t.Fatalf("category is %q, want corrupt: %v", CategoryOf(err), err)
+	}
+}
+
+// ------------------------------------------------------ classification gates
+
+func TestExecuteAndQueryGatesFollowTheAnalysis(t *testing.T) {
+	ctx := context.Background()
+	f := newFixture(t)
+	obj, _, _ := f.mustOpen(OpenOptions{Database: "mem"})
+	defer obj.Close(ctx)
+
+	refusals := []struct {
+		name string
+		sql  string
+		want *Error
+	}{
+		{"two statements", "INSERT INTO t VALUES (1); INSERT INTO t VALUES (2)", ErrClassificationRefused},
+		{"PARALLEL WITH", "INSERT INTO t VALUES (1) PARALLEL WITH INSERT INTO t VALUES (2)", ErrClassificationRefused},
+		{"a read through Execute", "SELECT 1", ErrClassificationRefused},
+		{"session control", "SET max_threads = 1", ErrClassificationRefused},
+		{"a global mutation", "CREATE FUNCTION plus_one AS (x) -> x + 1", ErrClassificationRefused},
+		{"a write to system", "INSERT INTO system.something VALUES (1)", ErrClassificationRefused},
+		{"database lifecycle", "DROP DATABASE mem", ErrClassificationRefused},
+		{"another database", "INSERT INTO other.t VALUES (1)", ErrClassificationRefused},
+		{"a table function", "INSERT INTO FUNCTION s3('...') SELECT * FROM t", ErrClassificationRefused},
+		{"a file sink", "SELECT * FROM t INTO OUTFILE '/tmp/x'", ErrClassificationRefused},
+		{"unparseable", "not sql at all", ErrClassificationRefused},
+		{"a credential", "INSERT INTO t SELECT * FROM s3('u', 'k', 'secret_access_key')", ErrSecretRefused},
+	}
+	for _, tc := range refusals {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := obj.Execute(ctx, tc.sql)
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("Execute reported %q, want %q: %v", CategoryOf(err), tc.want.Category, err)
+			}
+			// The refusal must not echo the statement, or a secret_refused
+			// message would carry the credential it exists to keep out.
+			if strings.Contains(err.Error(), "secret_access_key") {
+				t.Fatal("the error message quoted the statement")
+			}
+			if obj.PendingStatements() != 0 {
+				t.Fatalf("a refused statement was buffered")
+			}
+		})
+	}
+
+	// Query is gated the same way, from the other side.
+	for _, sql := range []string{
+		"INSERT INTO t VALUES (1)",
+		"SELECT 1; SELECT 2",
+		"SET max_threads = 1",
+		"not sql at all",
+	} {
+		if _, err := obj.Query(ctx, sql, ""); !errors.Is(err, ErrClassificationRefused) {
+			t.Errorf("Query accepted %q, or reported %q", sql, CategoryOf(err))
+		}
+	}
+
+	// A read-only statement carrying a credential runs — it never reaches the
+	// WAL, so it is a logging concern rather than a durability one.
+	if _, err := obj.Query(ctx, "SELECT * FROM s3('u', 'k', 'secret_access_key')", ""); err != nil {
+		t.Errorf("a secret-bearing read should be allowed: %v", err)
+	}
+}
+
+// A statement the engine refuses must not be logged: replay would run
+// something that never took effect.
+func TestAFailedStatementIsNotLogged(t *testing.T) {
+	ctx := context.Background()
+	f := newFixture(t)
+
+	engine := newFakeEngine()
+	engine.runErr = func(sql string) error {
+		if strings.Contains(sql, "(2)") {
+			return newError(CategoryEngine, "durable: engine says no")
+		}
+		return nil
+	}
+	ns, err := NewNamespace("file:///unused", NamespaceOptions{
+		EngineFactory:  engine.factory(),
+		BackendFactory: func(context.Context, string) (Backend, error) { return f.backend, nil },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	obj, _, err := ns.Open(ctx, "orders", OpenOptions{Database: "mem", ScratchRoot: t.TempDir()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer obj.Close(ctx)
+
+	mustExecute(t, obj, "INSERT INTO events VALUES (1)")
+	if _, err := obj.Execute(ctx, "INSERT INTO events VALUES (2)"); err == nil {
+		t.Fatal("the engine refused this statement")
+	}
+	if obj.PendingStatements() != 1 {
+		t.Fatalf("the buffer holds %d statements, want only the one that ran",
+			obj.PendingStatements())
+	}
+}
+
+// ------------------------------------------------------------------ barriers
+
+func TestFlushThroughCoalescesOntoOneCommit(t *testing.T) {
+	ctx := context.Background()
+	f := newFixture(t)
+	obj, _, _ := f.mustOpen(OpenOptions{})
+	defer obj.Close(ctx)
+
+	first := mustExecute(t, obj, "INSERT INTO events VALUES (1)")
+	second := mustExecute(t, obj, "INSERT INTO events VALUES (2)")
+
+	if err := obj.FlushThrough(ctx, second); err != nil {
+		t.Fatalf("flush through the second ticket: %v", err)
+	}
+	// Both are covered by that one segment, so the earlier watermark is
+	// already met and costs no round-trip.
+	if err := obj.FlushThrough(ctx, first); err != nil {
+		t.Fatalf("flush through the first ticket: %v", err)
+	}
+	if got := len(f.head().Manifest.WAL); got != 1 {
+		t.Fatalf("%d segments were published, want 1", got)
+	}
+	if obj.Stats().CommittedStatements != 2 {
+		t.Fatalf("committed %d statements", obj.Stats().CommittedStatements)
+	}
+}
+
+func TestCloseFlushesWhatIsPending(t *testing.T) {
+	ctx := context.Background()
+	f := newFixture(t)
+
+	obj, _, _ := f.mustOpen(OpenOptions{})
+	mustExecute(t, obj, "INSERT INTO events VALUES (1)")
+	if err := obj.Close(ctx); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if got := len(f.head().Manifest.WAL); got != 1 {
+		t.Fatalf("close published %d segments, want 1", got)
+	}
+}
+
+// A close that cannot reach its durability barrier must say so — and still
+// give back the engine and the scratch directory.
+func TestCloseReportsAFailedFlushAndStillReleasesResources(t *testing.T) {
+	ctx := context.Background()
+	f := newFixture(t)
+
+	obj, engine, _ := f.mustOpen(OpenOptions{Tuning: Tuning{
+		CommitDeadline: time.Second, MaxCommitAttempts: 2,
+	}})
+	mustExecute(t, obj, "INSERT INTO events VALUES (1)")
+
+	f.backend.mu.Lock()
+	f.backend.onReplace = func(key string, _ int) (ReplaceOutcome, error, bool) {
+		if key == HeadKey {
+			return ReplaceOutcome{Status: ReplaceNotMatched}, nil, true
+		}
+		return ReplaceOutcome{}, nil, false
+	}
+	f.backend.mu.Unlock()
+
+	scratch := obj.ScratchPath()
+	if err := obj.Close(ctx); err == nil {
+		t.Fatal("close swallowed a failed flush")
+	}
+	if engine.isStarted() {
+		t.Error("close left the engine open")
+	}
+	if _, err := os.Stat(scratch); err == nil {
+		t.Error("close left the scratch directory behind")
+	}
+	if obj.Stats().State != "closed" {
+		t.Errorf("state is %q after close", obj.Stats().State)
+	}
+}
+
+// ------------------------------------------------------------- engine gating
+
+func TestAnEngineBelowMinReaderIsRefusedAtOpen(t *testing.T) {
+	ctx := context.Background()
+	f := newFixture(t)
+
+	obj, _, _ := f.mustOpen(OpenOptions{})
+	if err := obj.Close(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	older := newFakeEngine()
+	older.version = "26.7.0"
+	ns, err := NewNamespace("file:///unused", NamespaceOptions{
+		EngineFactory:  older.factory(),
+		BackendFactory: func(context.Context, string) (Backend, error) { return f.backend, nil },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = ns.Open(ctx, "orders", OpenOptions{ScratchRoot: t.TempDir()})
+	if !errors.Is(err, ErrEngineIncompatible) {
+		t.Fatalf("category is %q, want engine_incompatible: %v", CategoryOf(err), err)
+	}
+	// The refusal costs nothing: no lease was taken, so the object is still
+	// free for a build that can read it.
+	if f.head().Lease.Owner != nil {
+		t.Fatalf("the refused open took the lease: %+v", f.head().Lease)
+	}
+}
+
+// A later release opens an object an earlier one wrote, and records itself as
+// the producer while leaving the floor alone.
+func TestALaterEngineOpensAnEarlierObject(t *testing.T) {
+	ctx := context.Background()
+	f := newFixture(t)
+
+	obj, _, _ := f.mustOpen(OpenOptions{})
+	mustExecute(t, obj, "INSERT INTO events VALUES (1)")
+	if _, err := obj.Flush(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := obj.Close(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	newer := newFakeEngine()
+	newer.version = "26.9.1"
+	ns, err := NewNamespace("file:///unused", NamespaceOptions{
+		EngineFactory:  newer.factory(),
+		BackendFactory: func(context.Context, string) (Backend, error) { return f.backend, nil },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	reopened, _, err := ns.Open(ctx, "orders", OpenOptions{ScratchRoot: t.TempDir()})
+	if err != nil {
+		t.Fatalf("a later engine should open an earlier object: %v", err)
+	}
+	if len(newer.statements()) != 1 {
+		t.Fatalf("the later engine restored %v", newer.statements())
+	}
+	if err := reopened.Close(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	head := f.head()
+	if head.Engine.Version != "26.9.1" {
+		t.Errorf("engine.version is %q; it records who wrote last", head.Engine.Version)
+	}
+	if head.Engine.MinReader != "26.9.1" {
+		// The new base has not been written yet by this engine, but every head
+		// write raises min_reader to the writer's own version, because that
+		// writer's WAL may use anything it supports.
+		t.Errorf("min_reader is %q, want the writer's own version", head.Engine.MinReader)
+	}
+	// And an object whose floor has risen refuses the older engine.
+	if err := assertEngineCompatible(head, runningEngine{version: "26.7.2-rc.2", backupFormat: 1}); !errors.Is(err, ErrEngineIncompatible) {
+		t.Errorf("the raised floor does not refuse an older reader: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------- protocol
+
+func TestAnUnknownWriterFeatureAllowsReadingButNotWriting(t *testing.T) {
+	ctx := context.Background()
+	f := newFixture(t)
+
+	// Publish a head that declares a writer feature this build has never
+	// heard of, the way a future revision would.
+	head := coldHead("mem", "26.7.2-rc.2", BackupFormatBaseline)
+	head.Protocol.WriterFeatures = []string{"data-wal"}
+	data, err := serializeHead(head, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.backend.PutBytesIfAbsent(ctx, HeadKey, data); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, _, err := f.open(OpenOptions{}); !errors.Is(err, ErrProtocolUnsupported) {
+		t.Fatalf("taking the lease reported %q, want protocol_unsupported", CategoryOf(err))
+	}
+	reader, _, _, err := f.open(OpenOptions{ReadOnly: true})
+	if err != nil {
+		t.Fatalf("an unknown writer feature must still allow a read-only open: %v", err)
+	}
+	reader.Close(ctx)
+}
+
+func TestAFutureProtocolVersionRefusesEvenAReader(t *testing.T) {
+	ctx := context.Background()
+	f := newFixture(t)
+
+	head := coldHead("mem", "26.7.2-rc.2", BackupFormatBaseline)
+	head.Protocol.Version = ProtocolVersion + 1
+	data, err := serializeHead(head, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.backend.PutBytesIfAbsent(ctx, HeadKey, data); err != nil {
+		t.Fatal(err)
+	}
+	for _, readOnly := range []bool{false, true} {
+		if _, _, _, err := f.open(OpenOptions{ReadOnly: readOnly}); !errors.Is(err, ErrProtocolUnsupported) {
+			t.Fatalf("readOnly=%v reported %q, want protocol_unsupported", readOnly, CategoryOf(err))
+		}
+	}
+}
+
+// Unknown fields must survive a whole session: open, execute, flush,
+// checkpoint, close.
+func TestUnknownFieldsSurviveASession(t *testing.T) {
+	ctx := context.Background()
+	f := newFixture(t)
+
+	head := coldHead("mem", "26.7.2-rc.2", BackupFormatBaseline)
+	base, err := serializeHead(head, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(base, &raw); err != nil {
+		t.Fatal(err)
+	}
+	raw["future_top_level"] = "keep me"
+	raw["manifest"].(map[string]any)["future_manifest"] = []any{1.0, 2.0}
+	withUnknowns, err := json.Marshal(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.backend.PutBytesIfAbsent(ctx, HeadKey, withUnknowns); err != nil {
+		t.Fatal(err)
+	}
+
+	obj, _, _ := f.mustOpen(OpenOptions{})
+	mustExecute(t, obj, "INSERT INTO events VALUES (1)")
+	if _, err := obj.Flush(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := obj.Checkpoint(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := obj.Close(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	final, _, err := f.backend.GetBytes(ctx, HeadKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(final, &out); err != nil {
+		t.Fatal(err)
+	}
+	if out["future_top_level"] != "keep me" {
+		t.Errorf("a top-level unknown field was lost: %v", out)
+	}
+	if _, ok := out["manifest"].(map[string]any)["future_manifest"]; !ok {
+		t.Errorf("an unknown manifest field was lost: %v", out["manifest"])
+	}
+}
+
+// ------------------------------------------------------------------ tuning
+
+func TestTuningIsValidated(t *testing.T) {
+	f := newFixture(t)
+	cases := []Tuning{
+		{LeaseTTL: -time.Second},
+		{HeartbeatInterval: -time.Second},
+		// Heartbeat has to leave room for a retry before expiry.
+		{LeaseTTL: 10 * time.Second, HeartbeatInterval: 9 * time.Second},
+		{MaxCommitAttempts: -1},
+	}
+	for _, tuning := range cases {
+		if _, _, _, err := f.open(OpenOptions{Tuning: tuning}); err == nil {
+			t.Errorf("tuning %+v should have been refused", tuning)
+		}
+	}
+}
+
+func TestStatsDescribeOneConsistentMoment(t *testing.T) {
+	ctx := context.Background()
+	f := newFixture(t)
+	obj, _, _ := f.mustOpen(OpenOptions{Database: "mem", Owner: "worker-1"})
+	defer obj.Close(ctx)
+
+	mustExecute(t, obj, "INSERT INTO events VALUES (1)")
+	if _, err := obj.Flush(ctx); err != nil {
+		t.Fatal(err)
+	}
+	mustExecute(t, obj, "INSERT INTO events VALUES (2)")
+
+	stats := obj.Stats()
+	if stats.ObjectID != "orders" || stats.Database != "mem" || stats.Owner != "worker-1" {
+		t.Errorf("stats identify the object as %+v", stats)
+	}
+	if stats.State != "open" || stats.Fenced {
+		t.Errorf("state is %q fenced=%v", stats.State, stats.Fenced)
+	}
+	if stats.ExecutedStatements != 2 || stats.CommittedStatements != 1 || stats.PendingStatements != 1 {
+		t.Errorf("counters are executed=%d committed=%d pending=%d",
+			stats.ExecutedStatements, stats.CommittedStatements, stats.PendingStatements)
+	}
+	if stats.PendingBytes <= 0 {
+		t.Errorf("pending bytes is %d", stats.PendingBytes)
+	}
+	if stats.CommittedSeq != 1 || stats.WALSegments != 1 {
+		t.Errorf("seq=%d segments=%d", stats.CommittedSeq, stats.WALSegments)
+	}
+	if stats.LeaseExpiresAt.IsZero() {
+		t.Error("a writer should report when it stops believing its lease")
+	}
+}
+
+func TestNamespaceRefusesAnUnknownScheme(t *testing.T) {
+	if _, err := NewNamespace("gs://bucket/prefix", NamespaceOptions{}); err == nil {
+		t.Fatal("an unregistered scheme should be refused at construction")
+	}
+	// And a registered one is accepted without touching the network.
+	if _, err := NewNamespace("s3://bucket/prefix?region=us-east-1", NamespaceOptions{
+		BackendFactory: func(context.Context, string) (Backend, error) { return nil, nil },
+	}); err != nil {
+		t.Fatalf("s3 should be registered: %v", err)
+	}
+}
+
+func TestNamespaceRefusesAHierarchicalObjectID(t *testing.T) {
+	f := newFixture(t)
+	ns, err := NewNamespace("file:///unused", NamespaceOptions{
+		EngineFactory:  newFakeEngine().factory(),
+		BackendFactory: func(context.Context, string) (Backend, error) { return f.backend, nil },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := ns.Open(context.Background(), "tenant/user", OpenOptions{}); err == nil {
+		t.Fatal("a hierarchical object id should be refused")
+	}
+}

--- a/chdb/durable/sigv4.go
+++ b/chdb/durable/sigv4.go
@@ -1,0 +1,277 @@
+package durable
+
+import (
+	"bufio"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// AWS Signature Version 4, for the six requests the S3 backend makes.
+//
+// Signing is here rather than delegated to the AWS SDK on purpose. The durable
+// control plane needs exactly two S3 operations — GetObject and PutObject,
+// the latter with a precondition — and the SDK that provides them brings a
+// dozen modules into the go.mod of everyone who imports this package, whether
+// or not they ever touch S3. The roadmap asks the cloud backends not to do
+// that to the core module, and in Go a dependency in a subpackage is a
+// dependency of the module.
+//
+// So the surface is small, and staying small is the point: no multipart, no
+// listing, no chunked signing, no presigning. What is here is the SigV4
+// header-signing form for a request whose payload hash is already known —
+// which it always is, because the protocol computes the SHA-256 of everything
+// it publishes before publishing it (contract §4.5). The digest a manifest
+// records is the digest that signs the upload; there is no second pass over a
+// checkpoint archive to produce it.
+
+// There is deliberately no UNSIGNED-PAYLOAD constant here. Every request this
+// package signs knows its payload hash, and leaving the escape hatch out means
+// a future operation cannot reach for it without first thinking about whether
+// the provider accepts it over plain HTTP.
+const (
+	sigV4Algorithm = "AWS4-HMAC-SHA256"
+	s3Service      = "s3"
+)
+
+// credentials are what SigV4 needs to sign. SessionToken is set only for
+// temporary credentials.
+type credentials struct {
+	AccessKeyID     string
+	SecretAccessKey string
+	SessionToken    string
+}
+
+func (c credentials) valid() bool {
+	return c.AccessKeyID != "" && c.SecretAccessKey != ""
+}
+
+// resolveCredentials finds credentials the way the AWS tools do, in the order
+// they do, stopping at the first complete pair.
+//
+// Three sources, and the list stops where a hand-written signer stops being
+// the right tool:
+//
+//  1. Given explicitly to the backend.
+//  2. The standard environment variables.
+//  3. The shared credentials file, honouring AWS_PROFILE.
+//
+// Not here: SSO, assumed roles, the EC2 and ECS metadata services, and
+// anything else that needs a token refresh loop. Those are the AWS SDK's job,
+// and a caller who needs them supplies its own Backend or its own credentials
+// — which is why explicit credentials come first in the list rather than last.
+func resolveCredentials(explicit credentials) (credentials, error) {
+	if explicit.valid() {
+		return explicit, nil
+	}
+	env := credentials{
+		AccessKeyID:     os.Getenv("AWS_ACCESS_KEY_ID"),
+		SecretAccessKey: os.Getenv("AWS_SECRET_ACCESS_KEY"),
+		SessionToken:    os.Getenv("AWS_SESSION_TOKEN"),
+	}
+	if env.valid() {
+		return env, nil
+	}
+	if fromFile, ok := credentialsFromSharedFile(); ok {
+		return fromFile, nil
+	}
+	return credentials{}, newError(CategoryBackend,
+		"durable: no S3 credentials found; set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, "+
+			"configure a shared credentials file, or pass credentials to the backend. "+
+			"SSO and instance-role credentials are not resolved here — supply them as environment "+
+			"variables or use a Backend built on the AWS SDK")
+}
+
+// credentialsFromSharedFile reads the requested profile out of the shared
+// credentials file. It is deliberately a small parser: the INI dialect that
+// file uses has corners (nested properties, quoted values) that only matter
+// for settings this signer does not read.
+func credentialsFromSharedFile() (credentials, bool) {
+	path := os.Getenv("AWS_SHARED_CREDENTIALS_FILE")
+	if path == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return credentials{}, false
+		}
+		path = filepath.Join(home, ".aws", "credentials")
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return credentials{}, false
+	}
+	defer f.Close()
+
+	wanted := os.Getenv("AWS_PROFILE")
+	if wanted == "" {
+		wanted = "default"
+	}
+	var (
+		inProfile bool
+		found     credentials
+	)
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			name := strings.TrimSpace(line[1 : len(line)-1])
+			// A file written by the SSO tooling prefixes profile names.
+			name = strings.TrimPrefix(name, "profile ")
+			inProfile = name == wanted
+			continue
+		}
+		if !inProfile {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		key = strings.ToLower(strings.TrimSpace(key))
+		value = strings.TrimSpace(value)
+		switch key {
+		case "aws_access_key_id":
+			found.AccessKeyID = value
+		case "aws_secret_access_key":
+			found.SecretAccessKey = value
+		case "aws_session_token":
+			found.SessionToken = value
+		}
+	}
+	return found, found.valid()
+}
+
+func hmacSHA256(key, data []byte) []byte {
+	mac := hmac.New(sha256.New, key)
+	mac.Write(data)
+	return mac.Sum(nil)
+}
+
+func sha256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+// signingKey derives the date/region/service-scoped key.
+//
+// service is a parameter even though this package only ever signs for S3, so
+// the derivation can be checked against AWS's own published example — which
+// uses a different service. Getting one link of this HMAC chain wrong produces
+// a signature that is simply rejected, with nothing to say which link it was.
+func signingKey(secret, datestamp, region, service string) []byte {
+	k := hmacSHA256([]byte("AWS4"+secret), []byte(datestamp))
+	k = hmacSHA256(k, []byte(region))
+	k = hmacSHA256(k, []byte(service))
+	return hmacSHA256(k, []byte("aws4_request"))
+}
+
+// uriEncodePath percent-encodes a path the way S3 canonicalisation wants:
+// every byte outside the unreserved set is escaped, and "/" is left alone as a
+// separator.
+//
+// net/url's escaping is not usable here. EscapedPath preserves whatever the
+// caller wrote, and QueryEscape turns a space into "+", which produces a
+// signature that does not match the request S3 received.
+func uriEncodePath(path string) string {
+	const unreserved = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~/"
+	var b strings.Builder
+	for i := 0; i < len(path); i++ {
+		c := path[i]
+		if strings.IndexByte(unreserved, c) >= 0 {
+			b.WriteByte(c)
+			continue
+		}
+		b.WriteByte('%')
+		const hexDigits = "0123456789ABCDEF"
+		b.WriteByte(hexDigits[c>>4])
+		b.WriteByte(hexDigits[c&0xf])
+	}
+	return b.String()
+}
+
+// signRequest adds the SigV4 headers to req in place.
+//
+// payloadHash is the lowercase hex SHA-256 of the body — known before the call
+// in every case this package has, which is what keeps the signer to its
+// header-signing form. now is passed in so a test can sign at a fixed instant.
+func signRequest(req *http.Request, creds credentials, region string, payloadHash string, now time.Time) {
+	utc := now.UTC()
+	amzDate := utc.Format("20060102T150405Z")
+	datestamp := utc.Format("20060102")
+
+	req.Header.Set("X-Amz-Date", amzDate)
+	req.Header.Set("X-Amz-Content-Sha256", payloadHash)
+	if creds.SessionToken != "" {
+		req.Header.Set("X-Amz-Security-Token", creds.SessionToken)
+	}
+	if req.Host == "" {
+		req.Host = req.URL.Host
+	}
+
+	// Sign host and every header this package sets itself. Signing the
+	// preconditions is not required by S3, but they are the headers that
+	// decide whether the request mutates anything, so leaving them out of the
+	// signature would let something between here and the bucket turn a
+	// conditional create into an overwrite.
+	signed := map[string]string{"host": req.Host}
+	for name := range req.Header {
+		lower := strings.ToLower(name)
+		switch {
+		case strings.HasPrefix(lower, "x-amz-"),
+			lower == "if-match", lower == "if-none-match", lower == "content-type":
+			signed[lower] = strings.TrimSpace(req.Header.Get(name))
+		}
+	}
+	names := make([]string, 0, len(signed))
+	for name := range signed {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var canonicalHeaders strings.Builder
+	for _, name := range names {
+		canonicalHeaders.WriteString(name)
+		canonicalHeaders.WriteByte(':')
+		canonicalHeaders.WriteString(signed[name])
+		canonicalHeaders.WriteByte('\n')
+	}
+	signedHeaders := strings.Join(names, ";")
+
+	// The protocol's keys carry no query parameters, so the canonical query
+	// string is whatever the URL holds, in the encoding net/url produced.
+	canonicalQuery := req.URL.Query().Encode()
+
+	canonicalRequest := strings.Join([]string{
+		req.Method,
+		uriEncodePath(req.URL.Path),
+		canonicalQuery,
+		canonicalHeaders.String(),
+		signedHeaders,
+		payloadHash,
+	}, "\n")
+
+	scope := strings.Join([]string{datestamp, region, s3Service, "aws4_request"}, "/")
+	stringToSign := strings.Join([]string{
+		sigV4Algorithm,
+		amzDate,
+		scope,
+		sha256Hex([]byte(canonicalRequest)),
+	}, "\n")
+
+	signature := hex.EncodeToString(hmacSHA256(
+		signingKey(creds.SecretAccessKey, datestamp, region, s3Service),
+		[]byte(stringToSign)))
+
+	req.Header.Set("Authorization", sigV4Algorithm+
+		" Credential="+creds.AccessKeyID+"/"+scope+
+		", SignedHeaders="+signedHeaders+
+		", Signature="+signature)
+}

--- a/chdb/durable/types.go
+++ b/chdb/durable/types.go
@@ -1,0 +1,192 @@
+package durable
+
+// The frozen wire types of Durable V1 (contract §4).
+//
+// Everything here is FROZEN: another binding has to be able to read what this
+// one writes. The JSON is compared semantically, not byte for byte — key order
+// and whitespace are free — but field names, types and meanings are not.
+
+// ProtocolVersion is the baseline this build implements. A higher version in a
+// head means "do not open".
+const ProtocolVersion = 1
+
+// V1 defines no non-empty feature names. Anything appearing in a head's
+// feature lists is therefore from a future revision, and the negotiation rules
+// apply: an unknown reader feature refuses the open outright, an unknown
+// writer feature still permits a read-only open.
+var (
+	KnownReaderFeatures = []string{}
+	KnownWriterFeatures = []string{}
+)
+
+// EngineName is what a chDB writer records in head.engine.name.
+const EngineName = "chdb"
+
+// BackupFormatBaseline is the archive-format generation this build
+// understands. V1's baseline is 1.
+//
+// It exists to be the one explicit signal that the backward-compatibility
+// promise has been withdrawn: core increments it when a later release can no
+// longer restore earlier full backups, and a reader refuses anything above its
+// own baseline. Without it a reader compares version numbers, sees a larger
+// one, concludes it is fine, and walks into a RESTORE that fails halfway
+// through recovery.
+//
+// The running engine's own value is not available yet — the C ABI exposes no
+// accessor — so every engine reports this baseline until one does.
+const BackupFormatBaseline = 1
+
+// Frozen V1 limits (contract §4.4, §4.5).
+const (
+	// MaxSQLBytes is the ceiling on one statement, in UTF-8 bytes.
+	MaxSQLBytes = 64 * 1024 * 1024
+	// MaxWALSegmentBytes is the ceiling on one uncompressed WAL segment.
+	MaxWALSegmentBytes = 128 * 1024 * 1024
+	// MaxHeadBytes is the ceiling on head.json.
+	MaxHeadBytes = 1024 * 1024
+)
+
+// Protocol is the version and feature negotiation block.
+type Protocol struct {
+	Version        int      `json:"version"`
+	ReaderFeatures []string `json:"reader_features"`
+	WriterFeatures []string `json:"writer_features"`
+}
+
+// EngineIdentity records which engine produced the object and what a reader
+// needs in order to restore it.
+type EngineIdentity struct {
+	Name string `json:"name"`
+
+	// Version is chdb_version() of the writer that last touched the object.
+	// Recorded for diagnosis and audit; explicitly *not* the compatibility
+	// gate. See negotiate.go.
+	Version string `json:"version"`
+
+	// BackupFormat is the archive-format generation. A reader refuses anything
+	// above its own baseline.
+	BackupFormat int `json:"backup_format"`
+
+	// MinReader is the oldest chDB release that may read the current state. A
+	// reader below it is refused; anything at or above it opens.
+	MinReader string `json:"min_reader"`
+}
+
+// ObjectRef points at one immutable object. The size and digest are not
+// decoration: base and WAL are verified against both before anything is
+// restored or replayed, and they are what makes an ambiguous upload
+// resolvable (contract §5.8).
+type ObjectRef struct {
+	// Key is relative to <namespace>/<object-id>/, "/"-separated, with no
+	// leading slash.
+	Key string `json:"key"`
+
+	Size int64 `json:"size"`
+
+	// SHA256 is the lowercase full hex digest.
+	SHA256 string `json:"sha256"`
+}
+
+// Lease is the writer lease. A released lease is the all-null form: owner,
+// instance and expiry absent while the generation stays, so the next acquirer
+// knows what to increment past.
+type Lease struct {
+	Generation int64 `json:"generation"`
+
+	// Owner is a human-visible name. Observability only; never an authority
+	// check.
+	Owner *string `json:"owner"`
+
+	// Instance identifies one live instance. This, with the generation, is the
+	// fence.
+	Instance *string `json:"instance"`
+
+	// ExpiresAt is epoch seconds, fractional allowed.
+	ExpiresAt *float64 `json:"expires_at"`
+}
+
+// held reports whether a lease names a live owner.
+func (l Lease) held() bool { return l.Owner != nil }
+
+// instanceIs reports whether this lease belongs to the given instance.
+func (l Lease) instanceIs(instance string) bool {
+	return l.Instance != nil && *l.Instance == instance
+}
+
+// Manifest is the object's committed state: one database, one base, and the
+// WAL segments to replay over it.
+type Manifest struct {
+	// DB is the one database this object holds.
+	DB string `json:"db"`
+
+	Base *ObjectRef `json:"base"`
+
+	// WAL is ordered by replay order.
+	WAL []ObjectRef `json:"wal"`
+
+	Seq int64 `json:"seq"`
+}
+
+// Head is the typed view of head.json.
+//
+// Unknown fields are not represented here — they travel separately in
+// headSnapshot.raw, because dropping them would silently strip a future
+// revision's state (contract §4.2, §4.3).
+type Head struct {
+	Protocol Protocol       `json:"protocol"`
+	Engine   EngineIdentity `json:"engine"`
+	Lease    Lease          `json:"lease"`
+	Manifest Manifest       `json:"manifest"`
+}
+
+// clone returns a deep copy, so a caller that mutates one field of a candidate
+// head cannot reach into the committed one through a shared slice.
+func (h Head) clone() Head {
+	out := h
+	out.Protocol.ReaderFeatures = append([]string(nil), h.Protocol.ReaderFeatures...)
+	out.Protocol.WriterFeatures = append([]string(nil), h.Protocol.WriterFeatures...)
+	if h.Manifest.Base != nil {
+		base := *h.Manifest.Base
+		out.Manifest.Base = &base
+	}
+	out.Manifest.WAL = append([]ObjectRef(nil), h.Manifest.WAL...)
+	return out
+}
+
+// headSnapshot is a head as read from the backend: the typed view, its CAS
+// token, and the raw JSON kept so unknown fields survive a write-back.
+type headSnapshot struct {
+	head Head
+	etag string
+	raw  map[string]any
+}
+
+// coldHead is the head a brand-new object starts from: no base, no WAL,
+// generation 1.
+//
+// The lease is left released here and filled in by the creating writer, since
+// cold create and lease acquisition are one conditional write (contract §5.2)
+// — publishing an unheld head first would leave a window in which a second
+// process could take a lease on a manifest nobody has restored into yet.
+func coldHead(db, engineVersion string, backupFormat int) Head {
+	return Head{
+		Protocol: Protocol{
+			Version:        ProtocolVersion,
+			ReaderFeatures: []string{},
+			WriterFeatures: []string{},
+		},
+		Engine: EngineIdentity{
+			Name:         EngineName,
+			Version:      engineVersion,
+			BackupFormat: backupFormat,
+			// A fresh object can only be read by this engine or later: its
+			// base will be produced by this engine.
+			MinReader: engineVersion,
+		},
+		Lease:    Lease{Generation: 1},
+		Manifest: Manifest{DB: db, Base: nil, WAL: []ObjectRef{}, Seq: 0},
+	}
+}
+
+func stringPtr(s string) *string  { return &s }
+func floatPtr(f float64) *float64 { return &f }

--- a/chdb/durable/version.go
+++ b/chdb/durable/version.go
@@ -1,0 +1,190 @@
+package durable
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// chDB release precedence.
+//
+// The V1 engine gate compares versions, and it compares them by release
+// precedence rather than as strings. The difference is not academic: as
+// strings, "26.10.0" < "26.7.0" and "26.7.2-rc.2" > "26.7.2", both of which
+// are backwards, and both of which would let a reader open an object it cannot
+// actually restore.
+//
+// The ordering is semver's:
+//
+//	26.7.2-rc.1  <  26.7.2-rc.2  <  26.7.2  <  26.7.3  <  26.8.1  <  27.0.0
+//
+// A pre-release sorts *below* the release it leads to, which is what makes an
+// object written by 26.7.2-rc.2 — the release that first exported the durable
+// ABI, and what chdb_version() reports there — readable by 26.7.2 and
+// everything after it.
+//
+// The parser is semver-shaped rather than a match on the two shapes chDB
+// happens to ship today. A future 26.7.2-beta.1 sorts correctly here, where a
+// tighter pattern would refuse an object it could have opened safely — the
+// wrong place to fail closed. Failing closed belongs where nothing can be
+// concluded: a string that does not parse at all is refused rather than
+// guessed at, because an unrecognised version is not evidence of
+// compatibility, and treating it as one is how a reader restores an archive
+// from a release nothing has tested it against.
+
+// parsedVersion is a version string decomposed for comparison.
+type parsedVersion struct {
+	// release holds the numeric components, e.g. [26, 7, 2]. At least one.
+	release []int64
+	// prerelease holds the dot-separated identifiers, e.g. ["rc", "2"], with
+	// numeric ones flagged. Nil for a final release, which sorts above every
+	// pre-release of the same numbers.
+	prerelease []preIdent
+}
+
+type preIdent struct {
+	text    string
+	number  int64
+	numeric bool
+}
+
+// Numeric release, optional -prerelease, optional +build. Build metadata is
+// parsed and ignored, as semver requires: it takes no part in precedence.
+var versionPattern = regexp.MustCompile(`^(\d+(?:\.\d+)*)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$`)
+
+// parseVersion decomposes a chDB version string, reporting whether it is one.
+func parseVersion(value string) (parsedVersion, bool) {
+	m := versionPattern.FindStringSubmatch(strings.TrimSpace(value))
+	if m == nil {
+		return parsedVersion{}, false
+	}
+	var release []int64
+	for _, part := range strings.Split(m[1], ".") {
+		n, err := strconv.ParseInt(part, 10, 64)
+		if err != nil {
+			return parsedVersion{}, false
+		}
+		release = append(release, n)
+	}
+	var prerelease []preIdent
+	if m[2] != "" {
+		for _, id := range strings.Split(m[2], ".") {
+			if n, err := strconv.ParseInt(id, 10, 64); err == nil && !strings.HasPrefix(id, "-") {
+				prerelease = append(prerelease, preIdent{text: id, number: n, numeric: true})
+			} else {
+				prerelease = append(prerelease, preIdent{text: id})
+			}
+		}
+	}
+	return parsedVersion{release: release, prerelease: prerelease}, true
+}
+
+func comparePrerelease(a, b []preIdent) int {
+	n := len(a)
+	if len(b) > n {
+		n = len(b)
+	}
+	for i := 0; i < n; i++ {
+		// A shorter identifier list sorts lower when all shared parts are
+		// equal: rc.1 comes before rc.1.1.
+		if i >= len(a) {
+			return -1
+		}
+		if i >= len(b) {
+			return 1
+		}
+		x, y := a[i], b[i]
+		if x.numeric && y.numeric {
+			if x.number != y.number {
+				if x.number < y.number {
+					return -1
+				}
+				return 1
+			}
+			continue
+		}
+		// Numeric identifiers always sort below alphanumeric ones.
+		if x.numeric != y.numeric {
+			if x.numeric {
+				return -1
+			}
+			return 1
+		}
+		if x.text != y.text {
+			if x.text < y.text {
+				return -1
+			}
+			return 1
+		}
+	}
+	return 0
+}
+
+// comparePrecedence returns a negative number if a precedes b, zero if they
+// are the same release, and a positive number otherwise.
+func comparePrecedence(a, b parsedVersion) int {
+	n := len(a.release)
+	if len(b.release) > n {
+		n = len(b.release)
+	}
+	for i := 0; i < n; i++ {
+		// A missing component is zero, so 26.7 and 26.7.0 are the same
+		// release.
+		var x, y int64
+		if i < len(a.release) {
+			x = a.release[i]
+		}
+		if i < len(b.release) {
+			y = b.release[i]
+		}
+		if x != y {
+			if x < y {
+				return -1
+			}
+			return 1
+		}
+	}
+	if a.prerelease == nil && b.prerelease == nil {
+		return 0
+	}
+	// No pre-release outranks any pre-release of the same numbers.
+	if a.prerelease == nil {
+		return 1
+	}
+	if b.prerelease == nil {
+		return -1
+	}
+	return comparePrerelease(a.prerelease, b.prerelease)
+}
+
+// CompareEngineVersions orders two chDB version strings by release
+// precedence, refusing either one it cannot parse rather than guessing.
+//
+// The returned int is negative when a precedes b, zero when they are the same
+// release, and positive otherwise.
+func CompareEngineVersions(a, b string) (int, error) {
+	pa, okA := parseVersion(a)
+	pb, okB := parseVersion(b)
+	if !okA || !okB {
+		bad := a
+		if okA {
+			bad = b
+		}
+		return 0, newError(CategoryEngineIncompatible,
+			"durable: cannot order chdb version %q by release precedence, so compatibility "+
+				"cannot be established; refusing rather than guessing", bad)
+	}
+	return comparePrecedence(pa, pb), nil
+}
+
+// maxEngineVersion returns the later of two version strings by precedence.
+func maxEngineVersion(a, b string) (string, error) {
+	cmp, err := CompareEngineVersions(a, b)
+	if err != nil {
+		return "", err
+	}
+	if cmp >= 0 {
+		return a, nil
+	}
+	return b, nil
+}

--- a/chdb/durable/version_test.go
+++ b/chdb/durable/version_test.go
@@ -1,0 +1,117 @@
+package durable
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestEngineVersionPrecedence(t *testing.T) {
+	// The ordering that matters, in order. Each entry must precede the next.
+	ascending := []string{
+		"26.5.0",
+		"26.7.0",
+		"26.7.1-rc.1",
+		"26.7.2-rc.1",
+		"26.7.2-rc.2",
+		"26.7.2-rc.2.1",
+		"26.7.2",
+		"26.7.3",
+		"26.10.0",
+		"27.0.0",
+	}
+	for i := 0; i < len(ascending)-1; i++ {
+		lower, higher := ascending[i], ascending[i+1]
+		cmp, err := CompareEngineVersions(lower, higher)
+		if err != nil {
+			t.Fatalf("comparing %s and %s: %v", lower, higher, err)
+		}
+		if cmp >= 0 {
+			t.Errorf("%s should precede %s, got %d", lower, higher, cmp)
+		}
+		reverse, err := CompareEngineVersions(higher, lower)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if reverse <= 0 {
+			t.Errorf("%s should follow %s, got %d", higher, lower, reverse)
+		}
+	}
+}
+
+// A missing component is zero, so a two-part version and its three-part
+// spelling are the same release. Ordering them apart would refuse an object
+// over a difference in how its producer spelled its own version.
+func TestEngineVersionTreatsMissingComponentsAsZero(t *testing.T) {
+	cmp, err := CompareEngineVersions("26.7", "26.7.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cmp != 0 {
+		t.Fatalf("26.7 and 26.7.0 are the same release, got %d", cmp)
+	}
+}
+
+// Build metadata takes no part in precedence, per semver.
+func TestEngineVersionIgnoresBuildMetadata(t *testing.T) {
+	cmp, err := CompareEngineVersions("26.7.2+build.7", "26.7.2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cmp != 0 {
+		t.Fatalf("build metadata must not order versions, got %d", cmp)
+	}
+}
+
+// Lexicographic comparison gets both of these backwards, which is the reason
+// this file exists rather than a strings.Compare.
+func TestEngineVersionIsNotLexicographic(t *testing.T) {
+	for _, tc := range []struct{ lower, higher string }{
+		{"26.7.0", "26.10.0"},
+		{"26.7.2-rc.2", "26.7.2"},
+	} {
+		if tc.lower < tc.higher {
+			t.Fatalf("test case %s < %s is not the lexicographic trap it is meant to be",
+				tc.lower, tc.higher)
+		}
+		cmp, err := CompareEngineVersions(tc.lower, tc.higher)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cmp >= 0 {
+			t.Errorf("%s should precede %s by release precedence", tc.lower, tc.higher)
+		}
+	}
+}
+
+// An unrecognised version is not evidence of compatibility, and treating it as
+// one is how a reader restores an archive from a release nothing has tested it
+// against.
+func TestEngineVersionRefusesWhatItCannotOrder(t *testing.T) {
+	for _, bad := range []string{"", "latest", "v26.7.2", "26.7.2-", "26..7"} {
+		if _, err := CompareEngineVersions(bad, "26.7.2"); err == nil {
+			t.Errorf("comparing %q should have been refused", bad)
+		} else if !errors.Is(err, ErrEngineIncompatible) {
+			t.Errorf("comparing %q gave category %q, want engine_incompatible",
+				bad, CategoryOf(err))
+		}
+	}
+}
+
+func TestMaxEngineVersionTakesTheLater(t *testing.T) {
+	got, err := maxEngineVersion("26.7.2-rc.2", "26.7.3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "26.7.3" {
+		t.Fatalf("max is %s, want 26.7.3", got)
+	}
+	// Equal releases return the first argument, which is the stored value —
+	// so an equal comparison never rewrites what is already in the head.
+	got, err = maxEngineVersion("26.7.2", "26.7.2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "26.7.2" {
+		t.Fatalf("max of equals is %s, want 26.7.2", got)
+	}
+}

--- a/chdb/durable/wal.go
+++ b/chdb/durable/wal.go
@@ -1,0 +1,160 @@
+package durable
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// WAL segment encoding and decoding (contract §4.4).
+//
+// The format is deliberately dull: UTF-8 JSONL, one {"sql": "..."} object per
+// line, newline-terminated, replayed in manifest order then line order. Being
+// dull is what lets four language bindings agree on it.
+//
+// Two limits are enforced on the write side and tolerated on the read side, as
+// the contract requires: a reader must be able to load anything a conforming
+// writer could have produced, so it refuses only what is over the *frozen*
+// ceiling, never a lower local preference.
+//
+// What this file does not do is make statements deterministic. now(), rand()
+// and reads of mutable external sources are replayed verbatim and will produce
+// whatever they produce; V1 promises ordered replay of the original statement
+// text and nothing more. Materialising those values before calling Execute is
+// the caller's job.
+
+// encodeWALLine renders one statement exactly as a segment holds it, without
+// the terminating newline.
+//
+// HTML escaping is turned off so that SQL containing <, > or & is stored as
+// written. The escaped form parses identically, but a WAL line is the most
+// likely thing an operator ever reads by hand, and < in place of < makes
+// that harder for no benefit.
+func encodeWALLine(sql string) ([]byte, error) {
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(map[string]string{"sql": sql}); err != nil {
+		return nil, wrapError(CategoryCorrupt, err, "durable: a statement cannot be encoded as JSON")
+	}
+	return bytes.TrimRight(buf.Bytes(), "\n"), nil
+}
+
+// walLineBytes is how many bytes a statement will occupy in a segment,
+// counting its newline.
+//
+// It must stay exactly consistent with encodeWALSegment: it is what the object
+// layer budgets against before executing, and a budget that disagrees with the
+// encoder by even one byte per line puts the boundary in the wrong place.
+// encodeWALSegment writes each line followed by a newline, so the per-
+// statement cost is additive and this can be summed. A test asserts the two
+// agree.
+func walLineBytes(sql string) (int64, error) {
+	line, err := encodeWALLine(sql)
+	if err != nil {
+		return 0, err
+	}
+	return int64(len(line)) + 1, nil
+}
+
+// assertStatementWithinLimit refuses a statement that could not be written
+// into a conforming segment.
+func assertStatementWithinLimit(sql string) error {
+	if int64(len(sql)) > MaxSQLBytes {
+		return &Error{
+			Category: CategoryLimitExceeded,
+			Message: fmt.Sprintf("durable: statement is %d UTF-8 bytes, over the V1 per-statement "+
+				"limit of %d", len(sql), MaxSQLBytes),
+			Limit:    MaxSQLBytes,
+			Observed: int64(len(sql)),
+		}
+	}
+	return nil
+}
+
+// encodeWALSegment encodes buffered statements into one segment.
+//
+// It refuses an oversized segment rather than splitting: a segment boundary is
+// a commit boundary, so splitting silently would turn one caller-visible flush
+// into two, and a crash between them would commit a prefix the caller was
+// never told about.
+func encodeWALSegment(statements []string) ([]byte, error) {
+	var buf bytes.Buffer
+	for _, sql := range statements {
+		if err := assertStatementWithinLimit(sql); err != nil {
+			return nil, err
+		}
+		line, err := encodeWALLine(sql)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(line)
+		buf.WriteByte('\n')
+	}
+	if int64(buf.Len()) > MaxWALSegmentBytes {
+		return nil, &Error{
+			Category: CategoryLimitExceeded,
+			Message: fmt.Sprintf("durable: WAL segment would be %d bytes, over the V1 limit of %d; "+
+				"flush more often", buf.Len(), MaxWALSegmentBytes),
+			Limit:    MaxWALSegmentBytes,
+			Observed: int64(buf.Len()),
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+// decodeWALSegment decodes a verified segment into its statements.
+//
+// It is strict on every count the contract names: exactly one JSON object per
+// line, a string sql, and a terminating newline. A tolerant reader here would
+// be the worst kind of bug — it would skip a statement and hand back a
+// database that looks fine and is missing a write.
+func decodeWALSegment(data []byte, key string) ([]string, error) {
+	if int64(len(data)) > MaxWALSegmentBytes {
+		return nil, &Error{
+			Category: CategoryLimitExceeded,
+			Message: fmt.Sprintf("durable: WAL segment %s is %d bytes, over the V1 limit of %d",
+				key, len(data), MaxWALSegmentBytes),
+			Limit:    MaxWALSegmentBytes,
+			Observed: int64(len(data)),
+		}
+	}
+	if len(data) == 0 {
+		return nil, nil
+	}
+	if data[len(data)-1] != '\n' {
+		return nil, newError(CategoryCorrupt,
+			"durable: WAL segment %s does not end with a newline; it may be truncated", key)
+	}
+	lines := strings.Split(string(data[:len(data)-1]), "\n")
+	out := make([]string, 0, len(lines))
+	for i, line := range lines {
+		var record map[string]any
+		decoder := json.NewDecoder(strings.NewReader(line))
+		decoder.UseNumber()
+		if err := decoder.Decode(&record); err != nil {
+			return nil, wrapError(CategoryCorrupt, err,
+				"durable: WAL segment %s line %d is not a JSON object", key, i+1)
+		}
+		if decoder.More() {
+			return nil, newError(CategoryCorrupt,
+				"durable: WAL segment %s line %d holds more than one JSON value", key, i+1)
+		}
+		sql, ok := record["sql"].(string)
+		if !ok {
+			return nil, newError(CategoryCorrupt,
+				`durable: WAL segment %s line %d has no string "sql" field`, key, i+1)
+		}
+		// The per-statement ceiling is part of the frozen format, so it binds
+		// the reader too. A conforming writer cannot produce a larger
+		// statement, and replaying one from a segment that somehow holds it
+		// would run SQL the limit exists to prevent — the segment ceiling
+		// alone leaves room for a single statement twice the allowed size.
+		if err := assertStatementWithinLimit(sql); err != nil {
+			return nil, err
+		}
+		out = append(out, sql)
+	}
+	return out, nil
+}

--- a/chdb/durable/wal_test.go
+++ b/chdb/durable/wal_test.go
@@ -1,0 +1,206 @@
+package durable
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestWALSegmentRoundTrip(t *testing.T) {
+	statements := []string{
+		"INSERT INTO events VALUES (1)",
+		// A newline, a quote and a backslash inside SQL must survive, because
+		// the format is line-oriented and these are what break a line-oriented
+		// format that was not thought about.
+		"INSERT INTO events VALUES ('a\nb', 'c\"d', 'e\\f')",
+		// Not escaped, because the escaped form is a worse document for no
+		// benefit.
+		"INSERT INTO events SELECT * FROM t WHERE a < 1 AND b > 2 AND c = 'x&y'",
+	}
+	data, err := encodeWALSegment(statements)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if data[len(data)-1] != '\n' {
+		t.Fatal("a segment must end with a newline")
+	}
+	// encoding/json escapes <, > and & by default. The escaped form parses
+	// identically, but a WAL line is the most likely thing an operator reads
+	// by hand, so the encoder turns it off.
+	if strings.Contains(string(data), `\u003c`) || strings.Contains(string(data), `\u0026`) {
+		t.Errorf("HTML escaping is on:\n%s", data)
+	}
+
+	decoded, err := decodeWALSegment(data, "wal/1-1-abcd1234.jsonl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(decoded) != len(statements) {
+		t.Fatalf("decoded %d statements, want %d", len(decoded), len(statements))
+	}
+	for i := range statements {
+		if decoded[i] != statements[i] {
+			t.Errorf("statement %d came back as %q, want %q", i, decoded[i], statements[i])
+		}
+	}
+}
+
+// The budget the object layer applies before executing has to agree with the
+// encoder exactly. A disagreement of one byte per line puts the segment
+// boundary in the wrong place.
+func TestWALLineBytesAgreesWithTheEncoder(t *testing.T) {
+	statements := []string{
+		"INSERT INTO t VALUES (1)",
+		"INSERT INTO t VALUES ('unicode: 数据库')",
+		"INSERT INTO t VALUES ('a\nb')",
+	}
+	var budget int64
+	for _, sql := range statements {
+		n, err := walLineBytes(sql)
+		if err != nil {
+			t.Fatal(err)
+		}
+		budget += n
+	}
+	data, err := encodeWALSegment(statements)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if int64(len(data)) != budget {
+		t.Fatalf("the encoder produced %d bytes and the budget said %d", len(data), budget)
+	}
+}
+
+func TestWALSegmentIsEmptyForNoStatements(t *testing.T) {
+	data, err := encodeWALSegment(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data) != 0 {
+		t.Fatalf("an empty segment is %d bytes", len(data))
+	}
+	decoded, err := decodeWALSegment(data, "wal/1-1-abcd1234.jsonl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(decoded) != 0 {
+		t.Fatalf("decoded %d statements from nothing", len(decoded))
+	}
+}
+
+// A tolerant reader here would be the worst kind of bug: it would skip a
+// statement and hand back a database that looks fine and is missing a write.
+func TestDecodeWALSegmentIsStrict(t *testing.T) {
+	cases := []struct {
+		name string
+		data string
+	}{
+		{"no terminating newline", `{"sql":"INSERT INTO t VALUES (1)"}`},
+		{"a blank line", "{\"sql\":\"a\"}\n\n{\"sql\":\"b\"}\n"},
+		{"not JSON", "{\"sql\":\"a\"}\nnot json\n"},
+		{"an array instead of an object", "[\"a\"]\n"},
+		{"no sql field", "{\"statement\":\"a\"}\n"},
+		{"sql is not a string", "{\"sql\":42}\n"},
+		{"two values on one line", "{\"sql\":\"a\"} {\"sql\":\"b\"}\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := decodeWALSegment([]byte(tc.data), "wal/1-1-abcd1234.jsonl")
+			if err == nil {
+				t.Fatal("a malformed segment must not decode")
+			}
+			if !errors.Is(err, ErrCorrupt) {
+				t.Fatalf("category is %q, want corrupt: %v", CategoryOf(err), err)
+			}
+		})
+	}
+}
+
+func TestWALLimitsAreRefusedNotSplit(t *testing.T) {
+	oversized := strings.Repeat("x", MaxSQLBytes+1)
+	if err := assertStatementWithinLimit(oversized); !errors.Is(err, ErrLimitExceeded) {
+		t.Fatalf("category is %q, want limit_exceeded", CategoryOf(err))
+	}
+	if _, err := encodeWALSegment([]string{oversized}); !errors.Is(err, ErrLimitExceeded) {
+		t.Fatalf("encoding an oversized statement gave %q", CategoryOf(err))
+	}
+
+	// A segment over the ceiling is refused rather than split, because a
+	// segment boundary is a commit boundary.
+	chunk := strings.Repeat("y", 1<<20)
+	var statements []string
+	for int64(len(statements))*(1<<20) <= MaxWALSegmentBytes {
+		statements = append(statements, chunk)
+	}
+	if _, err := encodeWALSegment(statements); !errors.Is(err, ErrLimitExceeded) {
+		t.Fatalf("encoding an oversized segment gave %q", CategoryOf(err))
+	}
+}
+
+func TestObjectKeyValidation(t *testing.T) {
+	valid := []string{
+		"head.json",
+		"wal/3-9-acde5678.jsonl",
+		"checkpoints/3-8-acde1234.tar.gz",
+		"a/b/c",
+	}
+	for _, key := range valid {
+		if !IsValidObjectKey(key) {
+			t.Errorf("%q should be a valid key", key)
+		}
+	}
+
+	invalid := []string{
+		"",
+		"/absolute",
+		"trailing/",
+		"double//slash",
+		"..",
+		"../escape",
+		"a/../b",
+		"a/./b",
+		`back\slash`,
+		"nul\x00byte",
+	}
+	for _, key := range invalid {
+		if IsValidObjectKey(key) {
+			t.Errorf("%q should be refused", key)
+		}
+	}
+}
+
+func TestMintedKeysAreUniquePerAttempt(t *testing.T) {
+	// Uniqueness per attempt is what makes an ambiguous upload resolvable
+	// rather than destructive: a retry can never overwrite the bytes the first
+	// try published.
+	seen := map[string]bool{}
+	for i := 0; i < 500; i++ {
+		key := walKey(3, 9)
+		if seen[key] {
+			t.Fatalf("%s was minted twice", key)
+		}
+		seen[key] = true
+		if !IsValidObjectKey(key) {
+			t.Fatalf("%s is not a valid key", key)
+		}
+		if !strings.HasPrefix(key, "wal/3-9-") || !strings.HasSuffix(key, ".jsonl") {
+			t.Fatalf("%s does not match the frozen shape", key)
+		}
+	}
+	checkpoint := checkpointKey(3, 8)
+	if !strings.HasPrefix(checkpoint, "checkpoints/3-8-") || !strings.HasSuffix(checkpoint, ".tar.gz") {
+		t.Fatalf("%s does not match the frozen shape", checkpoint)
+	}
+}
+
+func TestObjectIDMustBeOneSegment(t *testing.T) {
+	if err := validateObjectID("tenant-123"); err != nil {
+		t.Fatalf("a flat id should be accepted: %v", err)
+	}
+	// A hierarchical id would let one object's prefix contain another's.
+	for _, bad := range []string{"", ".", "..", "tenant/user", `tenant\user`, "nul\x00"} {
+		if err := validateObjectID(bad); err == nil {
+			t.Errorf("%q should be refused as an object id", bad)
+		}
+	}
+}

--- a/update_libchdb.sh
+++ b/update_libchdb.sh
@@ -5,7 +5,7 @@
 # it too, so both ways of fetching libchdb land on the same build. Keep it on
 # its own line and literal: the release check greps for it when it proposes a
 # bump, and the Makefile cuts the value out of it.
-CHDB_ENGINE_PIN=v26.7.0
+CHDB_ENGINE_PIN=v26.7.2-rc.2
 
 # CHDB_ENGINE_VERSION overrides the pin, which is how the release check runs the
 # suite against an engine this repository has not adopted yet.


### PR DESCRIPTION
A durable object is one chDB database whose committed state lives under a
prefix you own — S3, R2, MinIO, or a directory — as a full checkpoint plus
write-ahead-log segments, with one compare-and-set `head.json` holding both the
manifest and the writer lease. Local MergeTree stays the hot working copy; the
object is a folder of open-format files you can move between clouds, and the
Python and Node bindings implement the same protocol, so an object written here
opens there.

The protocol is specified in `CHDB_DURABLE_V1_CONTRACT.md` in the
[chdb](https://github.com/chdb-io/chdb) repository. That document, not this
implementation, is the source of truth.

```go
ns, err := durable.NewNamespace("s3://my-bucket/durable?region=eu-west-1",
        durable.NamespaceOptions{Owner: "worker-1"})

obj, existed, err := ns.Open(ctx, "tenant-123", durable.OpenOptions{Database: "mem"})
defer obj.Close(ctx)

ticket, err := obj.Execute(ctx, "INSERT INTO events VALUES (1)")
err = obj.FlushThrough(ctx, ticket)   // now it survives losing this machine
rows, err := obj.Query(ctx, "SELECT count() FROM events", "JSONEachRow")
_, err = obj.Checkpoint(ctx)          // fold base + WAL into a fresh base
```

**`go.mod` and `go.sum` are unchanged.** The S3 backend is `net/http` plus a
SigV4 signer, because the protocol needs `GetObject` and `PutObject` with a
precondition, and the SDK that provides them would land a dozen modules in the
`go.mod` of everyone who imports chdb-go whether or not they ever touch S3. The
digest the manifest already records is what signs each upload, so a checkpoint
archive is never read twice. A caller who needs SSO or instance-role
credentials supplies `S3Options.Credentials` or its own `durable.Backend`.

**Nothing outside `chdb/durable` changes behaviour.** The three new
`chdb.Session` methods and the `chdbpurego` management surface are additive:
the new ABI lives on a second interface rather than widening `ChdbConn`, which
callers may implement, and the symbols are probed with `Dlsym` so an older
libchdb still loads and only the caller who needs them gets an error.

## What decides whether a statement may run

Not this package. Every `Query` and `Execute` goes to ClickHouse's own parser
first — how many executable statements is this, what class are they, does every
persistent write land in the database this object owns, does the text embed a
credential — and the answer is the gate. There is no prefix list and no regular
expression anywhere in the package, because neither can see through
`INSERT ... FORMAT` inline data or resolve an unqualified table name. `BACKUP`
and `RESTORE` are never assembled as text either: core takes the database name
and the path as arguments and does its own quoting.

That needs chdb-core v26.7.2-rc.2 or later, so the engine pin moves there.

## Version compatibility

An object records the exact `chdb_version()` that wrote it, and that is **not**
a gate. Compatibility is decided by two explicit fields, the archive-format
generation and the minimum reader version, so an object written by
`26.7.2-rc.2` opens on every later release that can still restore its archive.
An exact match would refuse them all, which is the opposite of the promise.

Versions are compared by release precedence rather than as strings, because as
strings `"26.10.0" < "26.7.0"` and `"26.7.2-rc.2" > "26.7.2"` — both backwards,
and both would let a reader open an object it cannot restore. Every head write
raises the compatibility floor rather than overwriting it, so an older writer
cannot advertise an object as readable by a build that cannot restore its base.

## The commits

1. **Let a caller back up, restore and ask what a statement would do.** Binds
   `chdb_backup_database_n`, `chdb_restore_database_n`, `chdb_classify_query_n`
   and `chdb_version`, and exposes them on `chdb.Session`. The symbols are
   probed rather than declared: `RegisterLibFunc` panics on a missing one, and
   that panic would fire during the first call that needs the engine at all,
   killing the process of someone who only wanted to run a `SELECT` against an
   older libchdb. Moves the engine pin to v26.7.2-rc.2 and updates the vendored
   header.

2. **Keep a database's authoritative state in object storage.** The
   `chdb/durable` package: object layout, `head.json` with strict validation and
   unknown-field round-trip, statement WAL, full checkpoints, lease with
   heartbeat and self-fencing, head compare-and-set with ambiguous-commit
   reconcile, length and SHA-256 verification, the fourteen frozen error
   categories, and the local and S3 backends.

3. **Fail the durable engine tests when CI's engine is not the pinned one.**
   The end-to-end tests skip without the management ABI, so a developer on an
   older engine is not shown failures for it. In CI that skip is the wrong
   answer and it is reachable: `make install` pipes lib.chdb.io, which retries
   a failed download against `releases/latest`, and the pinned engine is a
   pre-release — so "latest" is an older release without the ABI. The job would
   install it, every end-to-end test would skip, and the run would be green
   having exercised neither a real archive nor the real parser.

## Testing

`go test ./...` and `.github/scripts/race-test.sh` pass. The state machine is
driven by a stand-in engine, which is what makes the contract's fault matrix
reachable — a published segment whose head commit fails, a commit whose
response was lost, an upload that cannot be settled, a force takeover fencing
its predecessor, a writer that cannot renew fencing itself. The format fixtures
and classification scenarios of §7.2 and §7.3 are covered, including
`producer-version-differs-but-compatible`, `engine-reader-too-old` and
`backup-format-too-new`.

The gates and a real chDB archive round trip are tested against the real
engine, since a stand-in cannot establish either. The skip guard in commit 3 is
verified both ways against v26.7.0's libchdb loaded through `CHDB_LIB_PATH`:
unset the tests skip and name the version they found, set they fail with the
same detail.

## Two things this does not do

**The packaged engine modules still carry v26.7.0**, which predates the
management ABI, so a build using `lib/embedded` is refused at `Open` with an
`engine_incompatible` error naming the release to move to. `CHDB_LIB_PATH` or a
machine install works today; closing it needs the engine modules repackaged and
republished, which is a release action rather than a code change. The
`embedded_engine` CI job therefore does not set the new guard.

**Cross-binding fixture exchange (§7.5) is not here.** Each binding's own suite
passes, but no fixture written by one has been restored by another yet. That is
the gate on releasing a stable chdb-core, and it is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Store chDB database state in owned object storage via `durable` package
> - Adds the `durable` package implementing a V1 object model that stores chDB database state (WAL, checkpoints, head metadata) in local filesystem or S3-compatible object storage using AWS SigV4
> - Manages object lifecycle with leases, write-ahead logs, and atomic compare-and-swap updates through conditional writes and ETags
> - Introduces pure-Go bindings for the management ABI in [admin.go](https://github.com/chdb-io/chdb-go/pull/63/files#diff-e5e491f0946f8057d2df6700a87a5707a85b1aa23f4b49f2b6dd6027405b60dc) for database backup, restore, and parser-backed SQL classification
> - Expands the C ABI in [chdb.h](https://github.com/chdb-io/chdb-go/pull/63/files#diff-d6fb89bf84e9e90309d522f0f895741f6df745f009cb89befff7f351d2c33534) with parameterized queries, streaming inserts, and Arrow C Data Interface integration. Bumps the libchdb engine version to v26.7.2-rc.2
> - Risk: `chdb_conn` in [chdb.h](https://github.com/chdb-io/chdb-go/pull/63/files#diff-d6fb89bf84e9e90309d522f0f895741f6df745f009cb89befff7f351d2c33534) removes the public queue pointer member, which may break external C code relying on the previous struct layout. CI jobs now enforce `CHDB_REQUIRE_DURABLE_ABI=1`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cc59518.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->